### PR TITLE
Fix CI and make it enforce what it claims to

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -1,32 +1,81 @@
 name: Backend Push or PR
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
+    branches: [main]
 
 env:
   CARGO_TERM_COLOR: always
+  # Backtraces on a failing test are the difference between a usable CI log and a re-run.
+  RUST_BACKTRACE: 1
+
+# A push that lands while an earlier run is still going makes that run irrelevant. Pushes to main
+# are exempt, so the record of what passed on main stays complete.
+concurrency:
+  group: backend-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
-  build:
+  test:
+    name: Test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install toolchain
+        # No `toolchain:` input — rust-toolchain.toml pins the channel. This used to request
+        # `beta` from an action tagged `stable`, so CI tested a toolchain nobody develops against.
         uses: dtolnay/rust-toolchain@stable
-        with:
-          toolchain: beta
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
+      - name: Start backing services
+        # The same compose file developers use, so a passing local run means the same thing here.
+        # The daemons are waited on for health; `minio-bucket` is a one-shot that creates the test
+        # bucket and exits, which `--wait` would report as a failed service, so it runs separately
+        # in the foreground and its exit code is the step's.
+        run: |
+          docker compose -f docker-compose.dev.yml --profile postgres up -d --wait postgres minio
+          docker compose -f docker-compose.dev.yml up --exit-code-from minio-bucket minio-bucket
       - name: Test
+        # The storage suite skips a backend whose service is unreachable, so a developer without a
+        # MinIO is not blocked by a failure in something they are not working on. The services are
+        # up here, so make a skip an error instead — otherwise a broken backend passes silently.
         run: cargo test --all
+        env:
+          STORAGE_TESTS_REQUIRE_ALL: 1
+      - name: Service logs
+        if: failure()
+        run: docker compose -f docker-compose.dev.yml logs
+
   lint:
+    name: Lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Install toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: beta
+          components: clippy
+      - name: Cache cargo
+        uses: Swatinem/rust-cache@v2
       - name: Cargo Check
-        run: cargo check --all
+        run: cargo check --all --all-targets
       - name: Cargo Clippy
-        run: cargo clippy --all -- -D warnings
+        # `--all-targets` so test code is linted too. Without it a warning can sit in a test module
+        # indefinitely, which is exactly where the two that existed were sitting.
+        run: cargo clippy --all --all-targets -- -D warnings
+
+  format:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install toolchain
+        # rustfmt.toml sets `imports_granularity` and `group_imports`, both nightly-only. Stable
+        # rustfmt ignores them silently, so `cargo fmt` produces different output depending on who
+        # ran it. Formatting is pinned to nightly so there is one answer.
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - name: Cargo Format
+        run: cargo fmt --all --check

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -2,13 +2,21 @@ name: Frontend Push or PR
 
 on:
   push:
-    branches: main
+    branches: [main]
   pull_request:
-    branches: main
-env:
-  CARGO_TERM_COLOR: always
+    branches: [main]
+
+concurrency:
+  group: frontend-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+defaults:
+  run:
+    working-directory: site
+
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,9 +24,15 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: "site/.node-version"
-      - name: Install Site
-        working-directory: site
-        run: npm install
-      - name: Build Site
-        working-directory: site
+          cache: npm
+          cache-dependency-path: site/package-lock.json
+      - name: Install
+        # `ci` rather than `install`: it installs exactly what the lockfile pins and fails if the
+        # two have drifted, instead of quietly resolving something else.
+        run: npm ci
+      - name: Lint
+        # Nothing ran eslint in CI before, so a lint error could only be found by hand.
+        run: npm run lint
+      - name: Build
+        # `build` runs the type check and the bundle together.
         run: npm run build

--- a/crates/core/src/repository/config.rs
+++ b/crates/core/src/repository/config.rs
@@ -60,7 +60,7 @@ pub trait RepositoryConfigType: Send + Sync + Debug {
     }
     /// Get the default config. Errors are usually a bug in the code
     fn default(&self) -> Result<Value, RepositoryConfigError>;
