### PR TITLE
Fix correctness blockers ahead of 2.0 stabilization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,6 +2360,7 @@ dependencies = [
  "futures",
  "http",
  "http-body",
+ "http-body-util",
  "md-5",
  "mime",
  "mime_guess",

--- a/crates/core/src/database/entities/project/versions/update.rs
+++ b/crates/core/src/database/entities/project/versions/update.rs
@@ -62,8 +62,11 @@ impl UpdateProjectVersion {
     pub async fn update(&self, version_id: Uuid, database: &PgPool) -> DBResult<()> {
         let mut update = UpdateQueryBuilder::new(DBProjectVersion::table_name());
         update
-            .set(DBProjectVersionColumn::Id, version_id)
-            .set(DBProjectVersionColumn::UpdatedAt, SqlFunctionBuilder::now());
+            .set(DBProjectVersionColumn::UpdatedAt, SqlFunctionBuilder::now())
+            // Without this the builder emits no WHERE clause at all, and the statement rewrites
+            // every row in the table. `Id` used to be passed to `set`, which put the target's id
+            // in the SET list instead of the filter.
+            .filter(DBProjectVersionColumn::Id.equals(version_id.value()));
 
         if let Some(release_type) = &self.release_type {
             update.set(DBProjectVersionColumn::ReleaseType, release_type);
@@ -81,5 +84,76 @@ impl UpdateProjectVersion {
         update.query().execute(database).await?;
 
         Ok(())
+    }
+
+    /// Builds the same statement [UpdateProjectVersion::update] runs, so it can be inspected
+    /// without a database.
+    #[cfg(test)]
+    fn build_sql(&self, version_id: Uuid) -> String {
+        let mut update = UpdateQueryBuilder::new(DBProjectVersion::table_name());
+        update
+            .set(DBProjectVersionColumn::UpdatedAt, SqlFunctionBuilder::now())
+            .filter(DBProjectVersionColumn::Id.equals(version_id.value()));
+
+        if let Some(release_type) = &self.release_type {
+            update.set(DBProjectVersionColumn::ReleaseType, release_type);
+        }
+        if let Some(extra) = &self.extra {
+            update.set(DBProjectVersionColumn::Extra, Json(extra));
+        }
+        if let Some(version_page) = &self.version_page {
+            update.set(DBProjectVersionColumn::VersionPage, version_page.value());
+        }
+        if let Some(publisher) = &self.publisher {
+            update.set(DBProjectVersionColumn::Publisher, *publisher);
+        }
+
+        update.format_sql_query().to_owned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::repository::project::ReleaseType;
+
+    /// The statement must be scoped to one row.
+    ///
+    /// This previously passed the target id to `set` rather than `filter`, which produced an
+    /// `UPDATE ... SET id = $1` with no `WHERE` — it rewrote the primary key of every version in
+    /// the table. Maven reached it on any re-deploy of an existing version.
+    #[test]
+    fn update_is_scoped_to_one_row() {
+        let sql = UpdateProjectVersion::default().build_sql(Uuid::new_v4());
+
+        let (set_clause, where_clause) = sql
+            .split_once(" WHERE ")
+            .unwrap_or_else(|| panic!("no WHERE clause — this rewrites every row: {sql}"));
+
+        assert!(
+            !set_clause.contains("id ="),
+            "statement assigns the primary key instead of filtering on it: {sql}"
+        );
+        assert!(
+            where_clause.contains("id ="),
+            "statement is not filtered by id: {sql}"
+        );
+    }
+
+    /// The filter must survive however many optional fields are set.
+    #[test]
+    fn update_is_scoped_with_every_field_set() {
+        let update = UpdateProjectVersion {
+            release_type: Some(ReleaseType::Stable),
+            publisher: Some(Some(1)),
+            version_page: Some(Some("page".to_owned())),
+            extra: Some(VersionData::default()),
+        };
+        let sql = update.build_sql(Uuid::new_v4());
+
+        assert!(
+            sql.contains("WHERE"),
+            "statement has no WHERE clause: {sql}"
+        );
     }
 }

--- a/crates/core/src/database/entities/repository.rs
+++ b/crates/core/src/database/entities/repository.rs
@@ -176,38 +176,34 @@ pub struct DBRepositoryConfig<T> {
 }
 pub type GenericDBRepositoryConfig = DBRepositoryConfig<Value>;
 impl DBRepositoryConfig<Value> {
-    pub async fn add_or_update(
+    /// Writes a config value, replacing any value already stored under the same key.
+    ///
+    /// Generic over the executor so this can run inside a transaction — creating a repository
+    /// writes the repository row and each of its configs, and those have to land together.
+    ///
+    /// A single upsert rather than select-then-insert-or-update: the old form could have two
+    /// concurrent writers both observe "no row" and race on the `unique_repository_config_key`
+    /// constraint, with one of them failing on what looks like an ordinary write.
+    pub async fn add_or_update<'c, E>(
         uuid: Uuid,
         key: String,
         value: Value,
-        database: &PgPool,
-    ) -> Result<(), sqlx::Error> {
-        // Check if the config already exists
-        let config = sqlx::query_as::<_, DBRepositoryConfig<Value>>(
-            r#"SELECT * FROM repository_configs WHERE repository_id = $1 AND key = $2"#,
+        database: E,
+    ) -> Result<(), sqlx::Error>
+    where
+        E: sqlx::Executor<'c, Database = Postgres>,
+    {
+        sqlx::query(
+            r#"INSERT INTO repository_configs (repository_id, key, value)
+               VALUES ($1, $2, $3)
+               ON CONFLICT (repository_id, key)
+               DO UPDATE SET value = EXCLUDED.value, updated_at = NOW()"#,
         )
         .bind(uuid)
         .bind(&key)
-        .fetch_optional(database)
+        .bind(Json(value))
+        .execute(database)
         .await?;
-        if let Some(config) = config {
-            sqlx::query(
-                r#"UPDATE repository_configs SET value = $1, updated_at = NOW() WHERE id = $2"#,
-            )
-            .bind(Json(value))
-            .bind(config.id)
-            .execute(database)
-            .await?;
-        } else {
-            sqlx::query(
-                r#"INSERT INTO repository_configs (repository_id, key, value) VALUES ($1, $2, $3)"#,
-            )
-            .bind(uuid)
-            .bind(&key)
-            .bind(Json(value))
-            .execute(database)
-            .await?;
-        }
         Ok(())
     }
 }

--- a/crates/core/src/storage/storage_path.rs
+++ b/crates/core/src/storage/storage_path.rs
@@ -1,6 +1,7 @@
 use std::{
     fmt::{Debug, Display},
     path::PathBuf,
+    str::FromStr,
 };
 
 use http::Uri;
@@ -20,6 +21,24 @@ impl StoragePathComponent {
             None
         }
     }
+    /// Whether a single path segment is safe to use as a storage path component.
+    ///
+    /// A [StoragePath] is joined onto a storage root (a directory for the local backends, a key
+    /// prefix for S3), so a component that means "go up a level" would let a request escape the
+    /// repository it addresses. `.` and `..` are therefore rejected outright rather than resolved.
+    ///
+    /// Separators and NUL are rejected because the component is later pushed onto a `PathBuf`
+    /// verbatim, where they would silently split into more components than the caller intended.
+    /// The remaining control characters have no legitimate use in an artifact path.
+    pub fn is_valid_component(component: &str) -> bool {
+        !(component.is_empty()
+            || component == "."
+            || component == ".."
+            || component.contains('/')
+            || component.contains('\\')
+            || component.contains('\0')
+            || component.chars().any(char::is_control))
+    }
 }
 impl PartialEq<&str> for StoragePathComponent {
     fn eq(&self, other: &&str) -> bool {
@@ -35,11 +54,8 @@ impl TryFrom<&str> for StoragePathComponent {
     type Error = InvalidStoragePath;
     #[instrument]
     fn try_from(value: &str) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            return Err(InvalidStoragePath::InvalidPath);
-        }
-        if value.contains('/') {
-            return Err(InvalidStoragePath::InvalidPath);
+        if !Self::is_valid_component(value) {
+            return Err(InvalidStoragePath::InvalidComponent(value.to_owned()));
         }
         Ok(StoragePathComponent(value.to_string()))
     }
@@ -135,6 +151,32 @@ impl StoragePath {
     pub fn is_directory(&self) -> bool {
         self.trailing_slash == Some(true)
     }
+    /// Parses a `/`-separated path, rejecting any component that is not a safe path segment.
+    ///
+    /// This is the constructor to use for anything a client controls — request paths, websocket
+    /// messages, request bodies. Empty segments (from a leading, trailing or doubled `/`) are
+    /// normalised away as usual; `.`, `..`, and segments containing a separator, NUL or a control
+    /// character are errors rather than being silently dropped.
+    #[instrument]
+    pub fn parse(value: &str) -> Result<Self, InvalidStoragePath> {
+        let trailing_slash = StoragePathComponent::should_add_slash(value);
+        let components = value
+            .split('/')
+            // A leading/trailing/doubled slash is normal in a URL and carries no meaning here.
+            .filter(|segment| !segment.is_empty())
+            .map(StoragePathComponent::try_from)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(StoragePath {
+            components,
+            trailing_slash,
+        })
+    }
+}
+impl FromStr for StoragePath {
+    type Err = InvalidStoragePath;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse(value)
+    }
 }
 impl From<Vec<StoragePathComponent>> for StoragePath {
     fn from(value: Vec<StoragePathComponent>) -> Self {
@@ -188,19 +230,21 @@ impl Display for StoragePath {
         write!(f, "{}", path)
     }
 }
+/// Builds a path from a `/`-separated string, **dropping** any component that
+/// [StoragePathComponent::is_valid_component] rejects.
+///
+/// This is the infallible constructor, used where the input is already trusted (paths read back
+/// out of the database, paths assembled from validated components). It drops rather than resolves
+/// unsafe components so that no caller can produce a traversing path even by mistake — but because
+/// dropping silently changes what the path addresses, anything reading untrusted input should use
+/// [StoragePath::parse], which reports the bad component instead.
 impl From<&str> for StoragePath {
     fn from(value: &str) -> Self {
         let trailing_slash = StoragePathComponent::should_add_slash(value);
-        let value = value.split("/").collect::<Vec<&str>>();
         let components = value
-            .iter()
-            .filter_map(|v| {
-                if v.is_empty() {
-                    None
-                } else {
-                    Some(StoragePathComponent(v.to_string()))
-                }
-            })
+            .split('/')
+            .filter(|v| StoragePathComponent::is_valid_component(v))
+            .map(|v| StoragePathComponent(v.to_string()))
             .collect::<Vec<StoragePathComponent>>();
         StoragePath {
             components,
@@ -229,20 +273,25 @@ impl<'de> Deserialize<'de> for StoragePath {
         D: Deserializer<'de>,
     {
         let string = String::deserialize(deserializer)?;
-        Ok(StoragePath::from(string))
+        // Deserialization is the boundary every client-supplied path crosses (the `{*path}` route
+        // capture and the browse websocket both land here), so it validates rather than dropping.
+        StoragePath::parse(&string).map_err(serde::de::Error::custom)
     }
 }
 #[derive(Debug, Error)]
 pub enum InvalidStoragePath {
     #[error("Invalid path")]
     InvalidPath,
+    #[error(
+        "Invalid path component `{0}`: components may not be `.`, `..`, or contain a path separator, NUL, or control characters"
+    )]
+    InvalidComponent(String),
 }
 impl TryFrom<Uri> for StoragePath {
     type Error = InvalidStoragePath;
     #[instrument]
     fn try_from(uri: Uri) -> Result<Self, Self::Error> {
-        let path = uri.path();
-        Ok(StoragePath::from(path))
+        StoragePath::parse(uri.path())
     }
 }
 
@@ -287,6 +336,98 @@ mod tests {
         let path = StoragePath::from("test/test2//test3/");
         assert_eq!(path.to_string(), "test/test2/test3/");
     }
+    /// A path that walks out of the repository root must not parse at all.
+    ///
+    /// These reach `parse` through the `{storage}/{repository}/{*path}` route capture, which axum
+    /// percent-decodes for us — so the encoded forms below arrive here already decoded, and only
+    /// the decoded form needs rejecting.
+    #[test]
+    fn parse_rejects_traversal() {
+        let traversing = [
+            "..",
+            "../etc/passwd",
+            "a/../../etc/passwd",
+            "a/b/..",
+            "/../../../../etc/shadow",
+            "dev/kingtux/../../../secret",
+        ];
+        for path in traversing {
+            let result = StoragePath::parse(path);
+            assert!(
+                result.is_err(),
+                "`{path}` parsed to {:?} instead of being rejected",
+                result.ok()
+            );
+        }
+    }
+
+    #[test]
+    fn parse_rejects_other_unsafe_components() {
+        for path in ["a/./b", ".", "a/b\\c", "a/b\0c", "a/b\nc"] {
+            assert!(
+                StoragePath::parse(path).is_err(),
+                "`{}` should have been rejected",
+                path.escape_debug()
+            );
+        }
+    }
+
+    /// Dots are only special as a whole component — real artifact names are full of them.
+    #[test]
+    fn parse_accepts_ordinary_artifact_paths() {
+        let accepted = [
+            "dev/kingtux/tms/1.0.0/tms-1.0.0.pom",
+            "test.txt",
+            "a/b.c.d/e",
+            "@scope/pkg/-/pkg-1.0.0.tgz",
+            "..leading-dots-are-fine",
+            "trailing..",
+        ];
+        for path in accepted {
+            assert!(
+                StoragePath::parse(path).is_ok(),
+                "`{path}` should have been accepted"
+            );
+        }
+    }
+
+    /// `parse` normalises the same leading/trailing/doubled slashes that `From<&str>` does.
+    #[test]
+    fn parse_matches_from_for_safe_paths() {
+        for path in [
+            "/test",
+            "test/test2/",
+            "test//test2",
+            "/test/test2/test3/",
+            "test.txt",
+        ] {
+            assert_eq!(
+                StoragePath::parse(path).unwrap(),
+                StoragePath::from(path),
+                "`{path}` disagreed between parse and From"
+            );
+        }
+    }
+
+    /// The infallible constructor drops what `parse` rejects, so no caller can build a
+    /// traversing path even by accident.
+    #[test]
+    fn from_str_drops_traversal_components() {
+        assert_eq!(
+            StoragePath::from("a/../../etc/passwd").to_string(),
+            "a/etc/passwd"
+        );
+        assert_eq!(StoragePath::from("../..").to_string(), "");
+        assert_eq!(StoragePath::from("a/./b").to_string(), "a/b");
+    }
+
+    /// Deserialization is the boundary client paths cross; it must reject, not drop.
+    #[test]
+    fn deserialize_rejects_traversal() {
+        let err = serde_json::from_str::<Test>(r#"{"path":"a/../../etc/passwd"}"#);
+        assert!(err.is_err(), "traversing path deserialized successfully");
+    }
+
     #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
     struct Test {
         path: StoragePath,

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -48,6 +48,7 @@ url = { version = "2.4", features = ["serde"] }
 workspace = true
 
 [dev-dependencies]
+http-body-util.workspace = true
 toml.workspace = true
 tracing-subscriber.workspace = true
 tracing-appender.workspace = true

--- a/crates/storage/src/fs/file_meta.rs
+++ b/crates/storage/src/fs/file_meta.rs
@@ -331,9 +331,11 @@ mod tests {
     use super::LocationMeta;
     use crate::meta::RepositoryMeta;
     fn random_repo_meta() -> RepositoryMeta {
-        let mut meta = RepositoryMeta::default();
-        meta.project_id = Some(Uuid::new_v4());
-        meta.project_version_id = Some(Uuid::new_v4());
+        let mut meta = RepositoryMeta {
+            project_id: Some(Uuid::new_v4()),
+            project_version_id: Some(Uuid::new_v4()),
+            ..Default::default()
+        };
 
         meta.insert("test", "map");
 

--- a/crates/storage/src/fs/file_reader.rs
+++ b/crates/storage/src/fs/file_reader.rs
@@ -26,7 +26,16 @@ pub enum StorageFileReader {
     /// An Async Reader type. This will be used for remote storage. Such as S3.
     AsyncReader(Pin<Box<dyn tokio::io::AsyncRead + Send>>),
     /// Content already in memory.
-    Bytes(FileContentBytes),
+    ///
+    /// Held in a cursor because [AsyncRead::poll_read] has to remember how much it has already
+    /// handed out. Without that the reader copies the same prefix on every poll and never reports
+    /// end-of-stream, so a response body built from it never terminates.
+    Bytes(io::Cursor<FileContentBytes>),
+}
+impl From<FileContentBytes> for StorageFileReader {
+    fn from(bytes: FileContentBytes) -> Self {
+        StorageFileReader::Bytes(io::Cursor::new(bytes))
+    }
 }
 impl StorageFileReader {
     pub async fn read_to_vec(self, size_hint: usize) -> io::Result<Vec<u8>> {
@@ -38,7 +47,17 @@ impl StorageFileReader {
             StorageFileReader::AsyncReader(mut reader) => {
                 tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buf).await?;
             }
-            StorageFileReader::Bytes(bytes) => return Ok(bytes.into()),
+            StorageFileReader::Bytes(cursor) => {
+                // Reads from wherever the cursor is, so this stays consistent with `poll_read`
+                // if anything has already been taken from the reader.
+                let position = cursor.position() as usize;
+                let inner = cursor.into_inner();
+                if position == 0 {
+                    return Ok(inner.into());
+                }
+                let remaining = inner.as_ref();
+                return Ok(remaining[position.min(remaining.len())..].to_vec());
+            }
         }
         Ok(buf)
     }
@@ -76,11 +95,7 @@ impl AsyncRead for StorageFileReader {
         match self.get_mut() {
             StorageFileReader::File(file) => Pin::new(file).poll_read(cx, buf),
             StorageFileReader::AsyncReader(reader) => Pin::new(reader).poll_read(cx, buf),
-            StorageFileReader::Bytes(bytes) => {
-                let len = std::cmp::min(buf.remaining(), bytes.len());
-                buf.put_slice(&bytes.as_ref()[..len]);
-                Poll::Ready(Ok(()))
-            }
+            StorageFileReader::Bytes(cursor) => Pin::new(cursor).poll_read(cx, buf),
         }
     }
 }
@@ -136,5 +151,46 @@ impl Body for StorageFileReaderBody {
         // Capacity should be the size of the response.
         hint.set_lower(self.capacity as u64);
         hint
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_body_util::BodyExt;
+
+    use super::*;
+
+    /// An in-memory reader must yield its content once and then stop.
+    ///
+    /// `poll_read` used to copy from the front of the buffer on every call without advancing, so
+    /// a reader never reached end-of-stream and the body repeated the same bytes forever. A small
+    /// body capacity here forces several polls, which is what exposes it.
+    #[tokio::test]
+    async fn bytes_reader_terminates() {
+        let content = b"Hello, World! This content is longer than one chunk.".to_vec();
+        let reader = StorageFileReader::from(FileContentBytes::Content(content.clone()));
+
+        let collected = reader.into_body(8).collect().await.unwrap().to_bytes();
+
+        assert_eq!(collected.as_ref(), content.as_slice());
+    }
+
+    /// Reading straight to a `Vec` must agree with streaming it.
+    #[tokio::test]
+    async fn bytes_reader_read_to_vec() {
+        let content = b"Hello, World!".to_vec();
+        let reader = StorageFileReader::from(FileContentBytes::Content(content.clone()));
+
+        assert_eq!(reader.read_to_vec(content.len()).await.unwrap(), content);
+    }
+
+    /// An empty body should produce no frames rather than hanging.
+    #[tokio::test]
+    async fn empty_bytes_reader_terminates() {
+        let reader = StorageFileReader::from(FileContentBytes::Content(Vec::new()));
+
+        let collected = reader.into_body(8).collect().await.unwrap().to_bytes();
+
+        assert!(collected.is_empty());
     }
 }

--- a/crates/storage/src/local/mod.rs
+++ b/crates/storage/src/local/mod.rs
@@ -256,37 +256,54 @@ impl LocalStorageInner {
                 if parent == self.config.path {
                     trace!("Do not update root directory");
                 } else {
-                    metas_updated += 1;
-                    self.meta_update_sender
-                        .send(parent.to_path_buf())
-                        .await
-                        .unwrap();
+                    metas_updated += self.queue_meta_update(parent.to_path_buf()).await;
                 }
             }
+            // `greatest_parent` is the topmost directory `save_file` had to create, so `path`
+            // always sits underneath it. Degrade to updating just the file's own meta if that
+            // ever stops holding rather than panicking in a background task.
+            let Ok(relative) = path.strip_prefix(&greatest_parent) else {
+                warn!(
+                    ?path,
+                    ?greatest_parent,
+                    "Path is not below the directory that was created for it"
+                );
+                metas_updated += self.queue_meta_update(path.to_path_buf()).await;
+                return Ok(metas_updated);
+            };
             let mut next_path = greatest_parent.clone();
-            for part in path.strip_prefix(&greatest_parent).unwrap().components() {
+            for part in relative.components() {
                 event!(Level::DEBUG, ?next_path, "Updating Meta");
-                self.meta_update_sender
-                    .send(next_path.clone())
-                    .await
-                    .unwrap();
-                metas_updated += 1;
+                metas_updated += self.queue_meta_update(next_path.clone()).await;
                 next_path = next_path.join(part);
             }
         } else {
-            self.meta_update_sender.send(path.to_path_buf()).await.unwrap();
-            metas_updated += 1;
-            let parent = path.parent();
-            if let Some(parent) = parent {
-                metas_updated += 1;
-                self.meta_update_sender
-                    .send(parent.to_path_buf())
-                    .await
-                    .unwrap();
+            metas_updated += self.queue_meta_update(path.to_path_buf()).await;
+            if let Some(parent) = path.parent() {
+                metas_updated += self.queue_meta_update(parent.to_path_buf()).await;
             }
         }
 
         Ok(metas_updated)
+    }
+
+    /// Queues a path for the background meta writer, returning how many updates were queued.
+    ///
+    /// The receiver is dropped by [Storage::unload], and these calls run from a detached task that
+    /// can outlive it. A send failure therefore means "the storage is shutting down", which is not
+    /// worth aborting a background task over — these used to `unwrap`, turning an ordinary
+    /// shutdown race into a panic.
+    async fn queue_meta_update(&self, path: PathBuf) -> usize {
+        match self.meta_update_sender.send(path).await {
+            Ok(()) => 1,
+            Err(err) => {
+                debug!(
+                    path = ?err.0,
+                    "Storage is unloaded; dropping queued meta update"
+                );
+                0
+            }
+        }
     }
 }
 impl LocalStorage {
@@ -467,7 +484,11 @@ impl Storage for LocalStorage {
         info!(?self, "Unloading Local Storage");
         let shutdown_signal = self.0.shutdown_signal.lock().await.take();
         if let Some(shutdown_signal) = shutdown_signal {
-            shutdown_signal.send(()).unwrap();
+            // The meta task exits on its own once the channel closes, so a receiver that is
+            // already gone means the job is done — not a reason to panic during shutdown.
+            if shutdown_signal.send(()).is_err() {
+                debug!("Meta update task had already stopped");
+            }
         } else {
             error!("Shutdown Signal already sent");
         }

--- a/crates/storage/src/s3/mod.rs
+++ b/crates/storage/src/s3/mod.rs
@@ -52,6 +52,9 @@ pub enum S3StorageError {
     #[error("Missing Tag: {0}")]
     MissingTag(Cow<'static, str>),
 
+    #[error("S3 storage is missing its {0}")]
+    MissingCredential(&'static str),
+
     #[error(transparent)]
     PathCollision(#[from] PathCollisionError),
 }
@@ -80,10 +83,21 @@ impl S3Credentials {
             secret_key: Some(secret_key.into()),
         }
     }
+    /// The keys are optional in the config, so a storage can be saved without them. Reject that
+    /// here rather than unwrapping — this runs while loading storages at boot and on every config
+    /// test, and a panic there takes the whole server down.
     pub fn credentials(&self) -> Result<Credentials, S3StorageError> {
+        let access_key = self
+            .access_key
+            .clone()
+            .ok_or(S3StorageError::MissingCredential("access key"))?;
+        let secret_key = self
+            .secret_key
+            .clone()
+            .ok_or(S3StorageError::MissingCredential("secret key"))?;
         Ok(Credentials {
-            access_key: self.access_key.clone().expect("todo"),
-            secret_key: self.secret_key.clone().expect("todo"),
+            access_key,
+            secret_key,
         })
     }
 }
@@ -462,12 +476,18 @@ impl Storage for S3Storage {
             name: location.to_string(),
             file_type: FileFileType {
                 file_size: get.content_length()?.unwrap_or_default(),
+                // A bucket can hold objects put there by anything, so a malformed `Content-Type`
+                // is a property of the data, not a bug. Report the file without a mime type
+                // rather than panicking on it.
                 mime_type: get
                     .content_type()?
-                    .map(|ct| Mime::from_str(ct.as_str()))
-                    .transpose()
-                    .unwrap()
-                    .map(SerdeMime),
+                    .and_then(|ct| match Mime::from_str(ct.as_str()) {
+                        Ok(mime) => Some(SerdeMime(mime)),
+                        Err(err) => {
+                            warn!(?err, content_type = ?ct, ?path, "Ignoring unparsable content type");
+                            None
+                        }
+                    }),
                 file_hash: FileHashes::default(),
             },
             modified: Local::now().fixed_offset(),
@@ -476,7 +496,7 @@ impl Storage for S3Storage {
         let body: Bytes = get.0.bytes().await.map_err(S3Error::from)?;
         let result = StorageFile::File {
             meta,
-            content: crate::StorageFileReader::Bytes(FileContentBytes::Bytes(body)),
+            content: crate::StorageFileReader::from(FileContentBytes::Bytes(body)),
         };
 
         Ok(Some(result))

--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -19,9 +19,10 @@ pub struct TestingStorageConfig {
 
 impl Default for TestingStorageConfig {
     fn default() -> Self {
-        let mut storage_test_configs = Vec::new();
-        storage_test_configs.push(LocalStorage::test_storage_config());
-        storage_test_configs.push(S3Config::test_storage_config());
+        let storage_test_configs = vec![
+            LocalStorage::test_storage_config(),
+            S3Config::test_storage_config(),
+        ];
         Self {
             logging: TestingLoggerConfig::default(),
             storage_test_configs,

--- a/nitro_repo/src/app/web.rs
+++ b/nitro_repo/src/app/web.rs
@@ -73,8 +73,11 @@ pub(crate) async fn start(config_path: Option<PathBuf>) -> anyhow::Result<()> {
     let cloned_site = site.clone();
     let auth_layer = AuthenticationLayer::from(site.clone());
     let mut app = Router::new()
+        // `/repositories/{storage}/{repository}/{*path}` is the canonical artifact URL — it is what
+        // `repositoryUrl()` in the frontend hands to Maven and npm. `/storages` used to be nested
+        // with the identical router, which served every artifact under a second URL that nothing
+        // generated and that reads as if it addressed the storage API.
         .nest("/repositories", crate::repository::repository_router())
-        .nest("/storages", crate::repository::repository_router())
         .nest("/api", api::api_routes())
         .nest("/badge", super::badge::badge_routes())
         .fallback(super::frontend::frontend_request)

--- a/nitro_repo/src/repository/maven/hosted.rs
+++ b/nitro_repo/src/repository/maven/hosted.rs
@@ -24,7 +24,7 @@ use nr_core::{
 };
 use nr_storage::{DynStorage, Storage, StorageFile};
 use parking_lot::RwLock;
-use tracing::{debug, error, event, info, instrument};
+use tracing::{debug, error, event, info, instrument, warn};
 use uuid::Uuid;
 
 use super::{
@@ -339,8 +339,16 @@ impl Repository for MavenHosted {
                 self.get_type(),
             ));
         };
-        info!(?nitro_deploy_version, "Handling Nitro Deploy Version");
-        todo!()
+        // Nitro Deploy is not implemented yet. This used to be `todo!()`, which was harmless only
+        // because POST never reached a repository handler; now that it does, it has to answer.
+        warn!(
+            ?nitro_deploy_version,
+            "Nitro Deploy was requested but is not implemented"
+        );
+        Ok(RepoResponse::unsupported_method_response(
+            request.parts.method,
+            self.get_type(),
+        ))
     }
     #[instrument(fields(repository_type = "maven/hosted"))]
     async fn resolve_project_and_version_for_path(

--- a/nitro_repo/src/repository/npm/types/request.rs
+++ b/nitro_repo/src/repository/npm/types/request.rs
@@ -183,8 +183,11 @@ impl GetPath {
         components: Vec<StoragePathComponent>,
     ) -> Result<Self, NPMRegistryError> {
         let length = components.len();
-        if length == 1 {
-            panic!("Invalid path");
+        if length < 2 {
+            // `GET /{storage}/{repository}/@scope` — a scope with no package after it. This used
+            // to `panic!`, which took the handler task down on a request anyone could make.
+            info!(?components, "Scoped path is missing a package name");
+            return Err(NPMRegistryError::InvalidGetRequest);
         }
         let name = format!("{}/{}", components[0], components[1]);
         if length == 2 {

--- a/nitro_repo/src/repository/repo_http.rs
+++ b/nitro_repo/src/repository/repo_http.rs
@@ -415,6 +415,7 @@ pub async fn handle_repo_request(
         let _guard = trace.span.enter();
         let response = match method {
             Method::GET => repository.handle_get(request).await,
+            Method::POST => repository.handle_post(request).await,
             Method::PUT => repository.handle_put(request).await,
             Method::DELETE => repository.handle_delete(request).await,
             Method::PATCH => repository.handle_patch(request).await,

--- a/nitro_repo/src/repository/repo_type.rs
+++ b/nitro_repo/src/repository/repo_type.rs
@@ -32,12 +32,17 @@ pub struct NewRepository {
     pub configs: HashMap<String, Value>,
 }
 impl NewRepository {
-    // TODO: Transactions
+    /// Creates the repository and all of its configs as one unit.
+    ///
+    /// A repository is only usable once its required configs exist — `load_repo` reads them to
+    /// decide which sub-handler to build. These used to be separate statements, so a config that
+    /// failed to insert left behind a repository row that could never be loaded.
     pub async fn insert(
         self,
         storage: Uuid,
         database: &sqlx::PgPool,
     ) -> Result<DBRepository, InternalError> {
+        let mut transaction = database.begin().await?;
         let repository = sqlx::query_as::<_, DBRepository>(
             r#"INSERT INTO repositories (id, storage_id, name, repository_type, active) VALUES ($1, $2, $3, $4, $5) RETURNING *"#,
         )
@@ -46,10 +51,12 @@ impl NewRepository {
         .bind(&self.name)
         .bind(&self.repository_type)
         .bind(true)
-        .fetch_one( database).await?;
+        .fetch_one(&mut *transaction).await?;
         for (key, value) in self.configs {
-            GenericDBRepositoryConfig::add_or_update(repository.id, key, value, database).await?;
+            GenericDBRepositoryConfig::add_or_update(repository.id, key, value, &mut *transaction)
+                .await?;
         }
+        transaction.commit().await?;
         Ok(repository)
     }
 }


### PR DESCRIPTION
First of a stack of PRs taking 2.0 from beta to stable. This one is only defects — no features — because later phases build on every path it touches.

## Security

**Path traversal in `StoragePath`.** `StoragePath::from(&str)` split on `/` and dropped empty segments, but never rejected `.` or `..` — and the validating `StoragePathComponent::TryFrom` was bypassed on that path. Components were then pushed onto a `PathBuf` and joined onto the storage root with no containment check. The repository route is `/{storage}/{repository}/{*path}` and axum percent-decodes the capture, so a request could address files outside the repository it named.

Now:
- `StoragePathComponent::is_valid_component` rejects `.`, `..`, separators, NUL and control characters.
- `StoragePath::parse` validates every component and is what `Deserialize` uses — so client-supplied paths (the route capture *and* the browse websocket) fail with a clear error.
- The infallible `From<&str>` drops unsafe components instead, so no internal caller can construct a traversing path either.

Dots are only special as a whole component; `dev/kingtux/tms/1.0.0/tms-1.0.0.pom` and `@scope/pkg/-/pkg-1.0.0.tgz` still parse.

## Data corruption

**`UpdateProjectVersion::update` rewrote every row.** The target id was passed to `set` rather than `filter`, and `UpdateQueryBuilder` emits no `WHERE` when no conditions were added:

```sql
UPDATE project_versions SET id = $1, updated_at = now(), ... ;   -- no WHERE
```

With one row it silently "works"; with more it rewrites every row's primary key and trips the unique constraint. Maven reached it on **any re-deploy of an existing version**.

## Other fixes

- **`POST` never reached `handle_post`** — the method match omitted it and fell through to `handle_other`. Routing it exposed Maven's `todo!()` Nitro Deploy handler, which now returns 405 exactly as the PUT path already did. Whether to implement Nitro Deploy or drop `require_nitro_deploy` is a Phase 4 decision.
- **`StorageFileReader::Bytes` never advanced a cursor** — `poll_read` copied from the front of the buffer every call, so a reader never reached end-of-stream and a response body built from it repeated the same bytes forever. Now holds an `io::Cursor`.
- **Repository creation was not transactional** — a config that failed to insert left a repository row that could never be loaded, since `load_repo` reads configs to pick its sub-handler. `DBRepositoryConfig::add_or_update` is now executor-generic and a single `ON CONFLICT` upsert rather than select-then-write, which also closes a race on `unique_repository_config_key`.
- **Five reachable panics**: S3 credentials `.expect("todo")` (a storage saved without keys panicked the server at boot and on every config test), S3 mime parsing `.unwrap()` on data the bucket owner controls, the npm `panic!("Invalid path")` on `GET /{storage}/{repo}/@scope`, and the local-storage channel `.unwrap()`s that fired on an ordinary shutdown race.
- **`/storages` was nested with the identical repository router as `/repositories`**, serving every artifact under a second URL nothing generates and that reads as if it addressed the storage API. Removed — `/repositories` is canonical and is what the frontend hands to Maven and npm. **Breaking** for anyone who hardcoded `/storages/...`.

## Tests

11 new tests, all runnable without a database or network:
- 6 for path parsing — traversal, control characters, that ordinary artifact paths still work, and that `parse` and `From` agree on safe input.
- 2 pinning the generated `UPDATE` SQL to a single row.
- 3 for the reader, including that an empty body terminates.

## Verification

`cargo check --all`, `cargo clippy --all --all-targets` (zero warnings), `cargo test --all` — 31 passing.

Two notes on the existing baseline, both **pre-existing on `main`** and confirmed by re-running on the base commit:
- `s3::tests::generic_test` fails with "connection refused" unless MinIO is listening on :9000. The harness only skips when *config* is absent, and it writes a default config automatically — so there is no way to skip it. Phase 1 adds MinIO to `docker-compose.yml` and reworks the harness.
- `cargo fmt --all` reformats several untouched files, because `rustfmt.toml` sets nightly-only options that stable silently skips. That churn is deliberately not in this diff; worth deciding separately whether to pin nightly for formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)