### PR TITLE
Rewrite S3 on the AWS SDK, add the FileSystemV2 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c049c0be4daef0b145cb3555416b3b8ef5b7888a38aea1a3a155801fe7b0810b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +222,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "aws-config"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b180a3c8b55960db3426d8964b8745e652466a1a49fe1a2eda828046d30b5e4"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.5.0",
+ "sha1 0.10.7",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e93964ffdaf57857f544be3666a5f57570bb699e934700f11b49708f61bb556e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,6 +288,424 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9007227e10b5fed2f3e0a2beff489211e2b5604c400b7a9d5d81ca9d64c24bb"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.140.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9660cf991e512fbe6094f1041ff3d3282bc5aeeeb6184e8de437ec2de024a10"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.105.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ffd0fbe7873cb548a7aa60f9573c268fff94155397fd4f14dc9f1ecaaab8516"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.107.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175763eb222a46377df7aa257a3bca980ab3e96703fefc8f4d0b8da6ad2e254c"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.110.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b14781dfbff48984017d57167b6ea0b6471c6920ec52b44a2677c7feb3c13"
+dependencies = [
+ "arc-swap",
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723c2234ad7511ceef63eab016b7ba6ff7c55590fefb96fa8467af014a07309f"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.5.0",
+ "p256",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f02e407fb3b54891734224b9ffac8a71fdd35f542500fa1af95754a6b2beb316"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67ecd999972b58e67cab052f5129906c08c25883bd0788ceefc55ef97d61307"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "md-5 0.11.0",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.61.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a9381123ab62d20c13082b151f30f962a3b112b727345394536dfa39a482944"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.64.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37843d9add67c3aff5856f409c6dc315d3cdff60f9c0cb5b670dab1e9920306d"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "635d23afda0a6ab48d666c4d447c4873e8d1e83518a2be2093122397e50b838e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.15",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.11.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.43",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.63.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dc65a121adb4b33729919fcfa14fa36fb33c1555a8f06bb0e2188dbfdc1d9ef"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e86338c869539a581bf161247762a6e87f92c5c075060057b5ed6d06632ed0c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512346c7212ab7436df2d77a16d976a468ae44a418835511d2a69269810aaf62"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07505b34e8f4b3591a4fa69e9792b52289b95488dbbc68c3c0075b7bedb245e1"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b98f2e1fd67ec06618f9c291e5e495a468e60519e44c9c1979cd0521f3affdb"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.5.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "221eaa237ddf1ca79b60d1372aad77e47f9c0ea5b3ce5099da8c61d027dc77b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d56e0a4e53127a632224e43633b0fe045fa9e1e3cfc68b9830f1115e103f910"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.5.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6dc683efb34b9e755675b37fedbe0103141e5b6df7bdc9eb6967756a8c167d8"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.5.0",
+ "http-body 0.4.6",
+ "http-body 1.1.0",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.62.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce84f71c72fee2cbbadde6e7d082f5fb466e3a84733855295fa7aafd1b31b7d8"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eec1cd5469f328c782dc3e33d4153cf118a54e33cbb3356d60d16f89883e1f94"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -247,10 +717,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -262,7 +732,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.7",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -280,8 +750,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -304,8 +774,8 @@ dependencies = [
  "fastrand",
  "futures-util",
  "headers",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "mime",
  "multer",
@@ -346,6 +816,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +832,16 @@ name = "base64"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b25655df2c3cdd83c5e5b293b88acd880332b2ddadd7c30ac43144fdc0033da9"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -462,6 +948,16 @@ name = "bytes"
 version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "bzip2"
@@ -587,6 +1083,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,16 +1154,6 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -708,6 +1200,16 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.1",
+]
 
 [[package]]
 name = "crc32fast"
@@ -774,6 +1276,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -790,6 +1304,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -958,6 +1481,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1034,6 +1558,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "edit-xml"
 version = "0.1.0"
 source = "git+https://github.com/wyatt-herkamp/edit-xml.git#8a04926d1f044aded01c6ec67c90247efc7a9312"
@@ -1041,7 +1579,7 @@ dependencies = [
  "ahash",
  "encoding_rs",
  "memchr",
- "quick-xml 0.39.4",
+ "quick-xml",
  "thiserror 2.0.19",
  "tracing",
 ]
@@ -1053,6 +1591,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1136,6 +1694,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,7 +1729,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -1177,19 +1745,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
+name = "foldhash"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1331,6 +1890,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1386,6 +1946,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1396,7 +1986,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1438,7 +2028,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1465,10 +2066,10 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http",
+ "http 1.5.0",
  "httpdate",
  "mime",
- "sha1",
+ "sha1 0.10.7",
 ]
 
 [[package]]
@@ -1477,7 +2078,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1490,7 +2091,7 @@ dependencies = [
  "hash32",
  "rustc_version",
  "serde",
- "spin",
+ "spin 0.9.9",
  "stable_deref_trait",
 ]
 
@@ -1512,7 +2113,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -1525,12 +2126,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "home"
 version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1545,12 +2166,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http",
+ "http 1.5.0",
 ]
 
 [[package]]
@@ -1561,8 +2193,8 @@ checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "pin-project-lite",
 ]
 
@@ -1595,6 +2227,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d22053281f852e11534f5198498373cbb59295120a20771d90f7ed1897490a72"
@@ -1603,9 +2259,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "httparse",
  "httpdate",
  "itoa",
@@ -1617,16 +2273,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.5.0",
+ "hyper 1.11.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.43",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.9",
 ]
@@ -1637,26 +2309,10 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
- "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -1670,19 +2326,17 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.5.0",
+ "http-body 1.1.0",
+ "hyper 1.11.0",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1919,7 +2573,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.9",
 ]
 
 [[package]]
@@ -1941,10 +2595,10 @@ dependencies = [
  "nom",
  "percent-encoding",
  "quoted_printable",
- "rustls",
- "socket2",
+ "rustls 0.23.43",
+ "socket2 0.6.5",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "url",
  "webpki-roots 1.0.9",
 ]
@@ -2017,6 +2671,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2056,7 +2719,7 @@ dependencies = [
  "chrono",
  "derive_builder",
  "edit-xml",
- "quick-xml 0.39.4",
+ "quick-xml",
  "serde",
  "strum 0.28.0",
  "thiserror 2.0.19",
@@ -2075,10 +2738,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "md5"
-version = "0.8.1"
+name = "md-5"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ebb8d8732c6a6df3d8f032a82911cfc747e00efb95cc46e8d0acd5b5b88570c"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
+]
 
 [[package]]
 name = "memchr"
@@ -2144,11 +2811,11 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http",
+ "http 1.5.0",
  "httparse",
  "memchr",
  "mime",
- "spin",
+ "spin 0.9.9",
  "version_check",
 ]
 
@@ -2159,23 +2826,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
 dependencies = [
  "getrandom 0.2.17",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -2211,10 +2861,10 @@ dependencies = [
  "futures",
  "futures-util",
  "handlebars",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-util",
  "inquire",
  "lettre",
@@ -2236,7 +2886,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rust-embed",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pemfile",
  "schemars",
  "semver",
@@ -2250,7 +2900,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "toml",
  "tower",
  "tower-http",
@@ -2309,7 +2959,7 @@ dependencies = [
  "clap",
  "derive_more",
  "digestible",
- "http",
+ "http 1.5.0",
  "mime",
  "nr-macros",
  "once_cell",
@@ -2351,6 +3001,10 @@ version = "2.0.0-BETA"
 dependencies = [
  "ahash",
  "anyhow",
+ "aws-config",
+ "aws-sdk-s3",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "base64 0.22.1",
  "bytes",
  "chrono",
@@ -2358,10 +3012,10 @@ dependencies = [
  "digest 0.10.7",
  "either",
  "futures",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "md-5",
+ "md-5 0.10.6",
  "mime",
  "mime_guess",
  "nr-core",
@@ -2369,7 +3023,7 @@ dependencies = [
  "postcard",
  "serde",
  "serde_json",
- "sha1",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "sha3",
  "strum 0.28.0",
@@ -2381,7 +3035,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "tux-io-s3",
+ "tux-io-encoding",
  "url",
  "utoipa",
  "uuid",
@@ -2475,47 +3129,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.81"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
-dependencies = [
- "bitflags 2.13.1",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.119",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "opentelemetry"
@@ -2551,7 +3168,7 @@ checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
 dependencies = [
  "async-trait",
  "bytes",
- "http",
+ "http 1.5.0",
  "opentelemetry",
  "reqwest",
 ]
@@ -2562,7 +3179,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
 dependencies = [
- "http",
+ "http 1.5.0",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
@@ -2616,6 +3233,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2662,7 +3297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
 dependencies = [
  "digest 0.10.7",
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2775,6 +3410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2871,6 +3512,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2904,17 +3554,6 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
- "serde",
- "tokio",
-]
-
-[[package]]
-name = "quick-xml"
 version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
@@ -2935,8 +3574,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.43",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -2956,7 +3595,7 @@ dependencies = [
  "rand_pcg",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.19",
@@ -2974,7 +3613,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3173,6 +3812,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,34 +3831,29 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-tls",
+ "hyper 1.11.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.43",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3224,6 +3864,16 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -3327,6 +3977,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
@@ -3336,9 +3998,21 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -3358,6 +4032,16 @@ checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
@@ -3432,10 +4116,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3444,7 +4152,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation 0.10.1",
+ "core-foundation",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -3579,6 +4287,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3704,6 +4423,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -3720,6 +4449,12 @@ checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "023a211cb3138dbc438680b32560ad89f699977624c9f8dbb95a47d5b4c07dd3"
 
 [[package]]
 name = "spki"
@@ -3778,7 +4513,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.43",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -3853,17 +4588,17 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.7",
  "rsa",
  "serde",
- "sha1",
+ "sha1 0.10.7",
  "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
@@ -3893,11 +4628,11 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.7",
@@ -4059,27 +4794,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.13.1",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4208,7 +4922,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.5",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4225,12 +4939,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
 dependencies = [
- "native-tls",
+ "rustls 0.21.12",
  "tokio",
 ]
 
@@ -4240,7 +4954,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.43",
  "tokio",
 ]
 
@@ -4329,10 +5043,10 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.11.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -4377,8 +5091,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.5.0",
+ "http-body 1.1.0",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -4528,60 +5242,38 @@ checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.5.0",
  "httparse",
  "log",
  "rand 0.9.5",
- "sha1",
+ "sha1 0.10.7",
  "thiserror 2.0.19",
 ]
 
 [[package]]
-name = "tux-io-s3"
+name = "tux-io-encoding"
 version = "0.1.0"
-source = "git+https://github.com/wyatt-herkamp/tux-io-s3-lib.git#372d7a77fb3e4230653a6858d6d92aa343d9e3c5"
+source = "git+https://github.com/wyatt-herkamp/tux-io-encoding.git#67b2b275d7c7de81dbf5b36e39d6b7be7853a990"
 dependencies = [
- "ahash",
- "base64 0.22.1",
  "bytes",
  "chrono",
- "futures",
- "hex",
- "hmac",
- "http",
- "http-body",
- "md5",
- "percent-encoding",
- "pin-project",
- "quick-xml 0.38.4",
- "reqwest",
- "serde",
- "sha2 0.10.9",
+ "flate2",
+ "http 1.5.0",
  "thiserror 2.0.19",
  "tokio",
- "tokio-util",
- "tracing",
- "tux-io-s3-types",
- "url",
+ "tux-io-encoding-macros",
+ "uuid",
+ "zstd",
 ]
 
 [[package]]
-name = "tux-io-s3-types"
+name = "tux-io-encoding-macros"
 version = "0.1.0"
-source = "git+https://github.com/wyatt-herkamp/tux-io-s3-lib.git#372d7a77fb3e4230653a6858d6d92aa343d9e3c5"
+source = "git+https://github.com/wyatt-herkamp/tux-io-encoding.git#67b2b275d7c7de81dbf5b36e39d6b7be7853a990"
 dependencies = [
- "chrono",
- "derive_more",
- "form_urlencoded",
- "headers",
- "http",
- "http-body",
- "itertools",
- "quick-xml 0.38.4",
- "serde",
- "thiserror 2.0.19",
- "tokio",
- "url",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4686,6 +5378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,6 +5463,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4995,17 +5699,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5208,6 +5901,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
 name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5344,13 +6043,13 @@ dependencies = [
  "deflate64",
  "flate2",
  "getrandom 0.3.4",
- "hmac",
+ "hmac 0.12.1",
  "indexmap",
  "lzma-rust2",
  "memchr",
  "pbkdf2",
  "ppmd-rust",
- "sha1",
+ "sha1 0.10.7",
  "time",
  "zeroize",
  "zopfli",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,20 @@ either = "1.12"
 
 base64 = "0.22"
 
+# Storage backends
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = "1"
+aws-smithy-types = { version = "1", features = ["byte-stream-poll-next"] }
+aws-smithy-runtime-api = "1"
+tux-io-encoding = { git = "https://github.com/wyatt-herkamp/tux-io-encoding.git", features = [
+    "tokio",
+    "chrono",
+    "uuid",
+    "bytes",
+    "zstd",
+    "gzip",
+] }
+
 # Error Handling
 schemars = { git = "https://github.com/wyatt-herkamp/schemars.git", branch = "if_for_adjacent" }
 

--- a/crates/core/migrations/20260801120000_normalize_storage_type_names.down.sql
+++ b/crates/core/migrations/20260801120000_normalize_storage_type_names.down.sql
@@ -1,0 +1,2 @@
+-- Restores the lowercase spelling the S3 backend used to register itself under.
+UPDATE storages SET storage_type = 's3' WHERE storage_type = 'S3';

--- a/crates/core/migrations/20260801120000_normalize_storage_type_names.up.sql
+++ b/crates/core/migrations/20260801120000_normalize_storage_type_names.up.sql
@@ -1,0 +1,11 @@
+-- Normalise `storages.storage_type` to match the storage factory names.
+--
+-- The column stores the name a storage is looked up by, matched exactly and case-sensitively
+-- against `StorageFactory::storage_name()`. The S3 backend used to report `"s3"` there while the
+-- config JSON stored alongside it is tagged `"S3"` (the `StorageTypeConfig` variant name), so one
+-- row carried two spellings of the same type. Both names are now `"S3"`.
+--
+-- Any row that does not match a factory is skipped at boot with a warning, so an un-migrated `s3`
+-- row would silently stop loading its storage.
+UPDATE storages SET storage_type = 'S3' WHERE storage_type = 's3';
+UPDATE storages SET storage_type = 'Local' WHERE storage_type = 'local';

--- a/crates/storage/Cargo.toml
+++ b/crates/storage/Cargo.toml
@@ -42,8 +42,15 @@ digest.workspace = true
 
 postcard = { version = "1.0", features = ["use-std", "alloc"] }
 either.workspace = true
-tux-io-s3 = { git = "https://github.com/wyatt-herkamp/tux-io-s3-lib.git" }
 url = { version = "2.4", features = ["serde"] }
+
+# S3 backend
+aws-config.workspace = true
+aws-sdk-s3.workspace = true
+aws-smithy-runtime-api.workspace = true
+aws-smithy-types.workspace = true
+# FileSystemV2 backend
+tux-io-encoding.workspace = true
 [lints]
 workspace = true
 

--- a/crates/storage/src/config.rs
+++ b/crates/storage/src/config.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::{StorageError, local::LocalConfig, s3::S3Config};
+use crate::{StorageError, fs_v2::FileSystemV2Config, local::LocalConfig, s3::S3Config};
 #[derive(Debug, Clone, Error)]
 #[error("Expected Config Type: {0}, Got: {1}")]
 pub struct InvalidConfigType(&'static str, &'static str);
@@ -133,5 +133,6 @@ macro_rules! storage_type_config {
 }
 storage_type_config! {
     Local(LocalConfig),
-    S3(S3Config)
+    S3(S3Config),
+    FileSystemV2(FileSystemV2Config)
 }

--- a/crates/storage/src/dyn_storage.rs
+++ b/crates/storage/src/dyn_storage.rs
@@ -3,188 +3,212 @@ use uuid::Uuid;
 
 use crate::{
     FileContent, FileType, Storage, StorageError, StorageFactory, StorageTypeConfig,
+    fs_v2::{FileSystemV2Factory, FileSystemV2Storage},
     local::{LocalStorage, LocalStorageFactory},
     meta::RepositoryMeta,
     s3::{S3Storage, S3StorageFactory},
     streaming::DynDirectoryListStream,
 };
-#[derive(Debug, Clone)]
-pub enum DynStorage {
+
+/// Generates the dynamic-dispatch enum over every storage backend.
+///
+/// [Storage] uses `impl Future` in return position, which makes it not object safe, so dispatch
+/// cannot go through `Box<dyn Storage>`. This enum stands in for that — but writing it by hand
+/// meant one match arm per method per backend, so adding a backend meant eleven near-identical
+/// arms that all had to be right. The macro is the same trick [crate::config::storage_type_config]
+/// already uses for the config registry.
+macro_rules! dyn_storage {
+    (
+        $(
+            $variant:ident($storage:ty)
+        ),* $(,)?
+    ) => {
+        #[derive(Debug, Clone)]
+        pub enum DynStorage {
+            $(
+                $variant($storage),
+            )*
+        }
+
+        $(
+            impl From<$storage> for DynStorage {
+                fn from(storage: $storage) -> Self {
+                    DynStorage::$variant(storage)
+                }
+            }
+        )*
+
+        impl Storage for DynStorage {
+            type Error = StorageError;
+            type DirectoryStream = DynDirectoryListStream;
+
+            fn storage_type_name(&self) -> &'static str {
+                match self {
+                    $( DynStorage::$variant(storage) => storage.storage_type_name(), )*
+                }
+            }
+
+            fn storage_config(&self) -> crate::BorrowedStorageConfig<'_> {
+                match self {
+                    $( DynStorage::$variant(storage) => storage.storage_config(), )*
+                }
+            }
+
+            async fn unload(&self) -> Result<(), StorageError> {
+                match self {
+                    $( DynStorage::$variant(storage) => storage.unload().await.map_err(Into::into), )*
+                }
+            }
+
+            async fn save_file(
+                &self,
+                repository: Uuid,
+                file: FileContent,
+                location: &StoragePath,
+            ) -> Result<(usize, bool), StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .save_file(repository, file, location)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn delete_file(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+            ) -> Result<bool, StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .delete_file(repository, location)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn get_file_information(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+            ) -> Result<Option<crate::StorageFileMeta<FileType>>, StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .get_file_information(repository, location)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn open_file(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+            ) -> Result<Option<crate::StorageFile>, StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .open_file(repository, location)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn validate_config_change(
+                &self,
+                config: StorageTypeConfig,
+            ) -> Result<(), StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .validate_config_change(config)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn put_repository_meta(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+                value: RepositoryMeta,
+            ) -> Result<(), StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .put_repository_meta(repository, location, value)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn get_repository_meta(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+            ) -> Result<Option<RepositoryMeta>, StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .get_repository_meta(repository, location)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn file_exists(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+            ) -> Result<bool, StorageError> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .file_exists(repository, location)
+                            .await
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+
+            async fn stream_directory(
+                &self,
+                repository: Uuid,
+                location: &StoragePath,
+            ) -> Result<Option<Self::DirectoryStream>, Self::Error> {
+                match self {
+                    $(
+                        DynStorage::$variant(storage) => storage
+                            .stream_directory(repository, location)
+                            .await
+                            .map(|stream| stream.map(DynDirectoryListStream::new))
+                            .map_err(Into::into),
+                    )*
+                }
+            }
+        }
+    };
+}
+
+dyn_storage! {
     Local(LocalStorage),
     S3(S3Storage),
-}
-impl Storage for DynStorage {
-    type Error = StorageError;
-    type DirectoryStream = DynDirectoryListStream;
-    async fn unload(&self) -> Result<(), StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage.unload().await.map_err(Into::into),
-            DynStorage::S3(storage) => storage.unload().await.map_err(Into::into),
-        }
-    }
-    fn storage_type_name(&self) -> &'static str {
-        match self {
-            DynStorage::Local(storage) => storage.storage_type_name(),
-            DynStorage::S3(storage) => storage.storage_type_name(),
-        }
-    }
-
-    fn storage_config(&self) -> crate::BorrowedStorageConfig<'_> {
-        match self {
-            DynStorage::Local(storage) => storage.storage_config(),
-            DynStorage::S3(storage) => storage.storage_config(),
-        }
-    }
-
-    async fn save_file(
-        &self,
-        repository: Uuid,
-        file: FileContent,
-        location: &StoragePath,
-    ) -> Result<(usize, bool), StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .save_file(repository, file, location)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .save_file(repository, file, location)
-                .await
-                .map_err(Into::into),
-        }
-    }
-
-    async fn delete_file(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-    ) -> Result<bool, StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .delete_file(repository, location)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .delete_file(repository, location)
-                .await
-                .map_err(Into::into),
-        }
-    }
-
-    async fn get_file_information(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-    ) -> Result<Option<crate::StorageFileMeta<FileType>>, StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .get_file_information(repository, location)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .get_file_information(repository, location)
-                .await
-                .map_err(Into::into),
-        }
-    }
-
-    async fn open_file(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-    ) -> Result<Option<crate::StorageFile>, StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .open_file(repository, location)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .open_file(repository, location)
-                .await
-                .map_err(Into::into),
-        }
-    }
-
-    async fn validate_config_change(&self, config: StorageTypeConfig) -> Result<(), StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .validate_config_change(config)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .validate_config_change(config)
-                .await
-                .map_err(Into::into),
-        }
-    }
-    async fn put_repository_meta(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-        value: RepositoryMeta,
-    ) -> Result<(), StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .put_repository_meta(repository, location, value)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .put_repository_meta(repository, location, value)
-                .await
-                .map_err(Into::into),
-        }
-    }
-    async fn get_repository_meta(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-    ) -> Result<Option<RepositoryMeta>, StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .get_repository_meta(repository, location)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .get_repository_meta(repository, location)
-                .await
-                .map_err(Into::into),
-        }
-    }
-    async fn file_exists(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-    ) -> Result<bool, StorageError> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .file_exists(repository, location)
-                .await
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .file_exists(repository, location)
-                .await
-                .map_err(Into::into),
-        }
-    }
-
-    async fn stream_directory(
-        &self,
-        repository: Uuid,
-        location: &StoragePath,
-    ) -> Result<Option<Self::DirectoryStream>, Self::Error> {
-        match self {
-            DynStorage::Local(storage) => storage
-                .stream_directory(repository, location)
-                .await
-                .map(|x| x.map(DynDirectoryListStream::new))
-                .map_err(Into::into),
-            DynStorage::S3(storage) => storage
-                .stream_directory(repository, location)
-                .await
-                .map(|x| x.map(DynDirectoryListStream::new))
-                .map_err(Into::into),
-        }
-    }
+    FileSystemV2(FileSystemV2Storage),
 }
 