-    
+
     /// Schema for the config
     fn schema(&self) -> Option<Schema> {
         None

--- a/crates/storage/src/testing.rs
+++ b/crates/storage/src/testing.rs
@@ -113,6 +113,13 @@ pub async fn start_storage_test(storage_type: &str) -> anyhow::Result<Option<Sto
         .into_iter()
         .find(|config| config.storage_config.storage_type == storage_type)
     else {
+        if require_all_storage_tests() {
+            anyhow::bail!(
+                "No test config for `{storage_type}` and STORAGE_TESTS_REQUIRE_ALL is set. \
+                 A config file that predates this backend will not name it — delete it and let \
+                 the defaults regenerate."
+            );
+        }
         info!(storage_type, "No test config for this storage type");
         return Ok(None);
     };

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -10,6 +10,10 @@ services:
   postgres:
     image: postgres:17-alpine
     restart: unless-stopped
+    # Behind a profile because `nr_tests.env` points at localhost:5432 and plenty of developers
+    # already run a Postgres there — starting a second one just fails to bind the port. Opt in with
+    # `--profile postgres` (which is what CI does, since a runner has nothing on 5432).
+    profiles: ["postgres"]
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password

--- a/justfile
+++ b/justfile
@@ -1,12 +1,20 @@
 build-release:
     cargo build --release
+# rustfmt.toml sets `imports_granularity` and `group_imports`, which are nightly-only. Stable
+# rustfmt ignores them without saying so, so formatting on stable reorders imports differently to
+# formatting on nightly and the two fight each other. Pinned to nightly so there is one answer.
 fmt:
-    cargo fmt --all
+    cargo +nightly fmt --all
     cd site && npm run format
 
-# Backing services the storage tests need (Postgres + MinIO).
+fmt-check:
+    cargo +nightly fmt --all --check
+
+# MinIO, for the S3 storage tests. Postgres is behind a `postgres` profile because most
+# developers already have one on 5432; add `--profile postgres` if you do not.
 services-up:
-    docker compose -f docker-compose.dev.yml up -d
+    docker compose -f docker-compose.dev.yml up -d --wait minio
+    docker compose -f docker-compose.dev.yml up --exit-code-from minio-bucket minio-bucket
 services-down:
     docker compose -f docker-compose.dev.yml down
 

--- a/nitro_repo/build.rs
+++ b/nitro_repo/build.rs
@@ -22,9 +22,7 @@ fn build_frontend() -> anyhow::Result<()> {
     {
         if !frontend_dist.exists() {
             if ignore_dir_not_found {
-                println!(
-                    "cargo::warning=site build directory not found - creating empty zip"
-                );
+                println!("cargo::warning=site build directory not found - creating empty zip");
                 return empty_zip();
             }
             return Err(anyhow::anyhow!(
@@ -36,9 +34,7 @@ fn build_frontend() -> anyhow::Result<()> {
         let frontend_dist = get_site_dist_dir()?;
         if !frontend_dist.exists() {
             if ignore_dir_not_found {
-                println!(
-                    "cargo::warning=site build directory not found - creating empty zip"
-                );
+                println!("cargo::warning=site build directory not found - creating empty zip");
                 return empty_zip();
             }
             return Err(anyhow::anyhow!("{} not found", frontend_dist.display()));

--- a/nitro_repo/src/app/api/storage/local.rs
+++ b/nitro_repo/src/app/api/storage/local.rs
@@ -72,9 +72,10 @@ pub async fn path_helper(
             let entry = entry.unwrap();
             let path = entry.path();
             if path.is_dir()
-                && let Some(file_name) = path.file_name() {
-                    directories.push(file_name.to_string_lossy().to_string());
-                }
+                && let Some(file_name) = path.file_name()
+            {
+                directories.push(file_name.to_string_lossy().to_string());
+            }
         }
         LocalStoragePathHelperResponse::Directories(directories)
     } else {

--- a/nitro_repo/src/app/authentication/mod.rs
+++ b/nitro_repo/src/app/authentication/mod.rs
@@ -358,7 +358,6 @@ impl AuthenticationRaw {
         }
     }
     pub fn new_from_cookie(cookie: &Cookie<'static>, site: &NitroRepo) -> Self {
-        
         match site.session_manager.get_session(cookie.value()) {
             Ok(Some(ok)) => AuthenticationRaw::Session(ok),
             Err(err) => {

--- a/nitro_repo/src/app/email_service.rs
+++ b/nitro_repo/src/app/email_service.rs
@@ -190,11 +190,7 @@ impl EmailService {
         let mut email_handlebars = Handlebars::new();
         email_handlebars
             .register_embed_templates::<EmailTemplates>()
-            .map_err(|e| {
-                io::Error::other(
-                    format!("Email Handlebars Error: {:?}", e),
-                )
-            })?;
+            .map_err(|e| io::Error::other(format!("Email Handlebars Error: {:?}", e)))?;
 
         let (sender, receiver) = flume::bounded(100);
         let handle = tokio::spawn(async move {

--- a/nitro_repo/src/logging/mod.rs
+++ b/nitro_repo/src/logging/mod.rs
@@ -180,14 +180,15 @@ pub fn init(config: LoggingConfig) -> anyhow::Result<LoggingState> {
     let subscriber = Registry::default().with(layers);
     subscriber.init();
     if let Some(metrics_config) = metrics_config
-        && metrics_config.enabled {
-            let provider = metrics(metrics_config)?;
-            global::set_meter_provider(provider.clone());
-            state.items.push(NamedLogger {
-                name: "metrics".to_string(),
-                logger: LoggingStateItem::Meter(provider),
-            });
-        }
+        && metrics_config.enabled
+    {
+        let provider = metrics(metrics_config)?;
+        global::set_meter_provider(provider.clone());
+        state.items.push(NamedLogger {
+            name: "metrics".to_string(),
+            logger: LoggingStateItem::Meter(provider),
+        });
+    }
     Ok(state)
 }
 

--- a/nitro_repo/src/utils/requests/json.rs
+++ b/nitro_repo/src/utils/requests/json.rs
@@ -63,7 +63,6 @@ fn is_json_content_type(headers: &HeaderMap) -> bool {
         return false;
     };
     event!(Level::TRACE, content_type = %content_type, "Parsed `Content-Type` header");
-    
 
     mime.type_() == "application"
         && (mime.subtype() == "json" || mime.suffix().is_some_and(|name| name == "json"))

--- a/site/src/components/nr/repository/RepositoryPageViewer.vue
+++ b/site/src/components/nr/repository/RepositoryPageViewer.vue
@@ -1,16 +1,16 @@
 <template>
   <div
-    v-if="page.page_type == PageType.Markdown"
+    v-if="page.page_type == PageType.Markdown && markdownSource"
     id="pageContent">
-    <vue-markdown :source="page.content" />
+    <vue-markdown :source="markdownSource" />
   </div>
 </template>
 <script setup lang="ts">
-import { defineProps, type PropType } from "vue";
+import { computed, type PropType } from "vue";
 import { PageType, type RepositoryPage, type RepositoryWithStorageName } from "@/types/repository";
 import VueMarkdown from "vue-markdown-render";
 
-defineProps({
+const props = defineProps({
   repository: {
     type: Object as PropType<RepositoryWithStorageName>,
     required: true,
@@ -20,6 +20,11 @@ defineProps({
     required: true,
   },
 });
+
+// `RepositoryPage.content` is optional — a repository can have a page configured with nothing in
+// it yet — but `vue-markdown` requires a definite string. Rendering an empty page body is not
+// useful, so an absent content also drops the wrapper entirely via the `v-if` above.
+const markdownSource = computed(() => props.page.content ?? "");
 </script>
 <style lang="scss">
 #pageContent {


### PR DESCRIPTION
Both workflows were red on `main`, each for a real reason, and neither would have caught the other's failure.

**Stacked on #554** — that PR carries the storage work that never reached `main`, and the test job here depends on it. Merge #554 first; this diff then shows only the CI changes.

## The two actual failures

**Frontend — a genuine type error.**

```
src/components/nr/repository/RepositoryPageViewer.vue(5,20): error TS2322:
  Type 'string | undefined' is not assignable to type 'string'.
```

`RepositoryPage.content` is `string | undefined` — a repository can have a page configured with nothing in it yet — but `vue-markdown`'s `source` prop requires a definite string. Rendering an empty page body isn't useful, so the wrapper is now dropped entirely when there's no content.

**Backend — the storage suite couldn't pass on a runner.**

```
Error: S3 Error: Reqwest Error: error sending request for url (http://localhost:9000/...)
    2: client error (Connect)
```

The test harness writes a default config naming a MinIO on `localhost:9000` automatically, so there was no way to opt out of the S3 test. Fixed by *starting the services*, not by skipping them.

## Beyond the failures, the workflows weren't doing much

| Problem | Fix |
|---|---|
| Both requested `beta` from an action tagged `stable` — CI tested a toolchain nobody develops against, ignoring `rust-toolchain.toml` | Drop the input; the pinned channel applies |
| Nothing cached — every run rebuilt the whole dependency graph | `Swatinem/rust-cache@v2`, npm cache via `setup-node` |
| Clippy ran without `--all-targets` | Added — this is exactly why two warnings sat in test modules until #552 |
| Frontend never ran eslint | Added |
| `npm install` where `npm ci` belongs — the lockfile wasn't authoritative | `npm ci` |
| No concurrency control | Superseded runs are cancelled, except on `main` |
| Nothing checked formatting | New job — see below |

## The formatting trap

`rustfmt.toml` contains **only** nightly-only options:

```toml
imports_granularity = "Crate"
group_imports = "StdExternalCrate"
```

Stable rustfmt ignores both **silently**. So `cargo fmt` grouped imports one way on stable and another on nightly, and running `just fmt` on the pinned stable toolchain reformatted files nobody had touched — I hit this on every branch so far and had to keep reverting the churn.

Formatting is now pinned to nightly in `just fmt` and enforced by a CI job, with a one-time normalisation of the seven files that had drifted. `just fmt-check` runs the same check locally.

## Storage tests now run for real

`docker-compose.dev.yml` brings up the services and CI sets `STORAGE_TESTS_REQUIRE_ALL=1`, so a skip becomes an error — a backend that can't connect, *or that has no config at all*, fails rather than quietly not running. That second case was a gap in my own skip logic from #553: a config file predating a backend wouldn't name it, and the run would silently cover less than it appeared to.

Verified both directions:

```
$ STORAGE_TESTS_REQUIRE_ALL=1 cargo test --all
test result: ok. 44 passed; 0 failed

$ # same, pointed at a port with nothing on it
Error: S3 is unreachable and STORAGE_TESTS_REQUIRE_ALL is set
test result: FAILED. 0 passed; 1 failed
```

Postgres sits behind a compose profile — most developers already have one on 5432, and starting a second just fails to bind the port (it did on mine). CI opts in with `--profile postgres`. The one-shot bucket-creation container is run separately from `--wait`, which would otherwise report a container that exits 0 as a failed service.

## Verification

All three backend jobs and the frontend job were run locally as the workflows run them: `cargo test --all` with the services up (44 passing), `cargo clippy --all --all-targets -- -D warnings` (clean), `cargo +nightly fmt --all --check` (clean), `npm ci && npm run lint && npm run build` (clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)