-pub static STORAGE_FACTORIES: &[&dyn StorageFactory] = &[&LocalStorageFactory, &S3StorageFactory];
+/// Every backend the server can load, in the order they are offered.
+pub static STORAGE_FACTORIES: &[&dyn StorageFactory] = &[
+    &LocalStorageFactory,
+    &S3StorageFactory,
+    &FileSystemV2Factory,
+];

--- a/crates/storage/src/error.rs
+++ b/crates/storage/src/error.rs
@@ -20,6 +20,8 @@ pub enum StorageError {
     #[error(transparent)]
     S3StorageError(S3StorageError),
     #[error(transparent)]
+    FsV2StorageError(crate::fs_v2::error::FsV2StorageError),
+    #[error(transparent)]
     InvalidConfigType(#[from] InvalidConfigType),
     #[error(transparent)]
     PathCollision(#[from] PathCollisionError),

--- a/crates/storage/src/fs/content.rs
+++ b/crates/storage/src/fs/content.rs
@@ -3,7 +3,6 @@ use std::{io::Write, path::PathBuf};
 use bytes::Bytes;
 use derive_more::derive::From;
 use nr_core::storage::FileHashes;
-use tux_io_s3::command::S3CommandBody;
 
 use super::{generate_from_bytes, generate_hashes_from_path};
 
@@ -35,11 +34,11 @@ pub enum FileContentBytes {
     Content(Vec<u8>),
     Bytes(Bytes),
 }
-impl From<FileContentBytes> for S3CommandBody {
+impl From<FileContentBytes> for Bytes {
     fn from(value: FileContentBytes) -> Self {
         match value {
-            FileContentBytes::Content(content) => S3CommandBody::from(content),
-            FileContentBytes::Bytes(bytes) => S3CommandBody::from(bytes),
+            FileContentBytes::Content(content) => Bytes::from(content),
+            FileContentBytes::Bytes(bytes) => bytes,
         }
     }
 }

--- a/crates/storage/src/fs/file_meta.rs
+++ b/crates/storage/src/fs/file_meta.rs
@@ -148,6 +148,54 @@ impl FileMeta {
     }
 }
 impl LocationMeta {
+    /// Encodes the metadata for storage next to the object it describes.
+    ///
+    /// Postcard, the same encoding the local backend's `.nr-meta` sidecars use, so every backend
+    /// reads and writes one format — an S3 sidecar object and a local sidecar file are byte
+    /// identical for the same metadata.
+    pub fn to_postcard(&self) -> Result<Vec<u8>, postcard::Error> {
+        postcard::to_allocvec(self)
+    }
+    /// Decodes metadata written by [LocationMeta::to_postcard].
+    pub fn from_postcard(bytes: &[u8]) -> Result<Self, postcard::Error> {
+        postcard::from_bytes(bytes)
+    }
+    /// Metadata for a file whose content is already in hand.
+    ///
+    /// For backends that do not have a filesystem to interrogate — the hashes come from the bytes
+    /// being written rather than from a path.
+    pub fn for_file(
+        created: DateTime<FixedOffset>,
+        modified: DateTime<FixedOffset>,
+        hashes: FileHashes,
+    ) -> Self {
+        LocationMeta {
+            created,
+            modified,
+            location_typed_meta: LocationTypedMeta::File(FileMeta { hashes }),
+            repository_meta: RepositoryMeta::default(),
+        }
+    }
+    /// Metadata for a directory with a known entry count.
+    pub fn for_directory(
+        created: DateTime<FixedOffset>,
+        modified: DateTime<FixedOffset>,
+        number_of_files: u64,
+    ) -> Self {
+        LocationMeta {
+            created,
+            modified,
+            location_typed_meta: LocationTypedMeta::Directory(DirectoryMeta { number_of_files }),
+            repository_meta: RepositoryMeta::default(),
+        }
+    }
+    /// The hashes recorded for a file, or an empty set for a directory.
+    pub fn hashes(&self) -> FileHashes {
+        match &self.location_typed_meta {
+            LocationTypedMeta::File(meta) => meta.hashes.clone(),
+            LocationTypedMeta::Directory(_) => FileHashes::default(),
+        }
+    }
     pub fn dir_meta_or_err(&self) -> Result<&DirectoryMeta, LocalStorageError> {
         if let LocationTypedMeta::Directory(meta) = &self.location_typed_meta {
             Ok(meta)

--- a/crates/storage/src/fs_v2/error.rs
+++ b/crates/storage/src/fs_v2/error.rs
@@ -1,0 +1,47 @@
+use std::path::PathBuf;
+
+use nr_core::storage::StoragePath;
+use thiserror::Error;
+
+use crate::{InvalidConfigType, PathCollisionError, StorageError, error::WrongFileType};
+
+#[derive(Debug, Error)]
+pub enum FsV2StorageError {
+    #[error("IO Error: {0}")]
+    IO(#[from] std::io::Error),
+    #[error("Object encoding error: {0}")]
+    Object(#[from] tux_io_encoding::fs::ObjectFileError),
+    #[error("Blocking storage task failed: {0}")]
+    BlockingTask(#[from] tokio::task::JoinError),
+    #[error("Could not encode repository metadata: {0}")]
+    Meta(#[from] postcard::Error),
+    #[error(transparent)]
+    InvalidConfigType(#[from] InvalidConfigType),
+    #[error(transparent)]
+    PathCollision(#[from] PathCollisionError),
+    #[error(transparent)]
+    WrongFileType(#[from] WrongFileType),
+    #[error("`{0}` has no parent directory")]
+    NoParentDirectory(StoragePath),
+    #[error("`{0}` does not exist")]
+    NotFound(StoragePath),
+    #[error("The storage root `{0}` is a file")]
+    RootIsAFile(PathBuf),
+    #[error("The path of a FileSystemV2 storage cannot be changed once it holds artifacts")]
+    PathCannotBeChanged,
+}
+
+/// Flattens the two errors that the crate models as first-class variants.
+///
+/// Mirrors the local and S3 backends: a path collision or a wrong file type means the same thing
+/// whichever backend produced it, so callers can match on one variant instead of unwrapping a
+/// backend-specific error first.
+impl From<FsV2StorageError> for StorageError {
+    fn from(value: FsV2StorageError) -> Self {
+        match value {
+            FsV2StorageError::PathCollision(err) => StorageError::PathCollision(err),
+            FsV2StorageError::WrongFileType(err) => StorageError::WrongFileType(err),
+            other => StorageError::FsV2StorageError(other),
+        }
+    }
+}

--- a/crates/storage/src/fs_v2/mod.rs
+++ b/crates/storage/src/fs_v2/mod.rs
@@ -1,0 +1,871 @@
+//! FileSystem V2 — on-disk storage where each artifact is a single self-describing object.
+//!
+//! # How it differs from [crate::local]
+//!
+//! The original local backend stores an artifact as the raw bytes plus a sibling `.nr-meta` file
+//! holding postcard-encoded metadata (and a `.nr-meta` inside every directory). That has three
+//! costs this backend does not pay:
+//!
+//! - **Two files per artifact.** Every listing has to filter hidden entries, and the two can drift
+//!   apart — a sidecar that fails to decode is silently rebuilt.
+//! - **Eventually consistent metadata.** Sidecars are written by a background task fed over a
+//!   channel, so a file's hashes are briefly wrong after it is written.
+//! - **Whole-file reads to hash.** `generate_hashes_from_path` reads the file into a `Vec` after
+//!   the fact.
+//!
+//! Here an object is one file in the [tux_io_encoding] layout: a 32 byte header, a metadata map, a
+//! tag map, then the content. Writing streams the content first and the prefix last, so hashes are
+//! computed from the bytes as they go past and written in the same pass. The write lands in a temp
+//! file that is renamed into place, so a reader never sees a half-written artifact.
+//!
+//! # Where things are stored
+//!
+//! - **Metadata map** (system controlled): `created`, `modified`, `content-type`, and one entry per
+//!   digest. Keys are [tux_io_encoding::MetaKey], which wraps `http::HeaderName` — so they are
+//!   lowercase and header-shaped.
+//! - **Tags** (user controlled): a single `nr-repository-meta` entry holding a postcard-encoded
+//!   [RepositoryMeta]. One opaque blob rather than a tag per field, because `extra_meta` keys are
+//!   arbitrary strings and would not all survive being mapped onto tag keys.
+//! - **Directories** are real directories. Their metadata lives in a `.nr-dir` object inside them,
+//!   which is what gives a directory somewhere to carry [RepositoryMeta] — Maven stamps project
+//!   ids onto directories, not just files.
+//!
+//! Range reads come for free here (`content_range_reader`), which the original local backend
+//! cannot do.
+use std::{
+    io::{ErrorKind, Write},
+    ops::Deref,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use chrono::{DateTime, FixedOffset, Local};
+use futures::future::BoxFuture;
+use nr_core::storage::{FileHashes, SerdeMime, StoragePath};
+use serde::{Deserialize, Serialize};
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, info, instrument, warn};
+use tux_io_encoding::{
+    CompressionTypes, MetaKey, Tags, ValueType,
+    compression_types::{GzipCompressionType, ZStdCompressionType},
+    fs::{AsyncTuxObject, CreateOptions, TuxObject},
+};
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+pub mod error;
+use error::FsV2StorageError;
+
+use crate::{
+    BorrowedStorageConfig, BorrowedStorageTypeConfig, DirectoryFileType, DynStorage, FileContent,
+    FileFileType, FileType, PathCollisionError, StaticStorageFactory, Storage, StorageConfig,
+    StorageConfigInner, StorageError, StorageFactory, StorageFile, StorageFileMeta,
+    StorageFileReader, StorageTypeConfig, StorageTypeConfigTrait, meta::RepositoryMeta,
+    streaming::VecDirectoryListStream, utils::new_type_arc_type,
+};
+
+/// Object inside a directory carrying that directory's metadata.
+const DIRECTORY_META_FILE: &str = ".nr-dir";
+/// Tag holding the postcard-encoded [RepositoryMeta].
+const REPOSITORY_META_TAG: &str = "nr-repository-meta";
+
+mod meta_keys {
+    use http::HeaderName;
+    pub const CREATED: HeaderName = HeaderName::from_static("created");
+    pub const MODIFIED: HeaderName = HeaderName::from_static("modified");
+    pub const CONTENT_TYPE: HeaderName = HeaderName::from_static("content-type");
+    pub const MD5: HeaderName = HeaderName::from_static("md5");
+    pub const SHA1: HeaderName = HeaderName::from_static("sha1");
+    pub const SHA2_256: HeaderName = HeaderName::from_static("sha2-256");
+    pub const SHA3_256: HeaderName = HeaderName::from_static("sha3-256");
+}
+
+/// Content compression applied to stored artifacts.
+///
+/// Off by default: most artifacts (jars, tarballs, `.tgz`) are already compressed, so the codec
+/// costs CPU for nothing. It is worth turning on for a repository of POMs and metadata XML.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum Compression {
+    #[default]
+    None,
+    Zstd,
+    Gzip,
+}
+impl From<Compression> for CompressionTypes {
+    fn from(value: Compression) -> Self {
+        match value {
+            Compression::None => CompressionTypes::default(),
+            // Mid-range levels: the point here is to shrink text-ish artifacts (POMs, metadata
+            // XML, packuments) without making a deploy wait on the codec.
+            Compression::Zstd => CompressionTypes::ZSTD(ZStdCompressionType(3)),
+            Compression::Gzip => CompressionTypes::Gzip(GzipCompressionType(6)),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub struct FileSystemV2Config {
+    /// Root directory holding one sub-directory per repository.
+    #[schema(value_type = String)]
+    pub path: PathBuf,
+    #[serde(default)]
+    pub compression: Compression,
+    /// `fsync` each object before publishing it.
+    ///
+    /// Costs a flush per write in exchange for a completed upload surviving a power loss. Off by
+    /// default because the rename is already atomic — a crash loses the write rather than
+    /// corrupting anything.
+    #[serde(default)]
+    pub sync: bool,
+}
+
+#[derive(Debug)]
+pub struct FileSystemV2Inner {
+    pub config: FileSystemV2Config,
+    pub storage_config: StorageConfigInner,
+}
+
+impl FileSystemV2Inner {
+    /// Absolute path for a repository-relative location.
+    fn resolve(&self, repository: Uuid, location: &StoragePath) -> PathBuf {
+        let mut path = self.config.path.join(repository.to_string());
+        for component in location.clone() {
+            path.push(component.as_ref());
+        }
+        path
+    }
+
+    /// Rejects a path whose ancestor is an existing artifact.
+    ///
+    /// `/a/b` being a file makes `/a/b/c` impossible; without this check the write would fail
+    /// later with a bare `NotADirectory` from the OS.
+    fn check_for_collisions(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<(), FsV2StorageError> {
+        let mut path = self.config.path.join(repository.to_string());
+        let mut conflicting_path = StoragePath::default();
+        let mut components = location.clone().into_iter().peekable();
+        while let Some(component) = components.next() {
+            path.push(component.as_ref());
+            conflicting_path.push_mut(component.as_ref());
+            if components.peek().is_none() {
+                break;
+            }
+            if path.is_file() {
+                return Err(PathCollisionError {
+                    path: location.clone(),
+                    conflicts_with: conflicting_path,
+                }
+                .into());
+            }
+        }
+        Ok(())
+    }
+
+    /// Where a directory keeps its own metadata.
+    fn directory_meta_path(directory: &Path) -> PathBuf {
+        directory.join(DIRECTORY_META_FILE)
+    }
+
+    /// Whether a directory entry is bookkeeping rather than a stored artifact.
+    fn is_hidden(name: &str) -> bool {
+        name == DIRECTORY_META_FILE
+    }
+
+    /// Opens the object backing a path, whether it is a file or a directory.
+    async fn open_object(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<Option<AsyncTuxObject>, FsV2StorageError> {
+        let path = self.resolve(repository, location);
+        let path = if path.is_dir() {
+            Self::directory_meta_path(&path)
+        } else {
+            path
+        };
+        Ok(AsyncTuxObject::open_optional(path).await?)
+    }
+
+    /// Writes a directory's metadata object, creating the directory if needed.
+    async fn write_directory_meta(
+        &self,
+        directory: &Path,
+        repository_meta: RepositoryMeta,
+    ) -> Result<(), FsV2StorageError> {
+        tokio::fs::create_dir_all(directory).await?;
+        let now = Local::now().fixed_offset();
+        let meta_path = Self::directory_meta_path(directory);
+
+        let created = match AsyncTuxObject::open_optional(&meta_path).await? {
+            Some(existing) => {
+                read_datetime(existing.metadata(), &meta_keys::CREATED).unwrap_or(now)
+            }
+            None => now,
+        };
+
+        let mut options = CreateOptions::new().with_sync(self.config.sync);
+        options
+            .metadata
+            .insert(MetaKey::from(meta_keys::CREATED), ValueType::from(created));
+        options
+            .metadata
+            .insert(MetaKey::from(meta_keys::MODIFIED), ValueType::from(now));
+        options.tags = repository_meta_tags(&repository_meta)?;
+
+        let writer = AsyncTuxObject::create(&meta_path, options).await?;
+        writer.finish().await?;
+        Ok(())
+    }
+
+    /// Reads a directory's [RepositoryMeta], if it has any.
+    async fn read_directory_meta(
+        &self,
+        directory: &Path,
+    ) -> Result<Option<AsyncTuxObject>, FsV2StorageError> {
+        Ok(AsyncTuxObject::open_optional(Self::directory_meta_path(directory)).await?)
+    }
+
+    /// Builds the listing entry for one filesystem path.
+    async fn meta_for_path(
+        &self,
+        path: &Path,
+        name: String,
+    ) -> Result<Option<StorageFileMeta<FileType>>, FsV2StorageError> {
+        if path.is_dir() {
+            let entries = self.count_entries(path).await?;
+            let (created, modified) = match self.read_directory_meta(path).await? {
+                Some(object) => timestamps_from(object.metadata()),
+                None => (None, None),
+            };
+            let modified = modified.unwrap_or_else(|| Local::now().fixed_offset());
+            return Ok(Some(StorageFileMeta {
+                name,
+                file_type: FileType::Directory(DirectoryFileType {
+                    file_count: entries,
+                }),
+                modified,
+                created: created.unwrap_or(modified),
+            }));
+        }
+
+        let Some(object) = AsyncTuxObject::open_optional(path).await? else {
+            return Ok(None);
+        };
+        let metadata = object.metadata();
+        let (created, modified) = timestamps_from(metadata);
+        let modified = modified.unwrap_or_else(|| Local::now().fixed_offset());
+        Ok(Some(StorageFileMeta {
+            name,
+            file_type: FileType::File(FileFileType {
+                file_size: object.content_length(),
+                mime_type: metadata
+                    .get_header(&meta_keys::CONTENT_TYPE)
+                    .and_then(ValueType::as_str)
+                    .and_then(|value| value.parse().ok())
+                    .map(SerdeMime),
+                file_hash: hashes_from(metadata),
+            }),
+            modified,
+            created: created.unwrap_or(modified),
+        }))
+    }
+
+    /// Counts the visible entries in a directory.
+    async fn count_entries(&self, directory: &Path) -> Result<u64, FsV2StorageError> {
+        let mut entries = tokio::fs::read_dir(directory).await?;
+        let mut count = 0;
+        while let Some(entry) = entries.next_entry().await? {
+            if !Self::is_hidden(&entry.file_name().to_string_lossy()) {
+                count += 1;
+            }
+        }
+        Ok(count)
+    }
+
+    /// Lists one directory level.
+    async fn list_directory(
+        &self,
+        directory: &Path,
+    ) -> Result<Vec<StorageFileMeta<FileType>>, FsV2StorageError> {
+        let mut files = Vec::new();
+        let mut entries = tokio::fs::read_dir(directory).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let name = entry.file_name().to_string_lossy().into_owned();
+            if Self::is_hidden(&name) {
+                continue;
+            }
+            if let Some(meta) = self.meta_for_path(&entry.path(), name).await? {
+                files.push(meta);
+            }
+        }
+        Ok(files)
+    }
+}
+
+/// Encodes [RepositoryMeta] into the tag map an object is created with.
+fn repository_meta_tags(meta: &RepositoryMeta) -> Result<Tags, FsV2StorageError> {
+    let mut tags = Tags::new();
+    tags.insert(
+        REPOSITORY_META_TAG.to_owned(),
+        ValueType::Bytes(postcard::to_allocvec(meta)?),
+    );
+    Ok(tags)
+}
+
+/// Decodes the [RepositoryMeta] tag, treating an unreadable one as absent.
+fn repository_meta_from_tags(tags: &Tags) -> RepositoryMeta {
+    let Some(ValueType::Bytes(bytes)) = tags.get(REPOSITORY_META_TAG) else {
+        return RepositoryMeta::default();
+    };
+    match postcard::from_bytes(bytes) {
+        Ok(meta) => meta,
+        Err(err) => {
+            warn!(?err, "Repository meta tag is unreadable; treating as empty");
+            RepositoryMeta::default()
+        }
+    }
+}
+
+fn read_datetime(
+    metadata: &tux_io_encoding::MetadataMap,
+    key: &http::HeaderName,
+) -> Option<DateTime<FixedOffset>> {
+    match metadata.get_header(key) {
+        Some(ValueType::RawDateTime(raw)) => DateTime::try_from(*raw).ok(),
+        _ => None,
+    }
+}
+
+fn timestamps_from(
+    metadata: &tux_io_encoding::MetadataMap,
+) -> (Option<DateTime<FixedOffset>>, Option<DateTime<FixedOffset>>) {
+    (
+        read_datetime(metadata, &meta_keys::CREATED),
+        read_datetime(metadata, &meta_keys::MODIFIED),
+    )
+}
+
+fn hashes_from(metadata: &tux_io_encoding::MetadataMap) -> FileHashes {
+    let read = |name: &http::HeaderName| {
+        metadata
+            .get_header(name)
+            .and_then(ValueType::as_str)
+            .map(str::to_owned)
+    };
+    FileHashes {
+        md5: read(&meta_keys::MD5),
+        sha1: read(&meta_keys::SHA1),
+        sha2_256: read(&meta_keys::SHA2_256),
+        sha3_256: read(&meta_keys::SHA3_256),
+    }
+}
+
+fn insert_hashes(metadata: &mut tux_io_encoding::MetadataMap, hashes: &FileHashes) {
+    let mut insert = |name: http::HeaderName, value: &Option<String>| {
+        if let Some(value) = value {
+            metadata.insert(MetaKey::from(name), ValueType::String(value.clone()));
+        }
+    };
+    insert(meta_keys::MD5, &hashes.md5);
+    insert(meta_keys::SHA1, &hashes.sha1);
+    insert(meta_keys::SHA2_256, &hashes.sha2_256);
+    insert(meta_keys::SHA3_256, &hashes.sha3_256);
+}
+
+#[derive(Debug, Clone)]
+pub struct FileSystemV2Storage(Arc<FileSystemV2Inner>);
+new_type_arc_type!(FileSystemV2Storage(FileSystemV2Inner));
+
+impl Storage for FileSystemV2Storage {
+    type Error = FsV2StorageError;
+    type DirectoryStream = VecDirectoryListStream;
+
+    fn storage_type_name(&self) -> &'static str {
+        FileSystemV2Factory::STORAGE_TYPE_NAME
+    }
+
+    #[instrument(
+        name = "Storage::unload",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn unload(&self) -> Result<(), FsV2StorageError> {
+        // Every write is published by rename before `save_file` returns, so there is nothing in
+        // flight to wait for — unlike the original local backend's background meta task.
+        info!("Unloading FileSystemV2 Storage");
+        Ok(())
+    }
+
+    fn storage_config(&self) -> BorrowedStorageConfig<'_> {
+        BorrowedStorageConfig {
+            storage_config: &self.storage_config,
+            config: BorrowedStorageTypeConfig::FileSystemV2(&self.config),
+        }
+    }
+
+    #[instrument(
+        name = "Storage::save_file",
+        skip(self, file),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn save_file(
+        &self,
+        repository: Uuid,
+        file: FileContent,
+        location: &StoragePath,
+    ) -> Result<(usize, bool), FsV2StorageError> {
+        self.check_for_collisions(repository, location)?;
+
+        let path = self.resolve(repository, location);
+        let parent = path
+            .parent()
+            .ok_or_else(|| FsV2StorageError::NoParentDirectory(location.clone()))?;
+        tokio::fs::create_dir_all(parent).await?;
+
+        let now = Local::now().fixed_offset();
+        // Carry forward whatever the previous version of this artifact recorded, so an overwrite
+        // does not reset the creation time or drop the project ids Maven attached to the path.
+        let (created, existing_repository_meta, already_exists) =
+            match AsyncTuxObject::open_optional(&path).await? {
+                Some(mut existing) => {
+                    let created =
+                        read_datetime(existing.metadata(), &meta_keys::CREATED).unwrap_or(now);
+                    let tags = existing.read_tags().await?;
+                    (created, repository_meta_from_tags(&tags), true)
+                }
+                None => (now, RepositoryMeta::default(), false),
+            };
+
+        let hashes = file.generate_hashes()?;
+        let bytes: Vec<u8> = file.try_into()?;
+        let size = bytes.len();
+
+        let mut options = CreateOptions::new()
+            .with_sync(self.config.sync)
+            .with_compression(self.config.compression.into());
+        options
+            .metadata
+            .insert(MetaKey::from(meta_keys::CREATED), ValueType::from(created));
+        options
+            .metadata
+            .insert(MetaKey::from(meta_keys::MODIFIED), ValueType::from(now));
+        if let Some(mime) = mime_guess::from_path(&path).first() {
+            options.metadata.insert(
+                MetaKey::from(meta_keys::CONTENT_TYPE),
+                ValueType::String(mime.to_string()),
+            );
+        }
+        insert_hashes(&mut options.metadata, &hashes);
+        options.tags = repository_meta_tags(&existing_repository_meta)?;
+
+        if matches!(self.config.compression, Compression::None) {
+            let mut writer = AsyncTuxObject::create(&path, options).await?;
+            writer.write_all(&bytes).await?;
+            writer.finish().await?;
+        } else {
+            // The compression codecs are synchronous, and `AsyncObjectWriter::create` rejects a
+            // compressed object outright for that reason. Compressed writes therefore go through
+            // the blocking writer on the blocking pool rather than the async one.
+            let path = path.clone();
+            tokio::task::spawn_blocking(move || -> Result<(), FsV2StorageError> {
+                let mut writer = TuxObject::create(&path, options)?;
+                let mut encoder = writer.content_encoder()?;
+                encoder.write_all(&bytes)?;
+                encoder.finish()?;
+                writer.finish()?;
+                Ok(())
+            })
+            .await
+            .map_err(FsV2StorageError::from)??;
+        }
+
+        // Keep the parent directory's own object present so it can carry metadata and timestamps.
+        if self.read_directory_meta(parent).await?.is_none() {
+            self.write_directory_meta(parent, RepositoryMeta::default())
+                .await?;
+        }
+
+        Ok((size, !already_exists))
+    }
+
+    #[instrument(
+        name = "Storage::put_repository_meta",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn put_repository_meta(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+        value: RepositoryMeta,
+    ) -> Result<(), FsV2StorageError> {
+        let path = self.resolve(repository, location);
+        if path.is_dir() {
+            return self.write_directory_meta(&path, value).await;
+        }
+
+        let Some(mut object) = AsyncTuxObject::open_writable(&path).await.map_or_else(
+            |err| match err {
+                tux_io_encoding::fs::ObjectFileError::IO(io)
+                    if io.kind() == ErrorKind::NotFound =>
+                {
+                    Ok(None)
+                }
+                other => Err(other),
+            },
+            |object| Ok(Some(object)),
+        )?
+        else {
+            return Err(FsV2StorageError::NotFound(location.clone()));
+        };
+        // Only the tag section changes, and it is rewritten atomically.
+        object.set_tags(repository_meta_tags(&value)?).await?;
+        Ok(())
+    }
+
+    #[instrument(
+        name = "Storage::get_repository_meta",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn get_repository_meta(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<Option<RepositoryMeta>, FsV2StorageError> {
+        let Some(mut object) = self.open_object(repository, location).await? else {
+            return Ok(None);
+        };
+        let tags = object.read_tags().await?;
+        Ok(Some(repository_meta_from_tags(&tags)))
+    }
+
+    #[instrument(
+        name = "Storage::delete_file",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn delete_file(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<bool, FsV2StorageError> {
+        let path = self.resolve(repository, location);
+        if path.is_dir() {
+            tokio::fs::remove_dir_all(&path).await?;
+            return Ok(true);
+        }
+        match tokio::fs::remove_file(&path).await {
+            Ok(()) => Ok(true),
+            Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    #[instrument(
+        name = "Storage::get_file_information",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn get_file_information(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<Option<StorageFileMeta<FileType>>, FsV2StorageError> {
+        let path = self.resolve(repository, location);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let name = location
+            .clone()
+            .into_iter()
+            .next_back()
+            .map(|component| component.to_string())
+            .unwrap_or_default();
+        self.meta_for_path(&path, name).await
+    }
+
+    #[instrument(
+        name = "Storage::open_file",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn open_file(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<Option<StorageFile>, FsV2StorageError> {
+        let path = self.resolve(repository, location);
+        let Some(meta) = self.get_file_information(repository, location).await? else {
+            return Ok(None);
+        };
+
+        match meta.file_type {
+            FileType::Directory(file_type) => Ok(Some(StorageFile::Directory {
+                meta: StorageFileMeta {
+                    name: meta.name,
+                    file_type,
+                    modified: meta.modified,
+                    created: meta.created,
+                },
+                files: self.list_directory(&path).await?,
+            })),
+            FileType::File(file_type) => {
+                let Some(object) = AsyncTuxObject::open_optional(&path).await? else {
+                    return Ok(None);
+                };
+                // `into_content_reader` hands over the file handle, so the reader can outlive this
+                // function and be handed straight to a response body.
+                let reader = if object.is_compressed() {
+                    // Compressed content has to be decoded, and the codecs are synchronous.
+                    let mut object = object;
+                    let content = object.read_content_to_vec().await?;
+                    StorageFileReader::from(crate::FileContentBytes::Content(content))
+                } else {
+                    StorageFileReader::AsyncReader(Box::pin(object.into_content_reader().await?))
+                };
+                Ok(Some(StorageFile::File {
+                    meta: StorageFileMeta {
+                        name: meta.name,
+                        file_type,
+                        modified: meta.modified,
+                        created: meta.created,
+                    },
+                    content: reader,
+                }))
+            }
+        }
+    }
+
+    #[instrument(
+        name = "Storage::validate_config_change",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn validate_config_change(
+        &self,
+        config: StorageTypeConfig,
+    ) -> Result<(), FsV2StorageError> {
+        let config = FileSystemV2Config::from_type_config(config)?;
+        if config.path != self.config.path {
+            // Moving the root would orphan everything already stored under the old one.
+            return Err(FsV2StorageError::PathCannotBeChanged);
+        }
+        Ok(())
+    }
+
+    #[instrument(
+        name = "Storage::file_exists",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn file_exists(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<bool, FsV2StorageError> {
+        Ok(self.resolve(repository, location).exists())
+    }
+
+    #[instrument(
+        name = "Storage::stream_directory",
+        skip(self),
+        fields(storage_type = "FileSystemV2")
+    )]
+    async fn stream_directory(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<Option<Self::DirectoryStream>, FsV2StorageError> {
+        let path = self.resolve(repository, location);
+        if !path.is_dir() {
+            return Ok(None);
+        }
+        let files = self.list_directory(&path).await?;
+        let name = location
+            .clone()
+            .into_iter()
+            .next_back()
+            .map(|component| component.to_string())
+            .unwrap_or_default();
+        let (created, modified) = match self.read_directory_meta(&path).await? {
+            Some(object) => timestamps_from(object.metadata()),
+            None => (None, None),
+        };
+        let modified = modified.unwrap_or_else(|| Local::now().fixed_offset());
+        Ok(Some(VecDirectoryListStream::new(
+            files.clone(),
+            StorageFileMeta {
+                name,
+                file_type: DirectoryFileType {
+                    file_count: files.len() as u64,
+                },
+                modified,
+                created: created.unwrap_or(modified),
+            },
+        )))
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct FileSystemV2Factory;
+
+impl FileSystemV2Factory {
+    pub const STORAGE_TYPE_NAME: &'static str = "FileSystemV2";
+
+    async fn prepare(config: &FileSystemV2Config) -> Result<(), FsV2StorageError> {
+        if config.path.is_file() {
+            return Err(FsV2StorageError::RootIsAFile(config.path.clone()));
+        }
+        tokio::fs::create_dir_all(&config.path).await?;
+        debug!(path = ?config.path, "FileSystemV2 root ready");
+        Ok(())
+    }
+}
+
+impl StaticStorageFactory for FileSystemV2Factory {
+    type StorageType = FileSystemV2Storage;
+    type ConfigType = FileSystemV2Config;
+    type Error = FsV2StorageError;
+
+    fn storage_type_name() -> &'static str {
+        Self::STORAGE_TYPE_NAME
+    }
+
+    async fn test_storage_config(config: StorageTypeConfig) -> Result<(), FsV2StorageError> {
+        Self::prepare(&FileSystemV2Config::from_type_config(config)?).await
+    }
+
+    async fn create_storage(
+        inner: StorageConfigInner,
+        type_config: Self::ConfigType,
+    ) -> Result<Self::StorageType, FsV2StorageError> {
+        Self::prepare(&type_config).await?;
+        Ok(FileSystemV2Storage::from(FileSystemV2Inner {
+            config: type_config,
+            storage_config: inner,
+        }))
+    }
+}
+
+impl StorageFactory for FileSystemV2Factory {
+    fn storage_name(&self) -> &'static str {
+        Self::STORAGE_TYPE_NAME
+    }
+
+    fn test_storage_config(
+        &self,
+        config: StorageTypeConfig,
+    ) -> BoxFuture<'static, Result<(), StorageError>> {
+        Box::pin(async move {
+            <Self as StaticStorageFactory>::test_storage_config(config).await?;
+            Ok(())
+        })
+    }
+
+    fn create_storage(
+        &self,
+        config: StorageConfig,
+    ) -> BoxFuture<'static, Result<DynStorage, StorageError>> {
+        Box::pin(async move {
+            let storage =
+                <Self as StaticStorageFactory>::create_storage_from_config(config).await?;
+            Ok(DynStorage::FileSystemV2(storage))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nr_core::storage::StoragePath;
+    use tracing::warn;
+    use uuid::Uuid;
+
+    use super::*;
+    use crate::{
+        StaticStorageFactory, fs_v2::FileSystemV2Factory, testing::storage::TestingStorage,
+    };
+
+    /// Compressed objects take a different write path to uncompressed ones.
+    ///
+    /// `AsyncObjectWriter::create` rejects compression outright — the codecs are synchronous — so
+    /// compressed writes go through the blocking writer instead. Nothing else covers that branch,
+    /// and a mistake in it would store content whose header claims a codec that was never applied,
+    /// which reads back as garbage rather than failing loudly.
+    async fn round_trip_with_compression(compression: Compression) -> anyhow::Result<()> {
+        let root = std::env::temp_dir().join(format!("nr-fs-v2-{}", Uuid::new_v4()));
+        let storage = <FileSystemV2Factory as StaticStorageFactory>::create_storage(
+            StorageConfigInner::test_config(),
+            FileSystemV2Config {
+                path: root.clone(),
+                compression,
+                sync: false,
+            },
+        )
+        .await?;
+
+        let repository = Uuid::new_v4();
+        let path = StoragePath::from("compressed/pom.xml");
+        // Repetitive enough that a codec has something to do.
+        let body = "<project><modelVersion>4.0.0</modelVersion></project>".repeat(64);
+
+        let (written, is_new) = storage
+            .save_file(repository, FileContent::from(body.as_str()), &path)
+            .await?;
+        assert_eq!(written, body.len());
+        assert!(is_new);
+
+        let Some(StorageFile::File { meta, content }) =
+            storage.open_file(repository, &path).await?
+        else {
+            panic!("Compressed object did not read back as a file");
+        };
+        let read = content.read_to_vec(body.len()).await?;
+        assert_eq!(
+            String::from_utf8(read)?,
+            body,
+            "Content did not survive a {compression:?} round trip"
+        );
+        assert!(
+            meta.file_type.file_hash.sha2_256.is_some(),
+            "Hashes should describe the original content, not the compressed bytes"
+        );
+
+        tokio::fs::remove_dir_all(&root).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn zstd_round_trip() -> anyhow::Result<()> {
+        round_trip_with_compression(Compression::Zstd).await
+    }
+
+    #[tokio::test]
+    async fn gzip_round_trip() -> anyhow::Result<()> {
+        round_trip_with_compression(Compression::Gzip).await
+    }
+
+    #[tokio::test]
+    async fn uncompressed_round_trip() -> anyhow::Result<()> {
+        round_trip_with_compression(Compression::None).await
+    }
+
+    #[tokio::test]
+    pub async fn generic_test() -> anyhow::Result<()> {
+        let Some(config) = crate::testing::start_storage_test("FileSystemV2").await? else {
+            warn!("FileSystemV2 Storage Test Skipped");
+            return Ok(());
+        };
+        let storage =
+            <FileSystemV2Factory as StaticStorageFactory>::create_storage_from_config(config)
+                .await?;
+        let testing_storage = TestingStorage::new(storage);
+        crate::testing::tests::full_test(testing_storage).await?;
+
+        Ok(())
+    }
+}

--- a/crates/storage/src/lib.rs
+++ b/crates/storage/src/lib.rs
@@ -13,6 +13,7 @@ mod config;
 mod dyn_storage;
 mod error;
 mod fs;
+pub mod fs_v2;
 pub use dyn_storage::*;
 pub mod local;
 pub mod meta;

--- a/crates/storage/src/local/mod.rs
+++ b/crates/storage/src/local/mod.rs
@@ -685,7 +685,7 @@ mod tests {
 
     #[tokio::test]
     pub async fn generic_test() -> anyhow::Result<()> {
-        let Some(config) = crate::testing::start_storage_test("Local")? else {
+        let Some(config) = crate::testing::start_storage_test("Local").await? else {
             warn!("Local Storage Test Skipped");
             return Ok(());
         };

--- a/crates/storage/src/s3/mod.rs
+++ b/crates/storage/src/s3/mod.rs
@@ -1,75 +1,118 @@
-#![allow(dead_code)]
+//! S3 storage backend, built on the official AWS SDK.
+//!
+//! # Layout
+//!
+//! Objects live under `{repository_uuid}/{storage path}`, mirroring the directory layout the local
+//! backends use. Two kinds of extra object make that layout navigable:
+//!
+//! - **Metadata sidecars.** S3 has nowhere to put the data [crate::meta::RepositoryMeta] carries —
+//!   object tags cap out at 10 entries of 256 characters, and `x-amz-meta-*` at 2 KB in total,
+//!   neither of which fits arbitrary repository metadata. So each object gets a sibling
+//!   `{key}.nr-meta` holding a postcard-encoded [LocationMeta], exactly as the local backend
+//!   writes beside a file on disk. One codec serves every backend.
+//! - **Directory markers.** S3 has no directories, only key prefixes. An empty object with
+//!   `Content-Type: application/x-directory` marks one, which is the convention MinIO and the AWS
+//!   console both understand. Listing does not depend on these markers — it works off
+//!   `CommonPrefixes` — but writing them keeps a bucket legible to other tools.
+//!
+//! # Credentials
+//!
+//! An explicit access/secret key pair is optional. With none configured the SDK's default provider
+//! chain applies (environment, shared config, IMDS, web identity), which is what makes an IAM role
+//! or an assumed role work without putting long-lived keys in the database.
 use std::{borrow::Cow, ops::Deref, str::FromStr, sync::Arc};
 
-use bytes::Bytes;
-use chrono::Local;
+use aws_config::{BehaviorVersion, Region};
+use aws_sdk_s3::{
+    Client,
+    config::Credentials as AwsCredentials,
+    error::SdkError,
+    primitives::ByteStream,
+    types::{Delete, ObjectIdentifier},
+};
+use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
+use chrono::{DateTime, FixedOffset, Local};
 use futures::future::BoxFuture;
-use http::header::ToStrError;
 use mime::Mime;
 use nr_core::storage::{FileHashes, SerdeMime, StoragePath};
 use regions::{CustomRegion, S3StorageRegion};
 
 pub mod regions;
 use serde::{Deserialize, Serialize};
-use tracing::{debug, error, info, instrument, warn};
-use tux_io_s3::{
-    InvalidResponseHeader, S3Error,
-    client::{BucketClient, S3ClientBuilder},
-    command::{
-        delete::DeleteObject,
-        list::ListObjectsV2,
-        put::{PutHeaders, PutObject},
-    },
-    types::{
-        credentials::Credentials, list::v2::ListBucketResult, region::S3Region, tag::OwnedTag,
-    },
-};
+use tracing::{debug, info, instrument, warn};
 use utoipa::ToSchema;
 pub mod tags;
 use uuid::Uuid;
+
+use crate::{
+    BorrowedStorageConfig, BorrowedStorageTypeConfig, DirectoryFileType, DynStorage, FileContent,
+    FileContentBytes, FileFileType, FileType, InvalidConfigType, LocationMeta, PathCollisionError,
+    StaticStorageFactory, Storage, StorageConfig, StorageConfigInner, StorageError, StorageFactory,
+    StorageFile, StorageFileMeta, StorageTypeConfig, StorageTypeConfigTrait,
+    fs::NITRO_REPO_META_EXTENSION, meta::RepositoryMeta, streaming::VecDirectoryListStream,
+    utils::new_type_arc_type,
+};
+
+/// Content type S3 tooling conventionally uses to mark a key as a directory.
+const DIRECTORY_CONTENT_TYPE: &str = "application/x-directory";
+/// Suffix of the sidecar object holding an object's [LocationMeta].
+const META_SUFFIX: &str = ".nr-meta";
+/// `DeleteObjects` accepts at most this many keys per call.
+const DELETE_BATCH_SIZE: usize = 1000;
+
 #[derive(Debug, thiserror::Error)]
 pub enum S3StorageError {
     #[error("No Region Provided")]
     NoRegionSpecified,
-    #[error("S3 Error: {0}")]
-    S3Error(#[from] tux_io_s3::S3Error),
-    #[error("S3 Client Builder Error: {0}")]
-    S3ClientBuilderError(#[from] tux_io_s3::client::BuilderError),
-    #[error(transparent)]
-    InvalidResponseHeader(#[from] InvalidResponseHeader),
-
-    #[error("ToStrError: {0}")]
-    ToStrError(#[from] ToStrError),
+    #[error("S3 storage is missing its {0}")]
+    MissingCredential(&'static str),
     #[error("Bucket Does Not Exist {0}")]
     BucketDoesNotExist(String),
     #[error("IO Error: {0}")]
     IOError(#[from] std::io::Error),
     #[error(transparent)]
     InvalidConfigType(#[from] InvalidConfigType),
-    #[error("Unexpected Status Code: Expected {expected}, Got {got}")]
-    UnexpectedStatusCode { expected: u16, got: u16 },
-
     #[error("Missing Tag: {0}")]
     MissingTag(Cow<'static, str>),
-
-    #[error("S3 storage is missing its {0}")]
-    MissingCredential(&'static str),
-
     #[error(transparent)]
     PathCollision(#[from] PathCollisionError),
+    #[error("Could not decode stored metadata: {0}")]
+    Meta(#[from] postcard::Error),
+    #[error("S3 error: {0}")]
+    S3(String),
 }
+
 impl S3StorageError {
     pub fn static_missing_tag(tag: &'static str) -> Self {
         S3StorageError::MissingTag(tag.into())
     }
 }
-use crate::{
-    BorrowedStorageConfig, BorrowedStorageTypeConfig, DirectoryFileType, DynStorage, FileContent,
-    FileContentBytes, FileFileType, FileType, InvalidConfigType, PathCollisionError,
-    StaticStorageFactory, Storage, StorageConfig, StorageConfigInner, StorageError, StorageFactory,
-    StorageFile, StorageFileMeta, StorageTypeConfig, StorageTypeConfigTrait, meta::RepositoryMeta,
-    streaming::VecDirectoryListStream, utils::new_type_arc_type,
-};
+
+/// The SDK's error type is generic over the operation, so each call site would otherwise need its
+/// own `From`. Collapsing to the rendered message keeps one variant while preserving the source
+/// chain the SDK builds up (which is where the useful detail lives).
+impl<E, R> From<SdkError<E, R>> for S3StorageError
+where
+    E: std::error::Error + 'static,
+    R: std::fmt::Debug,
+{
+    fn from(value: SdkError<E, R>) -> Self {
+        let mut message = value.to_string();
+        let mut source = std::error::Error::source(&value);
+        while let Some(cause) = source {
+            message.push_str(": ");
+            message.push_str(&cause.to_string());
+            source = cause.source();
+        }
+        S3StorageError::S3(message)
+    }
+}
+impl From<aws_smithy_types::byte_stream::error::Error> for S3StorageError {
+    fn from(value: aws_smithy_types::byte_stream::error::Error) -> Self {
+        S3StorageError::S3(value.to_string())
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct S3Credentials {
     pub access_key: Option<String>,
@@ -83,10 +126,17 @@ impl S3Credentials {
             secret_key: Some(secret_key.into()),
         }
     }
-    /// The keys are optional in the config, so a storage can be saved without them. Reject that
-    /// here rather than unwrapping — this runs while loading storages at boot and on every config
-    /// test, and a panic there takes the whole server down.
-    pub fn credentials(&self) -> Result<Credentials, S3StorageError> {
+    /// Whether any key material was configured at all.
+    ///
+    /// Neither key set means "use the environment", which is the supported way to run against an
+    /// IAM role. One key set without the other is a misconfiguration, not a request for that.
+    pub fn is_empty(&self) -> bool {
+        self.access_key.is_none() && self.secret_key.is_none()
+    }
+    pub fn credentials(&self) -> Result<Option<AwsCredentials>, S3StorageError> {
+        if self.is_empty() {
+            return Ok(None);
+        }
         let access_key = self
             .access_key
             .clone()
@@ -95,10 +145,13 @@ impl S3Credentials {
             .secret_key
             .clone()
             .ok_or(S3StorageError::MissingCredential("secret key"))?;
-        Ok(Credentials {
+        Ok(Some(AwsCredentials::new(
             access_key,
             secret_key,
-        })
+            None,
+            None,
+            "nitro-repo-storage-config",
+        )))
     }
 }
 
@@ -118,64 +171,154 @@ fn default_true() -> bool {
     true
 }
 impl S3Config {
-    pub fn region(&self) -> Result<S3Region, S3StorageError> {
+    pub fn region(&self) -> Result<Region, S3StorageError> {
         if let Some(custom) = &self.custom_region {
             if self.region.is_some() {
                 warn!("Region set with custom region, custom region will take precedence");
             }
-            return Ok(S3Region::Custom(custom.clone().into()));
+            return Ok(custom.region());
         }
-        if let Some(region) = &self.region {
-            return Ok(S3Region::Official((*region).into()));
+        if let Some(region) = self.region {
+            return Ok(region.into());
         }
         Err(S3StorageError::NoRegionSpecified)
     }
 }
-#[derive(Debug, Clone)]
-pub struct S3MetaTags {
-    pub name: String,
-    pub mime_type: Option<Mime>,
-    pub is_directory: bool,
-}
+
 #[derive(Debug)]
 pub struct S3StorageInner {
     pub config: S3Config,
     pub storage_config: StorageConfigInner,
-    pub bucket: BucketClient,
+    pub client: Client,
 }
+
 impl S3StorageInner {
-    pub async fn load_bucket(config: &S3Config) -> Result<BucketClient, S3StorageError> {
-        let credentials = config.credentials.credentials()?;
+    #[instrument(skip(config), fields(bucket = %config.bucket_name))]
+    pub async fn build_client(config: &S3Config) -> Result<Client, S3StorageError> {
         let region = config.region()?;
         debug!(?region, "Connecting to S3 Bucket");
-        let access_type = if config.path_style {
-            tux_io_s3::client::AccessType::PathStyle
-        } else {
-            tux_io_s3::client::AccessType::VirtualHostedStyle
-        };
-        let builder = S3ClientBuilder::default()
-            .with_region(region)
-            .with_credentials(Arc::new(credentials.into()))
-            .with_access_type(access_type)
-            .bucket_client(config.bucket_name.clone())?;
 
-        Ok(builder)
+        let mut loader = aws_config::defaults(BehaviorVersion::latest()).region(region);
+        if let Some(credentials) = config.credentials.credentials()? {
+            loader = loader.credentials_provider(credentials);
+        } else {
+            debug!("No credentials configured; using the default AWS provider chain");
+        }
+        let shared_config = loader.load().await;
+
+        let mut builder = aws_sdk_s3::config::Builder::from(&shared_config);
+        if let Some(custom) = &config.custom_region {
+            // A self-hosted endpoint (MinIO, Ceph, Garage) almost always needs path-style
+            // addressing, because `bucket.localhost` does not resolve.
+            builder = builder.endpoint_url(custom.endpoint.to_string());
+        }
+        builder = builder.force_path_style(config.path_style);
+
+        Ok(Client::from_conf(builder.build()))
     }
+
+    /// Confirms the bucket exists and is reachable with the configured credentials.
+    #[instrument(skip(self))]
+    pub async fn check_bucket(&self) -> Result<(), S3StorageError> {
+        match self
+            .client
+            .head_bucket()
+            .bucket(&self.config.bucket_name)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) if is_not_found(&err) => Err(S3StorageError::BucketDoesNotExist(
+                self.config.bucket_name.clone(),
+            )),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    /// The object key an artifact lives at.
     pub fn s3_path(&self, repository: &Uuid, path: &StoragePath) -> String {
-        format!("{}/{}", repository, path)
+        format!("{}/{}", repository, path.to_string().trim_end_matches('/'))
     }
-    pub async fn get_path_for_creation(
+    /// The prefix a directory's children live under. Always ends in `/`.
+    fn directory_prefix(&self, repository: &Uuid, path: &StoragePath) -> String {
+        let path = path.to_string();
+        let path = path.trim_matches('/');
+        if path.is_empty() {
+            format!("{}/", repository)
+        } else {
+            format!("{}/{}/", repository, path)
+        }
+    }
+    /// The sidecar key holding the metadata for `key`.
+    fn meta_key(key: &str) -> String {
+        format!("{}{}", key, META_SUFFIX)
+    }
+    /// Whether a key is one of our own bookkeeping objects rather than a stored artifact.
+    fn is_hidden_key(key: &str) -> bool {
+        key.ends_with(META_SUFFIX) || key.ends_with(NITRO_REPO_META_EXTENSION)
+    }
+
+    async fn head(
+        &self,
+        key: &str,
+    ) -> Result<Option<aws_sdk_s3::operation::head_object::HeadObjectOutput>, S3StorageError> {
+        match self
+            .client
+            .head_object()
+            .bucket(&self.config.bucket_name)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(output) => Ok(Some(output)),
+            Err(err) if is_not_found(&err) => Ok(None),
+            Err(err) => Err(err.into()),
+        }
+    }
+
+    #[instrument(skip(self))]
+    async fn does_path_exist(&self, key: &str) -> Result<bool, S3StorageError> {
+        Ok(self.head(key).await?.is_some())
+    }
+
+    /// Whether anything is stored under this key's prefix, which is what makes it a directory.
+    #[instrument(skip(self))]
+    async fn is_directory(&self, prefix: &str) -> Result<bool, S3StorageError> {
+        let listing = self
+            .client
+            .list_objects_v2()
+            .bucket(&self.config.bucket_name)
+            .prefix(prefix)
+            .max_keys(1)
+            .send()
+            .await?;
+        Ok(listing.key_count().unwrap_or_default() > 0)
+    }
+
+    /// Rejects writing under a path whose ancestor is already a file.
+    ///
+    /// `/a/b` being a file makes `/a/b/c` impossible on a real filesystem, and the local backends
+    /// enforce that. S3 would happily store both, so enforce it here too — otherwise the same
+    /// repository behaves differently depending on where it is stored.
+    async fn check_for_collisions(
         &self,
         repository: Uuid,
         location: &StoragePath,
-    ) -> Result<String, S3StorageError> {
-        let mut path = repository.to_string();
+    ) -> Result<(), S3StorageError> {
+        let mut key = repository.to_string();
         let mut conflicting_path = StoragePath::default();
-        for part in location.clone().into_iter() {
-            path.push('/');
-            path.push_str(part.as_ref());
-            conflicting_path.push_mut(part.as_ref());
-            if !self.is_directory(&path).await? {
+        let mut components = location.clone().into_iter().peekable();
+        while let Some(component) = components.next() {
+            key.push('/');
+            key.push_str(component.as_ref());
+            conflicting_path.push_mut(component.as_ref());
+            // The last component is the file being written; it is allowed to already exist.
+            if components.peek().is_none() {
+                break;
+            }
+            if let Some(head) = self.head(&key).await?
+                && head.content_type() != Some(DIRECTORY_CONTENT_TYPE)
+            {
                 return Err(PathCollisionError {
                     path: location.clone(),
                     conflicts_with: conflicting_path,
@@ -183,387 +326,675 @@ impl S3StorageInner {
                 .into());
             }
         }
-        Ok(path)
+        Ok(())
     }
-    #[instrument]
-    async fn does_path_exist(&self, path: &str) -> Result<bool, S3StorageError> {
-        Ok(self.bucket.head_object(path).await?.is_some())
-    }
-    #[instrument]
-    fn is_directory_from_result<'result>(
-        &self,
-        result: &'result ListBucketResult,
-        path: &str,
-    ) -> (bool, Option<&'result str>) {
-        let is_contents_empty = result.contents.as_ref().is_none_or(|c| c.is_empty());
-        if is_contents_empty && result.common_prefixes.is_none() {
-            return (true, None);
-        }
-        if path.ends_with("/") && !is_contents_empty {
-            return (true, None);
-        }
-        let path_with_slash = format!("{}/", path);
 
-        if let Some(common) = &result.common_prefixes
-            && let Some(directory) = common
-                .prefix
-                .iter()
-                .find(|prefix| *prefix == &path_with_slash)
+    /// Reads the metadata sidecar for an object, if one was written.
+    #[instrument(skip(self))]
+    async fn read_meta(&self, key: &str) -> Result<Option<LocationMeta>, S3StorageError> {
+        let meta_key = Self::meta_key(key);
+        let output = match self
+            .client
+            .get_object()
+            .bucket(&self.config.bucket_name)
+            .key(&meta_key)
+            .send()
+            .await
         {
-            return (true, Some(directory.as_str()));
-        }
-        (false, None)
-    }
-
-    #[instrument]
-    async fn is_directory(&self, path: &str) -> Result<bool, S3StorageError> {
-        let list = self
-            .bucket
-            .list_objects_v2(ListObjectsV2::<()> {
-                prefix: path.into(),
-                delimiter: Some("/".into()),
-                ..Default::default()
-            })
-            .await?;
-
-        Ok(self.is_directory_from_result(&list, path).0)
-    }
-
-    /// Returns None if the path is not a directory
-    #[instrument]
-    async fn index_directory(&self, path: &str) -> Result<Option<StorageFile>, S3StorageError> {
-        let path = if !path.ends_with("/") {
-            format!("{}/", path)
-        } else {
-            path.to_owned()
+            Ok(output) => output,
+            Err(err) if is_not_found(&err) => return Ok(None),
+            Err(err) => return Err(err.into()),
         };
-
-        let first = self
-            .bucket
-            .list_objects_v2(ListObjectsV2::<()> {
-                prefix: Cow::Borrowed(&path),
-                delimiter: Some("/".into()),
-                ..Default::default()
-            })
-            .await?;
-
-        let mut files = Vec::new();
-        for file in first.contents.unwrap_or_default() {
-            let meta = self.get_meta(&file.key).await?;
-            if let Some(meta) = meta {
-                files.push(meta);
+        let bytes = output.body.collect().await?.into_bytes();
+        match LocationMeta::from_postcard(&bytes) {
+            Ok(meta) => Ok(Some(meta)),
+            Err(err) => {
+                // Same call as the local backend's: a sidecar we cannot read is treated as absent
+                // and rebuilt, rather than making the artifact itself unreadable.
+                warn!(?err, ?meta_key, "Metadata sidecar is unreadable; ignoring");
+                Ok(None)
             }
         }
-        if let Some(common_prefixes) = first.common_prefixes {
-            for sub_directory in common_prefixes.prefix {
-                let meta = self.get_directory_meta(&sub_directory).await?;
-                if let Some(meta) = meta {
-                    files.push(meta);
+    }
+
+    #[instrument(skip(self, meta))]
+    async fn write_meta(&self, key: &str, meta: &LocationMeta) -> Result<(), S3StorageError> {
+        let encoded = meta.to_postcard()?;
+        self.client
+            .put_object()
+            .bucket(&self.config.bucket_name)
+            .key(Self::meta_key(key))
+            .content_type(mime::APPLICATION_OCTET_STREAM.as_ref())
+            .body(ByteStream::from(encoded))
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    /// Lists one directory level, returning its files and sub-directories.
+    ///
+    /// Paginated: a repository can hold far more than one `ListObjectsV2` page, and the previous
+    /// implementation silently returned only the first.
+    #[instrument(skip(self))]
+    async fn list_directory(
+        &self,
+        prefix: &str,
+    ) -> Result<Vec<StorageFileMeta<FileType>>, S3StorageError> {
+        let mut files = Vec::new();
+        let mut continuation: Option<String> = None;
+
+        loop {
+            let mut request = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.config.bucket_name)
+                .prefix(prefix)
+                .delimiter("/");
+            if let Some(token) = &continuation {
+                request = request.continuation_token(token);
+            }
+            let listing = request.send().await?;
+
+            for object in listing.contents() {
+                let Some(key) = object.key() else {
+                    continue;
+                };
+                // The marker object for the directory being listed shows up in its own listing.
+                if key == prefix || Self::is_hidden_key(key) {
+                    continue;
+                }
+                let name = key.trim_start_matches(prefix).trim_end_matches('/');
+                if name.is_empty() {
+                    continue;
+                }
+                let meta = self.read_meta(key).await?;
+                let modified = object
+                    .last_modified()
+                    .and_then(to_chrono)
+                    .or_else(|| meta.as_ref().map(|m| m.modified))
+                    .unwrap_or_else(|| Local::now().fixed_offset());
+                let created = meta.as_ref().map(|m| m.created).unwrap_or(modified);
+                files.push(StorageFileMeta {
+                    name: name.to_owned(),
+                    file_type: FileType::File(FileFileType {
+                        file_size: object.size().unwrap_or_default() as u64,
+                        mime_type: mime_for_name(name),
+                        file_hash: meta.map(|m| m.hashes()).unwrap_or_default(),
+                    }),
+                    modified,
+                    created,
+                });
+            }
+
+            for sub_directory in listing.common_prefixes() {
+                let Some(sub_prefix) = sub_directory.prefix() else {
+                    continue;
+                };
+                let name = sub_prefix.trim_start_matches(prefix).trim_end_matches('/');
+                if name.is_empty() {
+                    continue;
+                }
+                let meta = self.read_meta(sub_prefix.trim_end_matches('/')).await?;
+                let modified = meta
+                    .as_ref()
+                    .map(|m| m.modified)
+                    .unwrap_or_else(|| Local::now().fixed_offset());
+                files.push(StorageFileMeta {
+                    name: name.to_owned(),
+                    file_type: FileType::Directory(DirectoryFileType {
+                        file_count: meta
+                            .as_ref()
+                            .and_then(|m| m.dir_meta_or_err().ok().map(|d| d.number_of_files))
+                            .unwrap_or_default(),
+                    }),
+                    modified,
+                    created: meta.map(|m| m.created).unwrap_or(modified),
+                });
+            }
+
+            if listing.is_truncated().unwrap_or_default() {
+                continuation = listing.next_continuation_token().map(str::to_owned);
+                if continuation.is_some() {
+                    continue;
                 }
             }
+            break;
         }
 
-        Ok(Some(StorageFile::Directory {
-            meta: StorageFileMeta {
-                name: path.to_owned(),
-                file_type: DirectoryFileType {
-                    file_count: files.len() as u64,
-                },
-                modified: Local::now().fixed_offset(),
-                created: Local::now().fixed_offset(),
-            },
-            files,
-        }))
-    }
-    async fn get_meta(
-        &self,
-        path: &str,
-    ) -> Result<Option<StorageFileMeta<FileType>>, S3StorageError> {
-        let file_file = FileType::File(FileFileType {
-            file_size: 0,
-            mime_type: None,
-            file_hash: FileHashes::default(),
-        });
-
-        let meta = StorageFileMeta {
-            name: path.to_owned(),
-            file_type: file_file,
-            modified: Local::now().fixed_offset(),
-            created: Local::now().fixed_offset(),
-        };
-
-        Ok(Some(meta))
-    }
-    async fn get_directory_meta(
-        &self,
-        path: &str,
-    ) -> Result<Option<StorageFileMeta<FileType>>, S3StorageError> {
-        let file_file = FileType::Directory(DirectoryFileType { file_count: 0 });
-
-        let meta = StorageFileMeta {
-            name: path.to_owned(),
-            file_type: file_file,
-            modified: Local::now().fixed_offset(),
-            created: Local::now().fixed_offset(),
-        };
-
-        Ok(Some(meta))
-    }
-    #[instrument]
-    async fn get_object_tagging(
-        &self,
-        path: &str,
-    ) -> Result<Option<Vec<OwnedTag>>, S3StorageError> {
-        let Some(tagging) = self.bucket.get_object_tagging(path).await? else {
-            return Ok(None);
-        };
-
-        Ok(Some(tagging.into()))
+        Ok(files)
     }
 
-    async fn get_meta_tags(&self, path: &str) -> Result<Option<S3MetaTags>, S3StorageError> {
-        let Some(tags) = self.get_object_tagging(path).await? else {
-            return Ok(None);
-        };
+    /// Deletes every object under a prefix, in `DeleteObjects` batches.
+    #[instrument(skip(self))]
+    async fn delete_prefix(&self, prefix: &str) -> Result<bool, S3StorageError> {
+        let mut deleted_anything = false;
+        let mut continuation: Option<String> = None;
 
-        let name = tags
-            .iter()
-            .find(|tag| tag.key == tags::NAME)
-            .map(|tag| tag.value.clone())
-            .ok_or_else(|| S3StorageError::static_missing_tag(tags::NAME))?;
-
-        let mime_type = tags
-            .iter()
-            .find(|tag| tag.key == tags::MIME_TYPE)
-            .map(|tag| Mime::from_str(&tag.value))
-            .transpose();
-        let mime_type = match mime_type {
-            Ok(ok) => ok,
-            Err(e) => {
-                error!(?e, ?path, "Failed to parse mime type");
-                None
+        loop {
+            let mut request = self
+                .client
+                .list_objects_v2()
+                .bucket(&self.config.bucket_name)
+                .prefix(prefix)
+                .max_keys(DELETE_BATCH_SIZE as i32);
+            if let Some(token) = &continuation {
+                request = request.continuation_token(token);
             }
-        };
+            let listing = request.send().await?;
 
-        Ok(Some(S3MetaTags {
-            name,
-            mime_type,
-            is_directory: false,
-        }))
+            let keys: Vec<ObjectIdentifier> = listing
+                .contents()
+                .iter()
+                .filter_map(|object| object.key())
+                .map(|key| ObjectIdentifier::builder().key(key).build())
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|err| S3StorageError::S3(err.to_string()))?;
+
+            if !keys.is_empty() {
+                deleted_anything = true;
+                let delete = Delete::builder()
+                    .set_objects(Some(keys))
+                    .quiet(true)
+                    .build()
+                    .map_err(|err| S3StorageError::S3(err.to_string()))?;
+                self.client
+                    .delete_objects()
+                    .bucket(&self.config.bucket_name)
+                    .delete(delete)
+                    .send()
+                    .await?;
+            }
+
+            // Deleting as we go invalidates the continuation token, so re-list from the start
+            // until a pass finds nothing left.
+            if listing.is_truncated().unwrap_or_default() {
+                continuation = None;
+                continue;
+            }
+            break;
+        }
+
+        Ok(deleted_anything)
+    }
+
+    /// Writes an empty directory marker object for a prefix, if one is not already there.
+    async fn ensure_directory_marker(&self, prefix: &str) -> Result<(), S3StorageError> {
+        if self.does_path_exist(prefix).await? {
+            return Ok(());
+        }
+        self.client
+            .put_object()
+            .bucket(&self.config.bucket_name)
+            .key(prefix)
+            .content_type(DIRECTORY_CONTENT_TYPE)
+            .body(ByteStream::from_static(b""))
+            .send()
+            .await?;
+        Ok(())
+    }
+
+    /// Refreshes bookkeeping for the directory a write or delete just changed.
+    ///
+    /// Only the immediate parent gets its entry count recounted. Ancestors get a marker object if
+    /// they are missing one, but are not re-listed: counting every ancestor on every upload would
+    /// make a Maven deploy cost O(depth x objects) in `ListObjectsV2` calls. Readers
+    /// ([Storage::get_file_information], [Storage::stream_directory]) count from a live listing
+    /// anyway, so the stored count only backs the entry-count shown for a *sub*-directory in a
+    /// listing, where being slightly stale is acceptable.
+    async fn update_directory_metadata(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<(), S3StorageError> {
+        let now = Local::now().fixed_offset();
+        let mut directory = location.clone().parent();
+
+        let prefix = self.directory_prefix(&repository, &directory);
+        let key = prefix.trim_end_matches('/').to_owned();
+        let entries = self.list_directory(&prefix).await?;
+        let created = self
+            .read_meta(&key)
+            .await?
+            .map(|existing| existing.created)
+            .unwrap_or(now);
+        self.ensure_directory_marker(&prefix).await?;
+        self.write_meta(
+            &key,
+            &LocationMeta::for_directory(created, now, entries.len() as u64),
+        )
+        .await?;
+
+        while directory.number_of_components() > 0 {
+            directory = directory.parent();
+            let prefix = self.directory_prefix(&repository, &directory);
+            self.ensure_directory_marker(&prefix).await?;
+        }
+        Ok(())
     }
 }
+
+/// The SDK models "no such key" per operation (`HeadObjectError` has no `NoSuchKey` variant at
+/// all, it just 404s), so go by the HTTP status instead of matching each operation's error enum.
+fn is_not_found<E>(err: &SdkError<E, HttpResponse>) -> bool {
+    match err {
+        SdkError::ServiceError(service_error) => service_error.raw().status().as_u16() == 404,
+        _ => false,
+    }
+}
+
+fn to_chrono(timestamp: &aws_smithy_types::DateTime) -> Option<DateTime<FixedOffset>> {
+    DateTime::from_timestamp(timestamp.secs(), timestamp.subsec_nanos())
+        .map(|value| value.fixed_offset())
+}
+
+fn mime_for_name(name: &str) -> Option<SerdeMime> {
+    mime_guess::from_path(name).first().map(SerdeMime)
+}
+
 #[derive(Debug, Clone)]
 pub struct S3Storage(Arc<S3StorageInner>);
 new_type_arc_type!(S3Storage(S3StorageInner));
+
 impl Storage for S3Storage {
     type Error = S3StorageError;
     type DirectoryStream = VecDirectoryListStream;
+
     fn storage_type_name(&self) -> &'static str {
-        "s3"
+        S3StorageFactory::STORAGE_TYPE_NAME
     }
-    #[instrument(name = "Storage::unload", fields(storage_type = "s3"))]
+
+    #[instrument(name = "Storage::unload", skip(self), fields(storage_type = "S3"))]
     async fn unload(&self) -> Result<(), S3StorageError> {
         info!("Unloading S3 Storage");
         Ok(())
     }
-    #[instrument(fields(storage_type = "s3"))]
+
     fn storage_config(&self) -> BorrowedStorageConfig<'_> {
         BorrowedStorageConfig {
             storage_config: &self.storage_config,
             config: BorrowedStorageTypeConfig::S3(&self.config),
         }
     }
-    #[instrument(name = "Storage::save_file", fields(storage_type = "s3"))]
+
+    #[instrument(
+        name = "Storage::save_file",
+        skip(self, file),
+        fields(storage_type = "S3")
+    )]
     async fn save_file(
         &self,
-        repository: uuid::Uuid,
+        repository: Uuid,
         file: FileContent,
         location: &StoragePath,
     ) -> Result<(usize, bool), S3StorageError> {
-        let path = self.get_path_for_creation(repository, location).await?;
-        let already_exists = self.does_path_exist(&path).await?;
+        self.check_for_collisions(repository, location).await?;
+
+        let key = self.s3_path(&repository, location);
+        let existing = self.head(&key).await?;
+        let already_exists = existing.is_some();
         if already_exists {
             debug!("File already exists, overwriting");
         }
+
+        let hashes = file.generate_hashes()?;
+        let bytes: FileContentBytes = file.try_into()?;
+        let size = bytes.len();
         let content_type = if location.is_directory() {
-            "application/x-directory"
+            DIRECTORY_CONTENT_TYPE.to_owned()
         } else {
-            "application/octet-stream"
+            mime_for_name(&key)
+                .map(|mime| mime.0.to_string())
+                .unwrap_or_else(|| mime::APPLICATION_OCTET_STREAM.to_string())
         };
-        let file_as_bytes: FileContentBytes = file.try_into()?;
-        let size = file_as_bytes.len();
-        let put_objec = PutObject {
-            key: &path,
-            content: file_as_bytes.into(),
-            headers: PutHeaders {
-                content_type: content_type.into(),
-                metadata: Default::default(),
-                ..Default::default()
-            },
-            tags: None,
-        };
-        let response_data = self.bucket.execute_command(put_objec).await?;
-        debug!(?response_data, "File Saved");
-        // TODO: Check if the file was created
+
+        self.client
+            .put_object()
+            .bucket(&self.config.bucket_name)
+            .key(&key)
+            .content_type(content_type)
+            .body(ByteStream::from(bytes::Bytes::from(bytes)))
+            .send()
+            .await?;
+
+        let now = Local::now().fixed_offset();
+        // Preserve the original creation time across an overwrite, and any repository metadata
+        // already attached to the path — Maven stamps project ids onto it.
+        let previous = self.read_meta(&key).await?;
+        let created = previous.as_ref().map(|meta| meta.created).unwrap_or(now);
+        let mut meta = LocationMeta::for_file(created, now, hashes);
+        if let Some(previous) = previous {
+            meta.repository_meta = previous.repository_meta;
+        }
+        self.write_meta(&key, &meta).await?;
+
+        self.update_directory_metadata(repository, location).await?;
+
         Ok((size, !already_exists))
     }
-    #[instrument(name = "Storage::put_repository_meta", fields(storage_type = "s3"))]
+
+    #[instrument(
+        name = "Storage::put_repository_meta",
+        skip(self),
+        fields(storage_type = "S3")
+    )]
     async fn put_repository_meta(
         &self,
-        repository: uuid::Uuid,
+        repository: Uuid,
         location: &StoragePath,
         value: RepositoryMeta,
     ) -> Result<(), S3StorageError> {
-        todo!()
+        let key = self.s3_path(&repository, location);
+        let now = Local::now().fixed_offset();
+        let mut meta = match self.read_meta(&key).await? {
+            Some(meta) => meta,
+            None => {
+                // The path may be a directory that only exists as a prefix, so fall back to
+                // directory-shaped metadata rather than refusing to record anything.
+                let prefix = self.directory_prefix(&repository, location);
+                if self.is_directory(&prefix).await? {
+                    LocationMeta::for_directory(now, now, 0)
+                } else {
+                    LocationMeta::for_file(now, now, FileHashes::default())
+                }
+            }
+        };
+        meta.repository_meta = value;
+        meta.modified = now;
+        self.write_meta(&key, &meta).await
     }
-    #[instrument(name = "Storage::get_repository_meta", fields(storage_type = "s3"))]
+
+    #[instrument(
+        name = "Storage::get_repository_meta",
+        skip(self),
+        fields(storage_type = "S3")
+    )]
     async fn get_repository_meta(
         &self,
-        repository: uuid::Uuid,
+        repository: Uuid,
         location: &StoragePath,
     ) -> Result<Option<RepositoryMeta>, S3StorageError> {
-        todo!()
+        let key = self.s3_path(&repository, location);
+        Ok(self.read_meta(&key).await?.map(|meta| meta.repository_meta))
     }
-    #[instrument(name = "Storage::delete_file", fields(storage_type = "s3"))]
+
+    #[instrument(name = "Storage::delete_file", skip(self), fields(storage_type = "S3"))]
     async fn delete_file(
         &self,
-        repository: uuid::Uuid,
+        repository: Uuid,
         location: &StoragePath,
     ) -> Result<bool, S3StorageError> {
-        let path = self.s3_path(&repository, location);
-        let exists = self.does_path_exist(&path).await?;
-        if !exists {
+        let key = self.s3_path(&repository, location);
+        let prefix = self.directory_prefix(&repository, location);
+
+        // A directory has to take its children and their sidecars with it, or the bucket keeps
+        // serving files under a path that no longer exists.
+        if self.is_directory(&prefix).await? {
+            let deleted = self.delete_prefix(&prefix).await?;
+            self.delete_prefix(&S3StorageInner::meta_key(&key)).await?;
+            self.update_directory_metadata(repository, location).await?;
+            return Ok(deleted);
+        }
+
+        if !self.does_path_exist(&key).await? {
             return Ok(false);
         }
-        let delete_object = DeleteObject {
-            key: &path,
-            version_id: None,
-        };
-        let response_data = self.bucket.execute_command(delete_object).await?;
-        if response_data.status() != 204 {
-            return Err(S3StorageError::UnexpectedStatusCode {
-                expected: 204,
-                got: response_data.status().as_u16(),
-            });
-        }
+        self.client
+            .delete_object()
+            .bucket(&self.config.bucket_name)
+            .key(&key)
+            .send()
+            .await?;
+        self.client
+            .delete_object()
+            .bucket(&self.config.bucket_name)
+            .key(S3StorageInner::meta_key(&key))
+            .send()
+            .await?;
+        self.update_directory_metadata(repository, location).await?;
         Ok(true)
     }
-    #[instrument(name = "Storage::get_file_information", fields(storage_type = "s3"))]
+
+    #[instrument(
+        name = "Storage::get_file_information",
+        skip(self),
+        fields(storage_type = "S3")
+    )]
     async fn get_file_information(
         &self,
-        repository: uuid::Uuid,
+        repository: Uuid,
         location: &StoragePath,
-    ) -> Result<Option<crate::StorageFileMeta<FileType>>, S3StorageError> {
-        todo!()
+    ) -> Result<Option<StorageFileMeta<FileType>>, S3StorageError> {
+        let key = self.s3_path(&repository, location);
+        let name = location
+            .clone()
+            .into_iter()
+            .next_back()
+            .map(|component| component.to_string())
+            .unwrap_or_default();
+        let stored_meta = self.read_meta(&key).await?;
+
+        if let Some(head) = self.head(&key).await?
+            && head.content_type() != Some(DIRECTORY_CONTENT_TYPE)
+        {
+            let modified = head
+                .last_modified()
+                .and_then(to_chrono)
+                .or_else(|| stored_meta.as_ref().map(|meta| meta.modified))
+                .unwrap_or_else(|| Local::now().fixed_offset());
+            return Ok(Some(StorageFileMeta {
+                name,
+                file_type: FileType::File(FileFileType {
+                    file_size: head.content_length().unwrap_or_default() as u64,
+                    mime_type: head
+                        .content_type()
+                        .and_then(|value| match Mime::from_str(value) {
+                            Ok(mime) => Some(SerdeMime(mime)),
+                            Err(err) => {
+                                warn!(
+                                    ?err,
+                                    content_type = value,
+                                    "Ignoring unparsable content type"
+                                );
+                                None
+                            }
+                        })
+                        .or_else(|| mime_for_name(&key)),
+                    file_hash: stored_meta
+                        .as_ref()
+                        .map(|meta| meta.hashes())
+                        .unwrap_or_default(),
+                }),
+                modified,
+                created: stored_meta.map(|meta| meta.created).unwrap_or(modified),
+            }));
+        }
+
+        let prefix = self.directory_prefix(&repository, location);
+        if !self.is_directory(&prefix).await? {
+            return Ok(None);
+        }
+        let entries = self.list_directory(&prefix).await?;
+        let modified = stored_meta
+            .as_ref()
+            .map(|meta| meta.modified)
+            .unwrap_or_else(|| Local::now().fixed_offset());
+        Ok(Some(StorageFileMeta {
+            name,
+            file_type: FileType::Directory(DirectoryFileType {
+                file_count: entries.len() as u64,
+            }),
+            modified,
+            created: stored_meta.map(|meta| meta.created).unwrap_or(modified),
+        }))
     }
-    #[instrument(name = "Storage::open_file", fields(storage_type = "s3"))]
+
+    #[instrument(name = "Storage::open_file", skip(self), fields(storage_type = "S3"))]
     async fn open_file(
         &self,
-        repository: uuid::Uuid,
+        repository: Uuid,
         location: &StoragePath,
-    ) -> Result<Option<crate::StorageFile>, S3StorageError> {
-        let path = self.s3_path(&repository, location);
-        let Some(get) = self.bucket.get_object(&path).await? else {
+    ) -> Result<Option<StorageFile>, S3StorageError> {
+        let Some(meta) = self.get_file_information(repository, location).await? else {
             return Ok(None);
         };
-        let headers = get.headers();
-        if let Some(content_type) = headers.get("content-type")
-            && content_type == "application/x-directory"
-        {
-            return self.index_directory(&path).await;
-        }
-        let meta = StorageFileMeta::<FileFileType> {
-            name: location.to_string(),
-            file_type: FileFileType {
-                file_size: get.content_length()?.unwrap_or_default(),
-                // A bucket can hold objects put there by anything, so a malformed `Content-Type`
-                // is a property of the data, not a bug. Report the file without a mime type
-                // rather than panicking on it.
-                mime_type: get
-                    .content_type()?
-                    .and_then(|ct| match Mime::from_str(ct.as_str()) {
-                        Ok(mime) => Some(SerdeMime(mime)),
-                        Err(err) => {
-                            warn!(?err, content_type = ?ct, ?path, "Ignoring unparsable content type");
-                            None
-                        }
-                    }),
-                file_hash: FileHashes::default(),
-            },
-            modified: Local::now().fixed_offset(),
-            created: Local::now().fixed_offset(),
-        };
-        let body: Bytes = get.0.bytes().await.map_err(S3Error::from)?;
-        let result = StorageFile::File {
-            meta,
-            content: crate::StorageFileReader::from(FileContentBytes::Bytes(body)),
-        };
 
-        Ok(Some(result))
+        match meta.file_type {
+            FileType::Directory(file_type) => {
+                let prefix = self.directory_prefix(&repository, location);
+                let files = self.list_directory(&prefix).await?;
+                Ok(Some(StorageFile::Directory {
+                    meta: StorageFileMeta {
+                        name: meta.name,
+                        file_type,
+                        modified: meta.modified,
+                        created: meta.created,
+                    },
+                    files,
+                }))
+            }
+            FileType::File(file_type) => {
+                let key = self.s3_path(&repository, location);
+                let output = match self
+                    .client
+                    .get_object()
+                    .bucket(&self.config.bucket_name)
+                    .key(&key)
+                    .send()
+                    .await
+                {
+                    Ok(output) => output,
+                    Err(err) if is_not_found(&err) => return Ok(None),
+                    Err(err) => return Err(err.into()),
+                };
+                // Streamed rather than buffered: an artifact can be far larger than we want to
+                // hold in memory, and the response body is happy to pull from the socket.
+                let reader =
+                    crate::StorageFileReader::AsyncReader(Box::pin(output.body.into_async_read()));
+                Ok(Some(StorageFile::File {
+                    meta: StorageFileMeta {
+                        name: meta.name,
+                        file_type,
+                        modified: meta.modified,
+                        created: meta.created,
+                    },
+                    content: reader,
+                }))
+            }
+        }
     }
-    #[instrument(name = "Storage::validate_config_change", fields(storage_type = "s3"))]
+
+    #[instrument(
+        name = "Storage::validate_config_change",
+        skip(self),
+        fields(storage_type = "S3")
+    )]
     async fn validate_config_change(
         &self,
         config: StorageTypeConfig,
     ) -> Result<(), S3StorageError> {
-        let s3_config = S3Config::from_type_config(config)?;
-        let bucket = S3StorageInner::load_bucket(&s3_config).await?;
-        info!(?bucket, "Successfully connected to S3 Bucket");
-        Ok(())
-    }
-    #[instrument(name = "Storage::file_exists", fields(storage_type = "s3"))]
-    async fn file_exists(
-        &self,
-        repository: uuid::Uuid,
-        location: &StoragePath,
-    ) -> Result<bool, S3StorageError> {
-        let path = self.s3_path(&repository, location);
-        self.does_path_exist(&path).await
+        S3StorageFactory::test_config(S3Config::from_type_config(config)?).await
     }
 
+    #[instrument(name = "Storage::file_exists", skip(self), fields(storage_type = "S3"))]
+    async fn file_exists(
+        &self,
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<bool, S3StorageError> {
+        let key = self.s3_path(&repository, location);
+        if self.does_path_exist(&key).await? {
+            return Ok(true);
+        }
+        let prefix = self.directory_prefix(&repository, location);
+        self.is_directory(&prefix).await
+    }
+
+    #[instrument(
+        name = "Storage::stream_directory",
+        skip(self),
+        fields(storage_type = "S3")
+    )]
     async fn stream_directory(
         &self,
-        _repository: Uuid,
-        _location: &StoragePath,
-    ) -> Result<Option<Self::DirectoryStream>, Self::Error> {
-        todo!()
+        repository: Uuid,
+        location: &StoragePath,
+    ) -> Result<Option<Self::DirectoryStream>, S3StorageError> {
+        let prefix = self.directory_prefix(&repository, location);
+        if !self.is_directory(&prefix).await? {
+            return Ok(None);
+        }
+        let files = self.list_directory(&prefix).await?;
+        let name = location
+            .clone()
+            .into_iter()
+            .next_back()
+            .map(|component| component.to_string())
+            .unwrap_or_default();
+        let now = Local::now().fixed_offset();
+        let stored_meta = self.read_meta(prefix.trim_end_matches('/')).await?;
+        let directory_meta = StorageFileMeta {
+            name,
+            file_type: DirectoryFileType {
+                file_count: files.len() as u64,
+            },
+            modified: stored_meta
+                .as_ref()
+                .map(|meta| meta.modified)
+                .unwrap_or(now),
+            created: stored_meta.map(|meta| meta.created).unwrap_or(now),
+        };
+        Ok(Some(VecDirectoryListStream::new(files, directory_meta)))
     }
 }
+
 #[derive(Debug, Default)]
 pub struct S3StorageFactory;
+
+impl S3StorageFactory {
+    pub const STORAGE_TYPE_NAME: &'static str = "S3";
+
+    async fn test_config(config: S3Config) -> Result<(), S3StorageError> {
+        let client = S3StorageInner::build_client(&config).await?;
+        let inner = S3StorageInner {
+            storage_config: StorageConfigInner::test_config(),
+            config,
+            client,
+        };
+        inner.check_bucket().await?;
+        info!(bucket = %inner.config.bucket_name, "Successfully connected to S3 Bucket");
+        Ok(())
+    }
+}
+
 impl StaticStorageFactory for S3StorageFactory {
     type StorageType = S3Storage;
     type ConfigType = S3Config;
     type Error = S3StorageError;
 
     fn storage_type_name() -> &'static str {
-        "s3"
+        Self::STORAGE_TYPE_NAME
     }
 
     async fn test_storage_config(config: StorageTypeConfig) -> Result<(), S3StorageError> {
-        let s3_config = S3Config::from_type_config(config)?;
-        let bucket = S3StorageInner::load_bucket(&s3_config).await?;
-        info!(?bucket, "Successfully connected to S3 Bucket");
-        Ok(())
+        Self::test_config(S3Config::from_type_config(config)?).await
     }
 
     async fn create_storage(
         inner: StorageConfigInner,
         type_config: Self::ConfigType,
     ) -> Result<Self::StorageType, S3StorageError> {
-        let bucket = S3StorageInner::load_bucket(&type_config).await?;
-        let inner = S3StorageInner {
+        let client = S3StorageInner::build_client(&type_config).await?;
+        Ok(S3Storage::from(S3StorageInner {
             config: type_config,
             storage_config: inner,
-            bucket,
-        };
-        let storage = S3Storage::from(inner);
-        Ok(storage)
+            client,
+        }))
     }
 }
+
 impl StorageFactory for S3StorageFactory {
     fn storage_name(&self) -> &'static str {
-        "s3"
+        Self::STORAGE_TYPE_NAME
     }
 
     fn test_storage_config(
@@ -571,11 +1002,7 @@ impl StorageFactory for S3StorageFactory {
         config: StorageTypeConfig,
     ) -> BoxFuture<'static, Result<(), StorageError>> {
         Box::pin(async move {
-            let s3_config = S3Config::from_type_config(config)?;
-
-            let bucket = S3StorageInner::load_bucket(&s3_config).await?;
-            info!(?bucket, "Successfully connected to S3 Bucket");
-
+            <Self as StaticStorageFactory>::test_storage_config(config).await?;
             Ok(())
         })
     }
@@ -585,19 +1012,13 @@ impl StorageFactory for S3StorageFactory {
         config: StorageConfig,
     ) -> BoxFuture<'static, Result<DynStorage, StorageError>> {
         Box::pin(async move {
-            let s3_config = S3Config::from_type_config(config.type_config)?;
-            let storage_config = config.storage_config;
-            let bucket = S3StorageInner::load_bucket(&s3_config).await?;
-            let inner = S3StorageInner {
-                config: s3_config,
-                storage_config,
-                bucket,
-            };
-            let storage = S3Storage::from(inner);
+            let storage =
+                <Self as StaticStorageFactory>::create_storage_from_config(config).await?;
             Ok(DynStorage::S3(storage))
         })
     }
 }
+
 #[cfg(test)]
 mod tests {
     use tracing::warn;
@@ -606,13 +1027,13 @@ mod tests {
 
     #[tokio::test]
     pub async fn generic_test() -> anyhow::Result<()> {
-        let Some(config) = crate::testing::start_storage_test("s3")? else {
+        let Some(config) = crate::testing::start_storage_test("S3").await? else {
             warn!("S3 Storage Test Skipped");
             return Ok(());
         };
-        let local_storage =
+        let storage =
             <S3StorageFactory as StaticStorageFactory>::create_storage_from_config(config).await?;
-        let testing_storage = TestingStorage::new(local_storage);
+        let testing_storage = TestingStorage::new(storage);
         crate::testing::tests::full_test(testing_storage).await?;
 
         Ok(())

--- a/crates/storage/src/s3/regions.rs
+++ b/crates/storage/src/s3/regions.rs
@@ -1,8 +1,13 @@
 use serde::{Deserialize, Serialize};
 use strum::EnumIter;
-use tux_io_s3::types::region::{CustomRegion as TuxIoCustomRegion, OfficialRegion};
 use url::Url;
 use utoipa::ToSchema;
+
+/// The AWS regions offered in the storage creation UI.
+///
+/// This is served by `GET /api/storage/s3/regions` and appears in the OpenAPI schema, so it stays
+/// an enum even though the SDK models a region as an opaque string — the list is what makes the
+/// dropdown possible. Anything not listed here can still be reached through [CustomRegion].
 
 #[derive(Clone, Debug, Eq, Copy, PartialEq, Serialize, Deserialize, ToSchema, EnumIter)]
 pub enum S3StorageRegion {
@@ -58,57 +63,68 @@ pub enum S3StorageRegion {
 macro_rules! into_region {
     (
         $(
-            $variant:ident => $region:ident
+            $variant:ident => $region:literal
         ),*
     ) => {
-        impl From<S3StorageRegion> for OfficialRegion{
-            fn from(value: S3StorageRegion) -> Self {
-                match value {
+        impl S3StorageRegion {
+            /// The AWS region code, as the SDK and the S3 API spell it.
+            pub const fn region_code(self) -> &'static str {
+                match self {
                     $(
-                        S3StorageRegion::$variant => OfficialRegion::$region,
+                        S3StorageRegion::$variant => $region,
                     )*
                 }
+            }
+        }
+        impl From<S3StorageRegion> for aws_config::Region {
+            fn from(value: S3StorageRegion) -> Self {
+                aws_config::Region::from_static(value.region_code())
             }
         }
     };
 }
 
 into_region!(
-    UsEast1 => UsEast1,
-    UsEast2 => UsEast2,
-    UsWest1 => UsWest1,
-    UsWest2 => UsWest2,
-    CaCentral1 => CaCentral1,
-    AfSouth1 => AfSouth1,
-    ApEast1 => ApEast1,
-    ApSouth1 => ApSouth1,
-    ApNortheast1 => ApNortheast1,
-    ApNortheast2 => ApNortheast2,
-    ApNortheast3 => ApNortheast3,
-    ApSoutheast1 => ApSoutheast1,
-    ApSoutheast2 => ApSoutheast2,
-    CnNorth1 => CnNorth1,
-    CnNorthwest1 => CnNorthwest1,
-    EuNorth1 => EuNorth1,
-    EuCentral1 => EuCentral1,
-    EuCentral2 => EuCentral2,
-    EuWest1 => EuWest1,
-    EuWest2 => EuWest2,
-    EuWest3 => EuWest3,
-    IlCentral1 => IlCentral1,
-    MeSouth1 => MeSouth1,
-    SaEast1 => SaEast1
+    UsEast1 => "us-east-1",
+    UsEast2 => "us-east-2",
+    UsWest1 => "us-west-1",
+    UsWest2 => "us-west-2",
+    CaCentral1 => "ca-central-1",
+    AfSouth1 => "af-south-1",
+    ApEast1 => "ap-east-1",
+    ApSouth1 => "ap-south-1",
+    ApNortheast1 => "ap-northeast-1",
+    ApNortheast2 => "ap-northeast-2",
+    ApNortheast3 => "ap-northeast-3",
+    ApSoutheast1 => "ap-southeast-1",
+    ApSoutheast2 => "ap-southeast-2",
+    CnNorth1 => "cn-north-1",
+    CnNorthwest1 => "cn-northwest-1",
+    EuNorth1 => "eu-north-1",
+    EuCentral1 => "eu-central-1",
+    EuCentral2 => "eu-central-2",
+    EuWest1 => "eu-west-1",
+    EuWest2 => "eu-west-2",
+    EuWest3 => "eu-west-3",
+    IlCentral1 => "il-central-1",
+    MeSouth1 => "me-south-1",
+    SaEast1 => "sa-east-1"
 );
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
 pub struct CustomRegion {
     pub custom_region: Option<String>,
     pub endpoint: Url,
 }
-impl From<CustomRegion> for TuxIoCustomRegion {
-    fn from(value: CustomRegion) -> Self {
-        TuxIoCustomRegion {
-            name: value.custom_region,
-            endpoint: value.endpoint,
+impl CustomRegion {
+    /// The region name to sign requests with.
+    ///
+    /// SigV4 always needs *some* region in the credential scope even when the endpoint is a
+    /// self-hosted MinIO that ignores it, so fall back to `us-east-1` when none was configured —
+    /// that is what S3-compatible servers conventionally accept.
+    pub fn region(&self) -> aws_config::Region {
+        match &self.custom_region {
+            Some(name) => aws_config::Region::new(name.clone()),
+            None => aws_config::Region::from_static("us-east-1"),
         }
     }
 }

--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -2,11 +2,12 @@ use std::{env::current_dir, path::PathBuf};
 
 use nr_core::testing::logging::TestingLoggerConfig;
 use serde::{Deserialize, Serialize};
-use tracing::info;
+use tracing::{info, warn};
 use uuid::Uuid;
 pub mod tests;
 use crate::{
     StaticStorageFactory, StorageConfig, StorageConfigInner, StorageTypeConfig,
+    fs_v2::{Compression, FileSystemV2Config, FileSystemV2Factory, FileSystemV2Storage},
     local::{LocalConfig, LocalStorage, LocalStorageFactory},
     s3::{S3Config, S3Credentials, S3StorageFactory, regions::CustomRegion},
 };
@@ -22,6 +23,7 @@ impl Default for TestingStorageConfig {
         let storage_test_configs = vec![
             LocalStorage::test_storage_config(),
             S3Config::test_storage_config(),
+            FileSystemV2Storage::test_storage_config(),
         ];
         Self {
             logging: TestingLoggerConfig::default(),
@@ -74,19 +76,84 @@ impl TestingStorageType for S3Config {
                 custom_region: Some("minio-instance".to_owned()),
                 endpoint: "http://localhost:9000".parse().unwrap(),
             }),
-            credentials: S3Credentials::new_access_key("MY_ACCESS_KEY", "MY_SECRET_KEY"),
+            credentials: S3Credentials::new_access_key("nitro_repo", "nitro_repo_password"),
             path_style: true,
         }
     }
 }
 
-pub fn start_storage_test(storage_type: &str) -> anyhow::Result<Option<StorageConfig>> {
+impl TestingStorageType for FileSystemV2Storage {
+    type ConfigType = FileSystemV2Config;
+    type Factory = FileSystemV2Factory;
+    fn test_config() -> Self::ConfigType {
+        FileSystemV2Config {
+            path: testing_storage_directory().unwrap().join("fs_v2_test"),
+            compression: Compression::None,
+            sync: false,
+        }
+    }
+}
+
+/// Resolves the config for a backend's test run, or `None` when that backend cannot be tested here.
+///
+/// Two distinct reasons to skip, which used to be conflated:
+///
+/// - **No config.** Nothing to test against; skip quietly.
+/// - **Config present but the service is unreachable.** A default config is written automatically
+///   on first run and names a MinIO on `localhost:9000`, so a developer with no MinIO running had
+///   no way *not* to run the S3 test — and it failed the whole suite on "connection refused".
+///   That is an environment gap, not a defect, so it skips with a warning.
+///
+/// Set `STORAGE_TESTS_REQUIRE_ALL=1` to turn the second case back into a failure. CI sets it once
+/// the services are up, so a genuinely broken backend cannot hide behind a skip.
+pub async fn start_storage_test(storage_type: &str) -> anyhow::Result<Option<StorageConfig>> {
     let storage_configs = get_storage_configs()?;
 
-    let storage_config = storage_configs
+    let Some(storage_config) = storage_configs
         .into_iter()
-        .find(|config| config.storage_config.storage_type == storage_type);
-    Ok(storage_config)
+        .find(|config| config.storage_config.storage_type == storage_type)
+    else {
+        info!(storage_type, "No test config for this storage type");
+        return Ok(None);
+    };
+
+    if let Err(err) = probe_storage_config(&storage_config).await {
+        if require_all_storage_tests() {
+            return Err(err.context(format!(
+                "{storage_type} is unreachable and STORAGE_TESTS_REQUIRE_ALL is set"
+            )));
+        }
+        warn!(
+            storage_type,
+            ?err,
+            "Storage backend is unreachable; skipping. Set STORAGE_TESTS_REQUIRE_ALL=1 to fail instead."
+        );
+        return Ok(None);
+    }
+
+    Ok(Some(storage_config))
+}
+
+fn require_all_storage_tests() -> bool {
+    std::env::var("STORAGE_TESTS_REQUIRE_ALL")
+        .map(|value| !matches!(value.as_str(), "" | "0" | "false"))
+        .unwrap_or(false)
+}
+
+/// Checks a backend is actually usable before its test suite commits to running.
+async fn probe_storage_config(config: &StorageConfig) -> anyhow::Result<()> {
+    for factory in crate::STORAGE_FACTORIES {
+        if factory.storage_name() == config.storage_config.storage_type {
+            factory
+                .test_storage_config(config.type_config.clone())
+                .await?;
+            return Ok(());
+        }
+    }
+    anyhow::bail!(
+        "No storage factory named `{}`",
+        config.storage_config.storage_type
+    )
 }
 pub fn get_storage_configs() -> anyhow::Result<Vec<StorageConfig>> {
     let config = testing_config_file()?;

--- a/crates/storage/src/testing/storage.rs
+++ b/crates/storage/src/testing/storage.rs
@@ -109,19 +109,21 @@ impl<ST: Storage> Storage for TestingStorage<ST> {
 
     async fn put_repository_meta(
         &self,
-        _repository: Uuid,
-        _location: &StoragePath,
-        _value: RepositoryMeta,
+        repository: Uuid,
+        location: &StoragePath,
+        value: RepositoryMeta,
     ) -> Result<(), Self::Error> {
-        todo!()
+        self.storage
+            .put_repository_meta(repository, location, value)
+            .await
     }
 
     async fn get_repository_meta(
         &self,
-        _repository: Uuid,
-        _location: &StoragePath,
+        repository: Uuid,
+        location: &StoragePath,
     ) -> Result<Option<RepositoryMeta>, Self::Error> {
-        todo!()
+        self.storage.get_repository_meta(repository, location).await
     }
 
     async fn delete_file(

--- a/crates/storage/src/testing/tests.rs
+++ b/crates/storage/src/testing/tests.rs
@@ -3,12 +3,199 @@ use tracing::{debug, info};
 use uuid::Uuid;
 
 use super::storage::TestingStorage;
-use crate::{FileContent, Storage, StorageError, StorageFile};
-pub async fn full_test<ST: Storage>(storage: TestingStorage<ST>) -> anyhow::Result<()> {
+use crate::{FileContent, FileType, Storage, StorageError, StorageFile, meta::RepositoryMeta};
+pub async fn full_test<ST: Storage>(storage: TestingStorage<ST>) -> anyhow::Result<()>
+where
+    ST::DirectoryStream: 'static,
+{
     write_then_read(&storage).await?;
     write_multiple_then_list(&storage).await?;
     should_conflict(&storage).await?;
+    repository_meta_round_trip(&storage).await?;
+    file_information_is_accurate(&storage).await?;
+    overwrite_preserves_repository_meta(&storage).await?;
+    delete_removes_file(&storage).await?;
+    stream_directory_lists_children(&storage).await?;
     storage.unload().await?;
+    Ok(())
+}
+
+/// Repository metadata must survive a write/read cycle.
+///
+/// Maven stamps project and version ids onto stored paths through this, and resolves them back on
+/// every read. It was previously untested for every backend — the harness's own implementations
+/// of these two methods were `todo!()` — which is how S3 shipped with both of them unimplemented.
+pub async fn repository_meta_round_trip<ST: Storage>(
+    storage: &TestingStorage<ST>,
+) -> anyhow::Result<()> {
+    let repository = Uuid::new_v4();
+    let path = StoragePath::from("meta/target.txt");
+    storage
+        .save_file(repository, FileContent::from("content"), &path)
+        .await?;
+
+    assert_eq!(
+        storage.get_repository_meta(repository, &path).await?,
+        Some(RepositoryMeta::default()),
+        "A freshly written file should have empty repository meta, not none"
+    );
+
+    let mut meta = RepositoryMeta::default();
+    meta.set_project_id(Uuid::new_v4());
+    meta.set_version_id(Uuid::new_v4());
+    meta.insert("hello", "world");
+    storage
+        .put_repository_meta(repository, &path, meta.clone())
+        .await?;
+
+    assert_eq!(
+        storage.get_repository_meta(repository, &path).await?,
+        Some(meta),
+        "Repository meta did not round trip"
+    );
+    Ok(())
+}
+
+/// `get_file_information` must report the real size and hashes, not placeholders.
+///
+/// The S3 backend used to fabricate this — every file reported `file_size: 0` with no hashes —
+/// which silently broke Content-Length and ETag on every artifact served from a bucket.
+pub async fn file_information_is_accurate<ST: Storage>(
+    storage: &TestingStorage<ST>,
+) -> anyhow::Result<()> {
+    let repository = Uuid::new_v4();
+    let path = StoragePath::from("info/artifact.jar");
+    let body = "Some artifact content";
+    storage
+        .save_file(repository, FileContent::from(body), &path)
+        .await?;
+
+    let info = storage
+        .get_file_information(repository, &path)
+        .await?
+        .expect("File information missing for a file that was just written");
+
+    let FileType::File(file_type) = info.file_type else {
+        panic!("Expected a file, got {:?}", info.file_type);
+    };
+    assert_eq!(
+        file_type.file_size,
+        body.len() as u64,
+        "Reported size does not match what was written"
+    );
+    assert!(
+        file_type.file_hash.sha2_256.is_some(),
+        "No sha2-256 recorded; the ETag header depends on this"
+    );
+
+    let directory = storage
+        .get_file_information(repository, &StoragePath::from("info/"))
+        .await?
+        .expect("File information missing for the parent directory");
+    assert!(
+        matches!(directory.file_type, FileType::Directory(_)),
+        "Parent of a file should report as a directory, got {:?}",
+        directory.file_type
+    );
+    Ok(())
+}
+
+/// Overwriting an artifact must not silently discard the metadata attached to its path.
+pub async fn overwrite_preserves_repository_meta<ST: Storage>(
+    storage: &TestingStorage<ST>,
+) -> anyhow::Result<()> {
+    let repository = Uuid::new_v4();
+    let path = StoragePath::from("overwrite/artifact.pom");
+    storage
+        .save_file(repository, FileContent::from("first"), &path)
+        .await?;
+
+    let mut meta = RepositoryMeta::default();
+    let project_id = Uuid::new_v4();
+    meta.set_project_id(project_id);
+    storage.put_repository_meta(repository, &path, meta).await?;
+
+    storage
+        .save_file(repository, FileContent::from("second, longer"), &path)
+        .await?;
+
+    let after = storage
+        .get_repository_meta(repository, &path)
+        .await?
+        .expect("Repository meta vanished after an overwrite");
+    assert_eq!(
+        after.project_id,
+        Some(project_id),
+        "Overwriting an artifact dropped the project id attached to its path"
+    );
+    Ok(())
+}
+
+/// Deleting must remove the file and stop reporting it as present.
+pub async fn delete_removes_file<ST: Storage>(storage: &TestingStorage<ST>) -> anyhow::Result<()> {
+    let repository = Uuid::new_v4();
+    let path = StoragePath::from("delete/me.txt");
+    storage
+        .save_file(repository, FileContent::from("temporary"), &path)
+        .await?;
+    assert!(storage.file_exists(repository, &path).await?);
+
+    assert!(
+        storage.delete_file(repository, &path).await?,
+        "Deleting an existing file should report that it did something"
+    );
+    assert!(
+        !storage.file_exists(repository, &path).await?,
+        "File still exists after being deleted"
+    );
+    assert!(
+        storage.open_file(repository, &path).await?.is_none(),
+        "Deleted file can still be opened"
+    );
+    Ok(())
+}
+
+/// `stream_directory` must yield a directory's children, and nothing for a path that is not one.
+///
+/// This is what the browse websocket reads; it was `todo!()` on S3.
+pub async fn stream_directory_lists_children<ST: Storage>(
+    storage: &TestingStorage<ST>,
+) -> anyhow::Result<()>
+where
+    ST::DirectoryStream: 'static,
+{
+    let repository = Uuid::new_v4();
+    let names = ["one.txt", "two.txt", "three.txt"];
+    for name in names {
+        storage
+            .save_file(
+                repository,
+                FileContent::from("content"),
+                &StoragePath::from(format!("streamed/{name}")),
+            )
+            .await?;
+    }
+
+    let stream = storage
+        .stream_directory(repository, &StoragePath::from("streamed/"))
+        .await?
+        .expect("No stream for a directory that exists");
+    let files = crate::streaming::collect_directory_stream(stream).await?;
+    assert_eq!(
+        files.len(),
+        names.len(),
+        "Streamed directory returned the wrong number of entries: {files:?}"
+    );
+
+    let mut listed: Vec<&str> = files.iter().map(|file| file.name.as_str()).collect();
+    listed.sort_unstable();
+    let mut expected = names.to_vec();
+    expected.sort_unstable();
+    assert_eq!(
+        listed, expected,
+        "Streamed directory listed the wrong names"
+    );
+
     Ok(())
 }
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,55 @@
+# Backing services for running the test suite locally.
+#
+#   docker compose -f docker-compose.dev.yml up -d
+#   just test
+#
+# This is deliberately separate from docker-compose.yml, which deploys the published image and is
+# what a user runs. Nothing here should ever be pointed at real data — the credentials are fixed so
+# that the storage test harness can find the services without any local configuration.
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: password
+      # `nr_tests.env` points DATABASE_URL at this database.
+      POSTGRES_DB: nr_tests
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  minio:
+    image: minio/minio:latest
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: nitro_repo
+      MINIO_ROOT_PASSWORD: nitro_repo_password
+    ports:
+      - "9000:9000"
+      # Web console, for looking at what the S3 tests actually wrote. Deliberately not MinIO's
+      # default 9001 on the host side — that port collides with too many other dev tools.
+      - "9091:9001"
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # The S3 tests assume their bucket exists; creating it is not part of what they are testing.
+  minio-bucket:
+    image: minio/mc:latest
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      mc alias set local http://minio:9000 nitro_repo nitro_repo_password &&
+      mc mb --ignore-existing local/test-bucket &&
+      echo 'test-bucket ready'
+      "

--- a/justfile
+++ b/justfile
@@ -4,6 +4,22 @@ fmt:
     cargo fmt --all
     cd site && npm run format
 
+# Backing services the storage tests need (Postgres + MinIO).
+services-up:
+    docker compose -f docker-compose.dev.yml up -d
+services-down:
+    docker compose -f docker-compose.dev.yml down
+
+# Backends with no service running are skipped with a warning. Run `just services-up` first, or
+# `just test-all` to make a skipped backend a failure instead.
+test:
+    cargo test --all
+test-all:
+    STORAGE_TESTS_REQUIRE_ALL=1 cargo test --all
+
+lint:
+    cargo clippy --all --all-targets -- -D warnings
+
 
 release-dev-docker:
     docker build -t git.kingtux.dev/wherkamp/nitro_repo/nitro_repo:latest .

--- a/nitro_repo/src/app/api/storage.rs
+++ b/nitro_repo/src/app/api/storage.rs
@@ -9,7 +9,7 @@ use nr_core::{
     storage::StorageName,
     user::permissions::HasPermissions,
 };
-use nr_storage::{StorageConfig, StorageTypeConfig, local::LocalConfig};
+use nr_storage::{StorageConfig, StorageTypeConfig, fs_v2::FileSystemV2Config, local::LocalConfig};
 use serde::{Deserialize, Serialize};
 use tracing::{error, instrument};
 use utoipa::{IntoParams, OpenApi, ToSchema};
@@ -28,7 +28,13 @@ use crate::{
 #[derive(OpenApi)]
 #[openapi(
     paths(list_storages, new_storage, get_storage),
-    components(schemas(DBStorage, NewStorageRequest, StorageTypeConfig, LocalConfig)),
+    components(schemas(
+        DBStorage,
+        NewStorageRequest,
+        StorageTypeConfig,
+        LocalConfig,
+        FileSystemV2Config
+    )),
     nest(
         (path = "/local", api = local::LocalStorageAPI, tags=["local", "storage"]),
         (path = "/s3", api = s3::S3StorageAPI, tags=["s3", "storage"])


### PR DESCRIPTION
Stacked on #552 — review that one first; this PR targets its branch so the diff stays scoped.

Closes #503.

## S3

The blocker was never the client library. S3 had **nowhere to keep metadata**, so four `Storage` methods were `todo!()` — `put_repository_meta`, `get_repository_meta`, `get_file_information`, `stream_directory` — and the listing helpers *fabricated* everything they returned:

```rust
// s3/mod.rs, before
let file_file = FileType::File(FileFileType {
    file_size: 0,
    mime_type: None,
    file_hash: FileHashes::default(),
});
// ...
modified: Local::now().fixed_offset(),
created: Local::now().fixed_offset(),
```

Maven and the browse websocket lean on exactly those methods, so **Maven-on-S3 panicked**, and anything served from a bucket had no Content-Length and no ETag.

**Metadata model.** Each object gets a sibling `{key}.nr-meta` holding the same postcard-encoded `LocationMeta` the local backend already writes beside a file on disk. Object tags cap at 10 entries of 256 characters and `x-amz-meta-*` at 2 KB total — neither fits arbitrary `RepositoryMeta.extra_meta`. Sidecars also mean one codec serves all three backends.

Beyond the `todo!()`s:

- **Credentials are optional.** With none configured the SDK's default provider chain applies (env, shared config, IMDS, web identity), so IAM roles and assumed roles work without long-lived keys in the database.
- **Listing is prefix-based and paginated.** It used `CommonPrefixes` rather than trusting the `application/x-directory` marker, and it no longer silently returns only the first `ListObjectsV2` page. Markers are still written, so a bucket stays legible to the AWS console and MinIO.
- **Deleting a directory** does a recursive prefix delete in `DeleteObjects` batches. Previously it could only delete a single key, leaving children served under a path that no longer existed.
- **`open_file` streams** from the SDK `ByteStream` instead of buffering whole artifacts into memory.
- **`get_path_for_creation`'s collision check was inverted** — it errored when a component *was not* a directory, including the final filename, and only "worked" because the empty-result case returned `true`.
- Region handling maps onto `aws_config::Region`. `S3StorageRegion` stays, because it is served by `GET /api/storage/s3/regions` and is what makes the UI dropdown possible.

## FileSystemV2

A third backend, on [tux-io-encoding](https://github.com/wyatt-herkamp/tux-io-encoding). Each artifact is one self-describing object — 32-byte header, metadata map, tag map, content — rather than raw bytes plus a `.nr-meta` sidecar. Against the existing local backend that removes:

- **Two files per artifact.** No hidden entries to filter out of every listing, and no sidecar that can drift from its file (today an undecodable one is silently rebuilt).
- **Eventually-consistent metadata.** Sidecars are written by a background task fed over a channel; here the prefix is written in the same pass as the content.
- **Whole-file reads to hash.** `generate_hashes_from_path` reads the file back into a `Vec` after the fact.

It also gets range reads for free, which the local backend cannot do. Writes are published by temp-file rename, so a reader never observes a partial artifact.

Compression (zstd/gzip) is optional and off by default — most artifacts are already compressed. Because the codecs are synchronous, `AsyncObjectWriter::create` rejects a compressed object outright, so those writes go through the blocking writer on the blocking pool.

**`Local` is untouched and keeps working.** New storages can choose `FileSystemV2`.

## Structural

- **`DynStorage` is macro-generated.** `Storage` uses RPITIT so it is not object safe; dispatch went through a hand-written enum with one match arm per method per backend — eleven near-identical arms to add per backend. Same trick `storage_type_config!` already uses.
- **Storage type names normalised.** The S3 factory reported `"s3"` while the config JSON stored in the same row is tagged `"S3"`. A name that does not match a factory is skipped at boot with only a warning, so this was a live footgun. Migration included.
- `FileContent` no longer imports `tux_io_s3::S3CommandBody` — the shared file model was coupled to a specific S3 client.

## Testing

`TestingStorage::put_repository_meta` and `get_repository_meta` were themselves `todo!()`, so **repository-meta behaviour was untested for every backend** — which is how S3 shipped with both of them unimplemented. They are implemented, and `full_test` goes from three scenarios to eight:

| Scenario | Catches |
|---|---|
| `repository_meta_round_trip` | the two methods that were `todo!()` |
| `file_information_is_accurate` | fabricated sizes and missing hashes |
| `overwrite_preserves_repository_meta` | an overwrite dropping Maven's project ids |
| `delete_removes_file` | delete that does not delete |
| `stream_directory_lists_children` | the method the browse websocket needs |

All eight pass against **all three backends**, plus zstd/gzip/uncompressed round trips for FileSystemV2. 44 tests total.

`start_storage_test` now separates "no config" from "service unreachable". A default config naming a MinIO on `localhost:9000` is written automatically on first run, so a developer without one had **no way** to stop the S3 test failing the suite on connection refused — that is what made `cargo test --all` red on `main`. Both cases skip now, the second with a warning; `STORAGE_TESTS_REQUIRE_ALL=1` turns it back into a failure so CI cannot let a broken backend hide behind a skip.

`docker-compose.dev.yml` brings up Postgres and MinIO, with `just services-up` / `just test` / `just test-all` / `just lint`.

## Verification

`cargo check --all --all-targets`, `cargo clippy --all --all-targets` (zero warnings), `cargo test --all` — 44 passing, S3 exercised against a real MinIO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)