### PR TITLE
Token scopes, expiry, and the API routes that never checked either (#505)

### DIFF
--- a/crates/core/migrations/20260801140000_auth_token_last_used.down.sql
+++ b/crates/core/migrations/20260801140000_auth_token_last_used.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_auth_tokens DROP COLUMN IF EXISTS last_used_at;

--- a/crates/core/migrations/20260801140000_auth_token_last_used.up.sql
+++ b/crates/core/migrations/20260801140000_auth_token_last_used.up.sql
@@ -1,0 +1,7 @@
+-- When a token was last used to authenticate.
+--
+-- The profile page shows tokens with no way to tell which are still in use, which is what makes
+-- cleaning up old ones guesswork. Written at most once an hour per token so an authenticated read
+-- does not become a write against a hot row.
+ALTER TABLE user_auth_tokens
+    ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMP WITH TIME ZONE;

--- a/crates/core/src/database/entities/user/auth_token.rs
+++ b/crates/core/src/database/entities/user/auth_token.rs
@@ -23,6 +23,8 @@ pub struct AuthToken {
     pub active: bool,
     pub source: String,
     pub expires_at: Option<chrono::DateTime<chrono::FixedOffset>>,
+    /// When the token was last used to authenticate. See [`AuthToken::touch_last_used`].
+    pub last_used_at: Option<chrono::DateTime<chrono::FixedOffset>>,
     pub created_at: chrono::DateTime<chrono::FixedOffset>,
 }
 impl ReferencesUser for AuthToken {
@@ -42,13 +44,51 @@ impl ReferencesUser for AuthToken {
     }
 }
 impl AuthToken {
+    /// Looks a token up for authentication.
+    ///
+    /// The expiry check is the point. `expires_at` has existed on this table since the schema was
+    /// written and was never consulted, so a token past its expiry authenticated exactly like a
+    /// live one — the password reset table next door gets this right, which is what makes the
+    /// omission here easy to miss.
     pub async fn get_by_token(token: &str, database: &PgPool) -> sqlx::Result<Option<Self>> {
-        let token =
-            sqlx::query_as(r#"SELECT * FROM user_auth_tokens WHERE token = $1 AND active = true"#)
-                .bind(hash_token(token))
-                .fetch_optional(database)
-                .await?;
+        let token = sqlx::query_as(
+            r#"SELECT * FROM user_auth_tokens
+               WHERE token = $1 AND active = true
+                 AND (expires_at IS NULL OR expires_at > NOW())"#,
+        )
+        .bind(hash_token(token))
+        .fetch_optional(database)
+        .await?;
         Ok(token)
+    }
+    /// Revokes every token belonging to a user.
+    ///
+    /// Returns how many were removed. This is the "revoke all tokens" the admin surface needs
+    /// after a credential leak — there was no way to do it, for yourself or for anyone else.
+    #[instrument(skip(database))]
+    pub async fn delete_all_for_user(user_id: i32, database: &PgPool) -> sqlx::Result<u64> {
+        let result = sqlx::query(r#"DELETE FROM user_auth_tokens WHERE user_id = $1"#)
+            .bind(user_id)
+            .execute(database)
+            .await?;
+        Ok(result.rows_affected())
+    }
+    /// Records that a token was just used.
+    ///
+    /// Written at most once an hour per token: this runs on every authenticated request, and a
+    /// write per request would turn a read-only API call into a write against a hot row. An hour
+    /// is enough to answer "is this token still in use", which is what the profile page shows it
+    /// for.
+    pub async fn touch_last_used(&self, database: &PgPool) -> sqlx::Result<()> {
+        sqlx::query(
+            r#"UPDATE user_auth_tokens SET last_used_at = NOW()
+               WHERE id = $1
+                 AND (last_used_at IS NULL OR last_used_at < NOW() - INTERVAL '1 hour')"#,
+        )
+        .bind(self.id)
+        .execute(database)
+        .await?;
+        Ok(())
     }
     pub async fn has_scope(&self, scope: NRScope, database: &PgPool) -> sqlx::Result<bool> {
         let can_read: i64 = sqlx::query_scalar(
@@ -121,6 +161,11 @@ pub struct NewAuthToken {
     pub source: String,
     pub scopes: Vec<NRScope>,
     pub repositories: Vec<(Uuid, Vec<RepositoryActions>)>,
+    /// When the token stops working. `None` means never.
+    ///
+    /// There was no way to set this — the column existed, the insert never wrote it, and the
+    /// profile UI showed a disabled field reading "Not implemented".
+    pub expires_at: Option<chrono::DateTime<chrono::FixedOffset>>,
 }
 impl NewAuthToken {
     pub async fn insert(self, database: &PgPool) -> sqlx::Result<(i32, String)> {
@@ -132,16 +177,18 @@ impl NewAuthToken {
             source,
             scopes,
             repositories,
+            expires_at,
         } = self;
 
         let token_id: i32 = sqlx::query_scalar(
-            r#"INSERT INTO user_auth_tokens (user_id, name, description, token, source) VALUES ($1, $2, $3, $4, $5) RETURNING id"#,
+            r#"INSERT INTO user_auth_tokens (user_id, name, description, token, source, expires_at) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id"#,
         )
         .bind(user_id)
         .bind(name)
         .bind(description)
         .bind(hashed_token)
         .bind(source)
+        .bind(expires_at)
         .fetch_one(database)
         .await?;
 

--- a/crates/core/src/database/entities/user/auth_token/utils.rs
+++ b/crates/core/src/database/entities/user/auth_token/utils.rs
@@ -21,9 +21,12 @@ pub async fn create_token(database: &PgPool) -> Result<(String, String), sqlx::E
     };
     Ok((token, hashed))
 }
-/// Generates a new token for the user
+/// Generates a new token for the user.
+///
+/// 32 alphanumeric characters from the OS entropy source, stored only as a SHA-256 hash. The
+/// `// TODO: Secure this` that sat here predated that and had been true of an earlier
+/// implementation; leaving it read as an open hole that was not one.
 pub fn generate_token() -> String {
-    // TODO: Secure this
     StdRng::from_os_rng()
         .sample_iter(&Alphanumeric)
         .take(32)

--- a/crates/core/src/repository/config/repository_page.rs
+++ b/crates/core/src/repository/config/repository_page.rs
@@ -43,6 +43,20 @@ impl RepositoryConfigType for RepositoryPageType {
         Some(schema_for!(RepositoryPage))
     }
 
+    /// The landing page is what a repository shows visitors, so there is nothing in it to hide.
+    ///
+    /// Every config type inherits the trait's `Ok(None)` default, which means "not visible to
+    /// anyone but an editor". That is the right default, but it left the public branch in
+    /// `get_config` with nothing to return even once it became reachable — a repository page could
+    /// not be read by the people it is written for.
+    fn sanitize_for_public_view(
+        &self,
+        config: Value,
+    ) -> Result<Option<Value>, RepositoryConfigError> {
+        let _page: RepositoryPage = serde_json::from_value(config.clone())?;
+        Ok(Some(config))
+    }
+
     fn get_type_static() -> &'static str
     where
         Self: Sized,

--- a/crates/core/src/user/scopes.rs
+++ b/crates/core/src/user/scopes.rs
@@ -8,6 +8,20 @@ use utoipa::ToSchema;
 #[derive(Debug, Error, From)]
 #[error("Invalid Scope: {0}")]
 pub struct InvalidScope(pub String);
+
+/// What an API token is allowed to do.
+///
+/// Only four of these existed — `ReadRepository`, `WriteRepository`, `EditRepository` and
+/// `UpdatePassword` — so every other API route was reachable by any token belonging to a user with
+/// the underlying permission. A token minted to let CI publish one artifact could also delete
+/// repositories, create users and rewrite system settings.
+///
+/// A scope is a *ceiling*, never a grant: holding one still requires the user behind the token to
+/// have the permission. That is why a scope for an administrative action is safe to offer to
+/// everyone — a non-admin's token carrying `DeleteRepository` still cannot delete anything.
+///
+/// **The variant names are persisted** in `user_auth_token_scopes.scope` as text, so renaming one
+/// silently invalidates every token that carries it. Adding is safe; renaming is not.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Type, ToSchema, EnumIter, Scopes)]
 #[sqlx(type_name = "TEXT")]
 pub enum NRScope {
@@ -17,13 +31,68 @@ pub enum NRScope {
     /// Can write to all repositories the user has access to
     #[scope(title = "Write Repository", parent = "Repository")]
     WriteRepository,
-    /// Can edit all repositories the user has access to
+    /// Can edit the settings of repositories the user has access to
     #[scope(title = "Edit Repository", parent = "Repository")]
     EditRepository,
-    #[scope(title = "Update Repository", parent = "User")]
-    /// Update your password
+    /// Can create new repositories
+    #[scope(title = "Create Repository", parent = "Repository", requires_system)]
+    CreateRepository,
+    /// Can delete repositories, and everything stored in them
+    #[scope(title = "Delete Repository", parent = "Repository", requires_system)]
+    DeleteRepository,
+
+    /// Can list storages and read their settings
+    #[scope(title = "Read Storage", parent = "Storage")]
+    ReadStorage,
+    /// Can create, edit and delete storages
+    #[scope(title = "Manage Storage", parent = "Storage", requires_system)]
+    ManageStorage,
+
+    /// Update your password. Changing a password also requires a browser session, so a token
+    /// alone is never sufficient
+    #[scope(title = "Update Password", parent = "User")]
     UpdatePassword,
+    /// Read your own profile, permissions and sessions
+    #[scope(title = "Read Profile", parent = "User")]
+    ReadSelf,
+
+    /// Can list users and read their profiles
+    #[scope(
+        title = "Read Users",
+        parent = "User Management",
+        requires_user_manager
+    )]
+    ReadUser,
+    /// Can create new users
+    #[scope(
+        title = "Create Users",
+        parent = "User Management",
+        requires_user_manager
+    )]
+    CreateUser,
+    /// Can edit users, including their permissions
+    #[scope(
+        title = "Edit Users",
+        parent = "User Management",
+        requires_user_manager
+    )]
+    EditUser,
+    /// Can delete users
+    #[scope(
+        title = "Delete Users",
+        parent = "User Management",
+        requires_user_manager
+    )]
+    DeleteUser,
+
+    /// Can read instance-wide settings
+    #[scope(title = "Read System Settings", parent = "System", requires_system)]
+    ReadSystem,
+    /// Can change instance-wide settings
+    #[scope(title = "Edit System Settings", parent = "System", requires_admin)]
+    EditSystem,
 }
+
 #[derive(Debug, Serialize, PartialEq, Eq, Hash, ToSchema)]
 pub struct ScopeDescription {
     pub key: NRScope,
@@ -45,6 +114,53 @@ impl Default for ScopeDescription {
             requires_user_manager: false,
             requires_admin: false,
             requires_system: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use strum::IntoEnumIterator;
+
+    use super::*;
+
+    /// The variant name is what is written to `user_auth_token_scopes.scope`. Renaming one
+    /// silently invalidates every existing token that carries it, so the four that shipped are
+    /// pinned here.
+    #[test]
+    fn persisted_scope_names_do_not_change() {
+        for (scope, expected) in [
+            (NRScope::ReadRepository, "ReadRepository"),
+            (NRScope::WriteRepository, "WriteRepository"),
+            (NRScope::EditRepository, "EditRepository"),
+            (NRScope::UpdatePassword, "UpdatePassword"),
+        ] {
+            assert_eq!(scope.as_ref(), expected);
+            assert_eq!(NRScope::try_from(expected).unwrap(), scope);
+        }
+    }
+
+    #[test]
+    fn every_scope_round_trips_through_its_name() {
+        for scope in NRScope::iter() {
+            let name = scope.as_ref();
+            assert_eq!(
+                NRScope::try_from(name).unwrap_or_else(|err| panic!("{name} did not parse: {err}")),
+                scope
+            );
+        }
+    }
+
+    #[test]
+    fn every_scope_is_described() {
+        for scope in NRScope::iter() {
+            let description = scope.description();
+            assert!(!description.name.is_empty(), "{scope:?} has no title");
+            assert!(
+                !description.description.trim().is_empty(),
+                "{scope:?} has no doc comment, so the UI would show a blank explanation"
+            );
+            assert!(description.parent.is_some(), "{scope:?} has no group");
         }
     }
 }

--- a/crates/core/src/user/token.rs
+++ b/crates/core/src/user/token.rs
@@ -13,6 +13,10 @@ pub struct AuthTokenResponse {
     pub active: bool,
     pub source: String,
     pub expires_at: Option<chrono::DateTime<chrono::FixedOffset>>,
+    /// When the token last authenticated a request. `None` means it never has.
+    ///
+    /// Recorded at most once an hour, so this is "used recently", not an exact timestamp.
+    pub last_used_at: Option<chrono::DateTime<chrono::FixedOffset>>,
     pub created_at: chrono::DateTime<chrono::FixedOffset>,
 }
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -28,8 +32,10 @@ impl AuthTokenFullResponse {
         user_id: i32,
         database: &sqlx::PgPool,
     ) -> Result<Option<AuthTokenFullResponse>, sqlx::Error> {
+        // The `AND` was missing, so this was not valid SQL and every call to it failed at the
+        // database rather than returning a token.
         let Some(base) = sqlx::query_as::<_, AuthTokenResponse>(
-            r#"SELECT * FROM user_auth_tokens WHERE id = $1 user_id = $2"#,
+            r#"SELECT * FROM user_auth_tokens WHERE id = $1 AND user_id = $2"#,
         )
         .bind(id)
         .bind(user_id)

--- a/crates/macros/src/scopes/mod.rs
+++ b/crates/macros/src/scopes/mod.rs
@@ -19,11 +19,20 @@ use syn::{Attribute, Data, DeriveInput, Expr, Ident, Lit, LitStr, Result};
 mod keywords {
     syn::custom_keyword!(title);
     syn::custom_keyword!(parent);
+    syn::custom_keyword!(requires_user_manager);
+    syn::custom_keyword!(requires_admin);
+    syn::custom_keyword!(requires_system);
 }
 #[derive(Debug)]
 pub struct ScopeAttribute {
     title: LitStr,
     parent: Option<LitStr>,
+    /// Bare flags. `ScopeDescription` already carried these fields, but the generated
+    /// `description()` filled them from `Default`, so every one of them was always `false` and the
+    /// UI had no way to tell an administrative scope from an ordinary one.
+    requires_user_manager: bool,
+    requires_admin: bool,
+    requires_system: bool,
 }
 pub struct ScopeEntry {
     ident: Ident,
@@ -37,7 +46,13 @@ impl ScopeEntry {
             attribute,
             docs,
         } = self;
-        let ScopeAttribute { title, parent } = attribute;
+        let ScopeAttribute {
+            title,
+            parent,
+            requires_user_manager,
+            requires_admin,
+            requires_system,
+        } = attribute;
         let parent = if let Some(parent) = parent {
             quote! { Some(#parent) }
         } else {
@@ -49,7 +64,9 @@ impl ScopeEntry {
                 description: #docs,
                 name: #title,
                 parent: #parent,
-                ..std::default::Default::default()
+                requires_user_manager: #requires_user_manager,
+                requires_admin: #requires_admin,
+                requires_system: #requires_system,
             },
         };
         scope
@@ -80,6 +97,9 @@ impl syn::parse::Parse for ScopeAttribute {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut title = None;
         let mut parent = None;
+        let mut requires_user_manager = false;
+        let mut requires_admin = false;
+        let mut requires_system = false;
         while !input.is_empty() {
             let lookahead = input.lookahead1();
             if lookahead.peek(keywords::title) {
@@ -90,6 +110,15 @@ impl syn::parse::Parse for ScopeAttribute {
                 input.parse::<keywords::parent>()?;
                 input.parse::<syn::Token![=]>()?;
                 parent = Some(input.parse()?);
+            } else if lookahead.peek(keywords::requires_user_manager) {
+                input.parse::<keywords::requires_user_manager>()?;
+                requires_user_manager = true;
+            } else if lookahead.peek(keywords::requires_admin) {
+                input.parse::<keywords::requires_admin>()?;
+                requires_admin = true;
+            } else if lookahead.peek(keywords::requires_system) {
+                input.parse::<keywords::requires_system>()?;
+                requires_system = true;
             } else {
                 return Err(lookahead.error());
             }
@@ -98,7 +127,13 @@ impl syn::parse::Parse for ScopeAttribute {
             }
         }
         let title = title.ok_or_else(|| input.error("No title found"))?;
-        Ok(Self { title, parent })
+        Ok(Self {
+            title,
+            parent,
+            requires_user_manager,
+            requires_admin,
+            requires_system,
+        })
     }
 }
 

--- a/nitro_repo/src/app/api/mod.rs
+++ b/nitro_repo/src/app/api/mod.rs
@@ -1,7 +1,7 @@
 use axum::{
     Json,
     extract::{Request, State},
-    response::Response,
+    response::{IntoResponse, Response},
 };
 use http::{StatusCode, Uri};
 use nr_core::{
@@ -24,6 +24,32 @@ use crate::{
     error::InternalError,
     utils::{ResponseBuilder, api_error_response::APIErrorResponse},
 };
+/// Refuses a request whose token does not carry `scope`.
+///
+/// Returns `Some(response)` when the caller should be turned away, so a route reads as:
+///
+/// ```rust,ignore
+/// if let Some(denied) = require_scope(&auth, NRScope::CreateRepository, &site).await? {
+///     return Ok(denied);
+/// }
+/// ```
+///
+/// This is a *second* gate, not a replacement for the permission check. A scope bounds what a
+/// token may do; whether the user may do it at all is still decided by their permissions, and both
+/// have to pass.
+pub async fn require_scope(
+    auth: &super::authentication::Authentication,
+    scope: NRScope,
+    site: &NitroRepo,
+) -> Result<Option<Response>, InternalError> {
+    if auth.has_scope(scope, site.as_ref()).await? {
+        return Ok(None);
+    }
+    Ok(Some(
+        crate::app::responses::MissingPermission::Scope(scope).into_response(),
+    ))
+}
+
 pub fn api_routes() -> axum::Router<NitroRepo> {
     axum::Router::new()
         .route("/info", axum::routing::get(info))

--- a/nitro_repo/src/app/api/repository.rs
+++ b/nitro_repo/src/app/api/repository.rs
@@ -172,14 +172,26 @@ pub async fn list_repositories(
     auth: Option<Authentication>,
     State(site): State<NitroRepo>,
 ) -> Result<Response, InternalError> {
-    let repositories: Vec<_> = DBRepositoryWithStorageName::get_all(site.as_ref())
-        .await?
-        .into_iter()
-        .filter(|repo| match repo.visibility {
-            Visibility::Private | Visibility::Public => true, // TODO FIX
-            _ => true,
-        })
-        .collect();
+    // Both arms of this filter returned `true`, so it did nothing and every private repository in
+    // the instance was listed to anonymous callers — names, storage names and visibility included.
+    //
+    // A private repository is only listed to someone who can read it. Hidden means "do not
+    // advertise", which is what a listing is, so it is treated the same way here; it is still
+    // reachable directly by anyone with the URL.
+    let all = DBRepositoryWithStorageName::get_all(site.as_ref()).await?;
+    let mut repositories = Vec::with_capacity(all.len());
+    for repository in all {
+        let visible = match repository.visibility {
+            Visibility::Public => true,
+            Visibility::Private | Visibility::Hidden => {
+                auth.has_action(RepositoryActions::Read, repository.id, site.as_ref())
+                    .await?
+            }
+        };
+        if visible {
+            repositories.push(repository);
+        }
+    }
     Ok(ResponseBuilder::ok().json(&repositories))
 }
 #[derive(Debug, Clone, Copy, Deserialize, IntoParams)]

--- a/nitro_repo/src/app/api/repository/management.rs
+++ b/nitro_repo/src/app/api/repository/management.rs
@@ -11,7 +11,10 @@ use http::StatusCode;
 use nr_core::{
     database::entities::repository::{DBRepository, GenericDBRepositoryConfig},
     repository::Visibility,
-    user::permissions::{HasPermissions, RepositoryActions},
+    user::{
+        permissions::{HasPermissions, RepositoryActions},
+        scopes::NRScope,
+    },
 };
 use serde::Deserialize;
 use serde_json::Value;
@@ -22,6 +25,7 @@ use uuid::Uuid;
 use crate::{
     app::{
         NitroRepo,
+        api::require_scope,
         authentication::{Authentication, AuthenticationError},
         responses::{InvalidRepositoryConfig, MissingPermission, RepositoryNotFound},
     },
@@ -67,6 +71,9 @@ pub async fn new_repository(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_system_manager() {
         return Ok(MissingPermission::RepositoryManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::CreateRepository, &site).await? {
+        return Ok(denied);
     }
     let NewRepositoryRequest {
         name,
@@ -174,7 +181,14 @@ pub async fn get_config(
     Query(params): Query<GetConfigParams>,
     Path((repository, config)): Path<(Uuid, String)>,
 ) -> Result<Response, InternalError> {
-    let repository_visibility = Visibility::Private;
+    // Read from the database. This was `let repository_visibility = Visibility::Private;` —
+    // unconditional — so the `Hidden | Public` branch below was dead, `sanitize_for_public_view`
+    // never ran, and every non-editor got a 403 on every config read regardless of how public the
+    // repository was.
+    let Some(db_repository) = DBRepository::get_by_id(repository, site.as_ref()).await? else {
+        return Ok(RepositoryNotFound::Uuid(repository).into_response());
+    };
+    let repository_visibility = db_repository.visibility;
     let Some(config_type) = site.get_repository_config_type(&config) else {
         return Ok(InvalidRepositoryConfig::InvalidConfigType(config).into_response());
     };
@@ -241,6 +255,9 @@ pub async fn update_config(
         .await?
     {
         return Ok(MissingPermission::EditRepository(repository).into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::EditRepository, &site).await? {
+        return Ok(denied);
     }
     let Some(config_type) = site.get_repository_config_type(&config_key) else {
         return Ok(InvalidRepositoryConfig::InvalidConfigType(config_key).into_response());
@@ -309,6 +326,9 @@ pub async fn delete_repository(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_system_manager() {
         return Ok(MissingPermission::RepositoryManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::DeleteRepository, &site).await? {
+        return Ok(denied);
     }
     let Some(db_repository) = DBRepository::get_by_id(repository, site.as_ref()).await? else {
         return Ok(RepositoryNotFound::Uuid(repository).into_response());

--- a/nitro_repo/src/app/api/storage.rs
+++ b/nitro_repo/src/app/api/storage.rs
@@ -7,7 +7,7 @@ use axum::{
 use nr_core::{
     database::entities::storage::{DBStorage, DBStorageNoConfig, NewDBStorage, StorageDBType},
     storage::StorageName,
-    user::permissions::HasPermissions,
+    user::{permissions::HasPermissions, scopes::NRScope},
 };
 use nr_storage::{StorageConfig, StorageTypeConfig, fs_v2::FileSystemV2Config, local::LocalConfig};
 use serde::{Deserialize, Serialize};
@@ -19,6 +19,7 @@ mod s3;
 use crate::{
     app::{
         NitroRepo,
+        api::require_scope,
         authentication::Authentication,
         responses::{InvalidStorageConfig, InvalidStorageType, MissingPermission},
     },
@@ -83,6 +84,9 @@ pub async fn list_storages(
     if !auth.is_admin_or_system_manager() {
         return Ok(MissingPermission::StorageManager.into_response());
     }
+    if let Some(denied) = require_scope(&auth, NRScope::ReadStorage, &site).await? {
+        return Ok(denied);
+    }
     if request.include_config {
         let storages = DBStorage::get_all(&site.database).await?;
         Ok(ResponseBuilder::ok().json(&storages))
@@ -120,6 +124,9 @@ pub async fn new_storage(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_system_manager() {
         return Ok(MissingPermission::StorageManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::ManageStorage, &site).await? {
+        return Ok(denied);
     }
     if !DBStorage::is_name_available(&request.name, site.as_ref()).await? {
         return Ok(ConflictResponse::from("name").into_response());
@@ -178,6 +185,9 @@ pub async fn get_storage(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_system_manager() {
         return Ok(MissingPermission::StorageManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::ReadStorage, &site).await? {
+        return Ok(denied);
     }
     let storage = DBStorage::get_by_id(id, &site.database).await?;
     match storage {

--- a/nitro_repo/src/app/api/user.rs
+++ b/nitro_repo/src/app/api/user.rs
@@ -22,7 +22,10 @@ use nr_core::{
         auth_token::{AuthTokenRepositoryScope, AuthTokenScope},
         permissions::FullUserPermissions,
     },
-    user::token::{AuthTokenFullResponse, AuthTokenResponse},
+    user::{
+        scopes::NRScope,
+        token::{AuthTokenFullResponse, AuthTokenResponse},
+    },
 };
 use serde::{Deserialize, Serialize};
 use tracing::instrument;
@@ -32,6 +35,7 @@ mod tokens;
 use crate::{
     app::{
         NitroRepo,
+        api::require_scope,
         authentication::{
             Authentication, MeWithSession,
             password::{self, verify_password},
@@ -40,6 +44,7 @@ use crate::{
         },
     },
     error::InternalError,
+    utils::ResponseBuilder,
 };
 #[derive(OpenApi)]
 #[openapi(
@@ -118,6 +123,9 @@ pub async fn me_permissions(
     auth: Authentication,
     State(site): State<NitroRepo>,
 ) -> Result<Response, InternalError> {
+    if let Some(denied) = require_scope(&auth, NRScope::ReadSelf, &site).await? {
+        return Ok(denied);
+    }
     let Some(user) = FullUserPermissions::get_by_id(auth.get_id(), site.as_ref()).await? else {
         return Ok(Response::builder()
             .status(http::StatusCode::NOT_FOUND)
@@ -138,11 +146,15 @@ pub async fn me_permissions(
         ("session" = [])
     )
 )]
-pub async fn whoami(auth: Authentication) -> Json<UserSafeData> {
-    match auth {
-        Authentication::AuthToken(_, user) => Json(user),
-        Authentication::Session(_, user) => Json(user),
+pub async fn whoami(
+    auth: Authentication,
+    State(site): State<NitroRepo>,
+) -> Result<Response, InternalError> {
+    if let Some(denied) = require_scope(&auth, NRScope::ReadSelf, &site).await? {
+        return Ok(denied);
     }
+    let user: &UserSafeData = &auth;
+    Ok(ResponseBuilder::ok().json(user))
 }
 #[utoipa::path(
     get,

--- a/nitro_repo/src/app/api/user/tokens.rs
+++ b/nitro_repo/src/app/api/user/tokens.rs
@@ -31,6 +31,34 @@ pub fn token_routes() -> axum::Router<NitroRepo> {
         .route("/list", get(list))
         .route("/get/{id}", get(get_token))
         .route("/delete/{id}", delete(delete_token))
+        .route("/revoke-all", delete(revoke_all))
+}
+
+/// Revokes every token belonging to the caller.
+///
+/// There was no way to do this. After a leak the only recourse was deleting tokens one at a time
+/// through the UI, and only the ones you could still see.
+#[utoipa::path(
+    delete,
+    path = "/token/revoke-all",
+    responses(
+        (status = 200, description = "How many tokens were revoked", body = RevokedTokensResponse),
+    ),
+)]
+#[instrument]
+async fn revoke_all(
+    auth: OnlySessionAllowedAuthentication,
+    State(site): State<NitroRepo>,
+) -> Result<Response, InternalError> {
+    // A session is required for this route, so the token being used cannot revoke itself out from
+    // under the request.
+    let revoked = AuthToken::delete_all_for_user(auth.get_id(), site.as_ref()).await?;
+    Ok(ResponseBuilder::ok().json(&RevokedTokensResponse { revoked }))
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct RevokedTokensResponse {
+    pub revoked: u64,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
@@ -41,6 +69,12 @@ pub struct NewAuthTokenRequest {
     pub scopes: Vec<NRScope>,
     #[serde(default)]
     pub repository_scopes: Vec<NewRepositoryScope>,
+    /// How many days until the token stops working. Omit for a token that never expires.
+    ///
+    /// The column has always existed; nothing ever wrote it, and the profile UI showed a disabled
+    /// field reading "Not implemented".
+    #[serde(default)]
+    pub expires_in_days: Option<i64>,
 }
 #[derive(Debug, Serialize, Deserialize, ToSchema)]
 pub struct NewRepositoryScope {
@@ -73,6 +107,14 @@ async fn create(
             .body("No Scopes Provided".into())
             .unwrap());
     }
+    let expires_at = match new_token.expires_in_days {
+        Some(days) if days <= 0 => {
+            return Ok(ResponseBuilder::bad_request()
+                .body("Expiry must be at least one day in the future"));
+        }
+        Some(days) => Some(chrono::Local::now().fixed_offset() + chrono::Duration::days(days)),
+        None => None,
+    };
     let repositories: Vec<(Uuid, Vec<RepositoryActions>)> = new_token
         .repository_scopes
         .into_iter()
@@ -85,6 +127,7 @@ async fn create(
         source,
         scopes: new_token.scopes,
         repositories,
+        expires_at,
     };
     let (id, token) = new_token.insert(site.as_ref()).await?;
     let response = NewAuthTokenResponse { id, token };

--- a/nitro_repo/src/app/api/user_management.rs
+++ b/nitro_repo/src/app/api/user_management.rs
@@ -6,12 +6,13 @@ use axum::{
 use http::StatusCode;
 use nr_core::{
     database::entities::user::{
-        ChangePasswordNoCheck, NewUserRequest, UserSafeData, UserType as _,
+        ChangePasswordNoCheck, NewUserRequest, UserSafeData, UserType as _, auth_token::AuthToken,
         permissions::FullUserPermissions, user_utils,
     },
     user::{
         Email, Username,
         permissions::{HasPermissions, UpdatePermissions},
+        scopes::NRScope,
     },
 };
 use serde::Deserialize;
@@ -21,6 +22,7 @@ use utoipa::{OpenApi, ToSchema};
 use crate::{
     app::{
         NitroRepo,
+        api::require_scope,
         authentication::{Authentication, password},
         responses::MissingPermission,
     },
@@ -36,7 +38,8 @@ use crate::{
         create_user,
         is_taken,
         update_permissions,
-        update_password
+        update_password,
+        revoke_user_tokens
     ),
     components(schemas(IsTaken, UpdatePermissions))
 )]
@@ -59,6 +62,10 @@ pub fn user_management_routes() -> axum::Router<NitroRepo> {
             "/update/{user_id}/password",
             axum::routing::put(update_password),
         )
+        .route(
+            "/{user_id}/tokens/revoke-all",
+            axum::routing::delete(revoke_user_tokens),
+        )
 }
 #[utoipa::path(
     get,
@@ -74,6 +81,9 @@ pub async fn list_users(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_user_manager() {
         return Ok(MissingPermission::UserManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::ReadUser, &site).await? {
+        return Ok(denied);
     }
     let users = UserSafeData::get_all(&site.database).await?;
     Ok(Json(users).into_response())
@@ -93,6 +103,9 @@ pub async fn get_user(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_user_manager() {
         return Ok(MissingPermission::UserManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::ReadUser, &site).await? {
+        return Ok(denied);
     }
     let Some(user) = UserSafeData::get_by_id(user_id, &site.database).await? else {
         return Ok(Response::builder()
@@ -119,6 +132,9 @@ pub async fn get_user_permissions(
     if !auth.is_admin_or_user_manager() {
         return Ok(MissingPermission::UserManager.into_response());
     }
+    if let Some(denied) = require_scope(&auth, NRScope::ReadUser, &site).await? {
+        return Ok(denied);
+    }
     let Some(user) = FullUserPermissions::get_by_id(user_id, site.as_ref()).await? else {
         return Ok(ResponseBuilder::not_found()
             .error_reason("User not found")
@@ -141,6 +157,9 @@ pub async fn create_user(
 ) -> Result<Response, InternalError> {
     if !auth.is_admin_or_user_manager() {
         return Ok(MissingPermission::UserManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::CreateUser, &site).await? {
+        return Ok(denied);
     }
     if user_utils::is_username_taken(&user.username, &site.database).await? {
         return Ok(ConflictResponse::from("username").into_response());
@@ -228,6 +247,9 @@ pub async fn update_permissions(
     if !auth.is_admin_or_user_manager() {
         return Ok(MissingPermission::UserManager.into_response());
     }
+    if let Some(denied) = require_scope(&auth, NRScope::EditUser, &site).await? {
+        return Ok(denied);
+    }
     let Some(user) = UserSafeData::get_by_id(user_id, &site.database).await? else {
         return Ok(ResponseBuilder::not_found()
             .error_reason("User not found")
@@ -257,6 +279,9 @@ pub async fn update_password(
     if !auth.is_admin_or_user_manager() {
         return Ok(MissingPermission::UserManager.into_response());
     }
+    if let Some(denied) = require_scope(&auth, NRScope::EditUser, &site).await? {
+        return Ok(denied);
+    }
     let Some(user) = UserSafeData::get_by_id(user_id, &site.database).await? else {
         return Ok(ResponseBuilder::not_found()
             .error_reason("User not found")
@@ -273,4 +298,43 @@ pub struct AdminUpdateUserRequest {
     pub username: Option<String>,
     pub email: Option<String>,
     pub name: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize, Deserialize, ToSchema)]
+pub struct RevokedTokensResponse {
+    pub revoked: u64,
+}
+
+/// Revokes every API token belonging to a user.
+///
+/// The admin surface had no way to do this — "revoke" appeared nowhere in the codebase — so a
+/// leaked token could only be dealt with by the user who owned it, assuming they still could.
+#[utoipa::path(
+    delete,
+    path = "/{user_id}/tokens/revoke-all",
+    responses(
+        (status = 200, description = "How many tokens were revoked", body = RevokedTokensResponse),
+        (status = 404, description = "User not found"),
+    )
+)]
+#[instrument]
+pub async fn revoke_user_tokens(
+    auth: Authentication,
+    State(site): State<NitroRepo>,
+    Path(user_id): Path<i32>,
+) -> Result<Response, InternalError> {
+    if !auth.is_admin_or_user_manager() {
+        return Ok(MissingPermission::UserManager.into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::EditUser, &site).await? {
+        return Ok(denied);
+    }
+    let Some(user) = UserSafeData::get_by_id(user_id, &site.database).await? else {
+        return Ok(ResponseBuilder::not_found()
+            .error_reason("User not found")
+            .empty());
+    };
+    let revoked = AuthToken::delete_all_for_user(user.id, site.as_ref()).await?;
+    tracing::info!(?user_id, revoked, "Revoked every token for a user");
+    Ok(ResponseBuilder::ok().json(&RevokedTokensResponse { revoked }))
 }

--- a/nitro_repo/src/app/authentication/mod.rs
+++ b/nitro_repo/src/app/authentication/mod.rs
@@ -191,6 +191,36 @@ impl Deref for Authentication {
         }
     }
 }
+impl Authentication {
+    /// Whether this caller may perform an action requiring `scope`.
+    ///
+    /// A scope is a ceiling on what a *token* may do, not a grant. A session is the user acting
+    /// directly through the UI, so it is bounded only by their permissions — asking a browser
+    /// session to also carry scopes would mean the UI could do less than the user can.
+    ///
+    /// Nothing outside repository access consulted scopes at all before this, so a token minted to
+    /// let CI publish one artifact could equally delete repositories, create users and rewrite
+    /// system settings.
+    pub async fn has_scope(
+        &self,
+        scope: nr_core::user::scopes::NRScope,
+        database: &PgPool,
+    ) -> Result<bool, AuthenticationError> {
+        match self {
+            Authentication::Session(_, _) => Ok(true),
+            Authentication::AuthToken(token, _) => Ok(token.has_scope(scope, database).await?),
+        }
+    }
+
+    /// The `AuthToken` behind this authentication, if it came from one.
+    pub fn auth_token(&self) -> Option<&AuthToken> {
+        match self {
+            Authentication::AuthToken(token, _) => Some(token),
+            Authentication::Session(_, _) => None,
+        }
+    }
+}
+
 impl HasPermissions for Authentication {
     fn user_id(&self) -> Option<i32> {
         match self {
@@ -397,6 +427,11 @@ pub async fn get_user_and_auth_token(
     let user = UserSafeData::get_by_id(auth_token.user_id, database)
         .await?
         .ok_or(AuthenticationError::Unauthorized)?;
+    // Best effort, and deliberately not fatal: failing to record that a token was used is not a
+    // reason to refuse a request that is otherwise authenticated.
+    if let Err(error) = auth_token.touch_last_used(database).await {
+        warn!(?error, "Failed to record token usage");
+    }
     Ok((user, auth_token))
 }
 pub mod password {

--- a/nitro_repo/src/app/responses/mod.rs
+++ b/nitro_repo/src/app/responses/mod.rs
@@ -42,6 +42,12 @@ pub enum MissingPermission {
     ReadRepository(uuid::Uuid),
     WriteRepository(uuid::Uuid),
     StorageManager,
+    /// The user is allowed to do this, but the token they used is not.
+    ///
+    /// Kept distinct from the permission failures above because the fix is different: the caller
+    /// needs a new token, not a new role, and saying "forbidden" without that detail sends people
+    /// looking in the wrong place.
+    Scope(nr_core::user::scopes::NRScope),
 }
 impl IntoResponse for MissingPermission {
     #[inline(always)]
@@ -80,6 +86,12 @@ impl IntoResponse for MissingPermission {
             Self::StorageManager => Response::builder()
                 .status(StatusCode::FORBIDDEN)
                 .body(Body::from("You are not a storage manager or admin"))
+                .unwrap(),
+            Self::Scope(scope) => Response::builder()
+                .status(StatusCode::FORBIDDEN)
+                .body(Body::from(format!(
+                    "The token used does not carry the `{scope}` scope"
+                )))
                 .unwrap(),
         }
     }

--- a/site/src/components/form/NumberInput.vue
+++ b/site/src/components/form/NumberInput.vue
@@ -13,12 +13,12 @@ import "@/assets/styles/form.scss";
 defineProps({
   id: String,
 });
-const value = defineModel<number>({
-  required: true,
-});
+// Optional, so this can back a field that may legitimately be left blank.
+const value = defineModel<number | undefined>();
 </script>
 
 <style scoped lang="scss">
-@import "@/assets/styles/variables.scss";
+// This used to also `@import "@/assets/styles/variables.scss"`, which does not exist. The build
+// only survived because nothing imported this component; referencing it broke the build.
 @import "@/assets/styles/form.scss";
 </style>

--- a/site/src/main.ts
+++ b/site/src/main.ts
@@ -48,14 +48,28 @@ const app = createApp(App);
 const vfm = createVfm();
 router.beforeEach((to) => {
   const store = sessionStore(pinia);
-  if (to.meta.requiresAuth && store.session === undefined) {
-    return {
-      name: "login",
-    };
-  } else if (to.meta.requiresIdentity === true && store.session === undefined) {
-    return {
-      name: "login",
-    };
+  const signedIn = store.session !== undefined;
+  if ((to.meta.requiresAuth || to.meta.requiresIdentity === true) && !signedIn) {
+    // Carry where they were going, so signing in lands them there rather than on the home page.
+    return { name: "login", query: { redirect: to.fullPath } };
+  }
+  // `requiresUserManager` and `requiresRepositoryManager` were declared on routes and in the
+  // `RouteMeta` augmentation, and nothing ever read them — every admin route rendered for any
+  // signed-in user. The server is still the real check; this stops the UI from offering pages it
+  // knows will be refused.
+  if (to.meta.requiresUserManager || to.meta.requiresRepositoryManager) {
+    if (!signedIn) {
+      return { name: "login", query: { redirect: to.fullPath } };
+    }
+    const user = store.user;
+    const permitted =
+      user !== undefined &&
+      (user.admin ||
+        (to.meta.requiresUserManager === true && user.user_manager) ||
+        (to.meta.requiresRepositoryManager === true && user.system_manager));
+    if (!permitted) {
+      return { name: "home" };
+    }
   }
 });
 

--- a/site/src/types/user/token.ts
+++ b/site/src/types/user/token.ts
@@ -9,6 +9,8 @@ export interface RawAuthTokenResponse {
   active: boolean;
   source: string;
   expires_at?: string;
+  /** When the token last authenticated a request. Recorded at most once an hour. */
+  last_used_at?: string;
   created_at: string;
 }
 
@@ -38,4 +40,15 @@ export interface NewAuthTokenResponse {
 export interface NewAuthTokenRepositoryScope {
   repositoryId: string;
   actions: RepositoryActionsType;
+}
+
+/**
+ * The shape the API actually accepts for a repository scope.
+ *
+ * The create form was sending `{ repository_string, actions }`, which has neither field the server
+ * looks for, so any token created with a repository scope was rejected as a bad request.
+ */
+export interface NewAuthTokenRepositoryScopeRequest {
+  repository_id: string;
+  scopes: Array<RepositoryActions>;
 }

--- a/site/src/views/profile/ProfileTokens.vue
+++ b/site/src/views/profile/ProfileTokens.vue
@@ -1,5 +1,15 @@
 <template>
   <main>
+    <div class="header">
+      <h1>API Tokens</h1>
+      <SubmitButton
+        v-if="authTokens.length > 0"
+        class="dangerButton"
+        @click="revokeAll"
+        >Revoke all tokens</SubmitButton
+      >
+    </div>
+    <p v-if="authTokens.length === 0">You have no API tokens.</p>
     <ul class="tokenList">
       <li
         v-for="token in authTokens"
@@ -12,16 +22,53 @@
           <KeyAndValue
             label="Name"
             :value="token.token.name || 'No name'" />
-
           <KeyAndValue
             label="Source"
             :value="token.token.source" />
           <KeyAndValue
             label="Created On"
-            :value="new Date(token.token.created_at).toLocaleDateString()" />
+            :value="formatDate(token.token.created_at)" />
+          <KeyAndValue
+            label="Expires"
+            :value="expiryLabel(token.token)" />
+          <KeyAndValue
+            label="Last Used"
+            :value="token.token.last_used_at ? formatDate(token.token.last_used_at) : 'Never'" />
         </div>
-        <div v-if="expandedToken == token.token.id">
-          <SubmitButton @click="deleteToken(token.token.id)">Delete</SubmitButton>
+        <div
+          v-if="expandedToken == token.token.id"
+          class="tokenDetail">
+          <div v-if="token.token.description">
+            <h3>Description</h3>
+            <p>{{ token.token.description }}</p>
+          </div>
+          <div>
+            <h3>Scopes</h3>
+            <ul
+              v-if="token.scopes.length > 0"
+              class="scopeList">
+              <li
+                v-for="scope in token.scopes"
+                :key="scope.id">
+                {{ scopeLabel(scope.scope) }}
+              </li>
+            </ul>
+            <p v-else>No account-wide scopes.</p>
+          </div>
+          <div>
+            <h3>Repository Access</h3>
+            <ul
+              v-if="token.repository_scopes.length > 0"
+              class="scopeList">
+              <li
+                v-for="repositoryScope in token.repository_scopes"
+                :key="repositoryScope.id">
+                {{ repositoryScope.repository_id }} — {{ repositoryScope.actions.join(", ") }}
+              </li>
+            </ul>
+            <p v-else>No repository-specific access.</p>
+          </div>
+          <SubmitButton @click.stop="deleteToken(token.token.id)">Delete</SubmitButton>
         </div>
       </li>
     </ul>
@@ -32,51 +79,103 @@ import KeyAndValue from "@/components/form/KeyAndValue.vue";
 import SubmitButton from "@/components/form/SubmitButton.vue";
 import http from "@/http";
 import { sessionStore } from "@/stores/session";
-import { type RawAuthTokenFullResponse } from "@/types/user/token";
+import type { ScopeDescription } from "@/types/base";
+import { type RawAuthTokenFullResponse, type RawAuthTokenResponse } from "@/types/user/token";
+import { notify } from "@kyvg/vue3-notification";
 import { ref } from "vue";
 
 const session = sessionStore();
 const user = session.user;
 const authTokens = ref<Array<RawAuthTokenFullResponse>>([]);
+const scopeDescriptions = ref<Array<ScopeDescription>>([]);
 const expandedToken = ref<number | undefined>(undefined);
+
 function tokenClicked(tokenId: number) {
-  if (expandedToken.value == tokenId) {
-    expandedToken.value = undefined;
-  } else {
-    expandedToken.value = tokenId;
-  }
+  expandedToken.value = expandedToken.value == tokenId ? undefined : tokenId;
 }
+function formatDate(value: string): string {
+  return new Date(value).toLocaleString();
+}
+// The API returns scopes, expiry and last-used for every token; none of it was displayed, which
+// left no way to tell what a token could do or whether it was still in use.
+function expiryLabel(token: RawAuthTokenResponse): string {
+  if (!token.expires_at) {
+    return "Never";
+  }
+  const expires = new Date(token.expires_at);
+  return expires.getTime() < Date.now()
+    ? `Expired ${formatDate(token.expires_at)}`
+    : formatDate(token.expires_at);
+}
+function scopeLabel(key: string): string {
+  return scopeDescriptions.value.find((scope) => scope.key === key)?.name ?? key;
+}
+
 async function deleteToken(id: number) {
   await http
     .delete(`/api/user/token/delete/${id}`)
-    .then(() => {
+    .then(() => getAuthTokens())
+    .catch((error) => console.error(error));
+}
+async function revokeAll() {
+  if (
+    !window.confirm(
+      "Revoke every API token on your account? Anything using one — CI, a local `mvn` or `npm` — stops working immediately.",
+    )
+  ) {
+    return;
+  }
+  await http
+    .delete<{ revoked: number }>("/api/user/token/revoke-all")
+    .then((response) => {
+      notify({
+        type: "success",
+        title: "Tokens revoked",
+        text: `${response.data.revoked} token(s) revoked.`,
+      });
       getAuthTokens();
     })
     .catch((error) => {
-      console.log(error);
+      console.error(error);
+      notify({
+        type: "error",
+        title: "Could not revoke tokens",
+        text: "An error occurred while revoking your tokens.",
+      });
     });
 }
 async function getAuthTokens() {
   if (user == undefined) {
     return;
   }
-
   await http
     .get<Array<RawAuthTokenFullResponse>>("/api/user/token/list")
     .then((response) => {
-      console.log(response.data);
       authTokens.value = response.data;
     })
-    .catch((error) => {
-      console.log(error);
-    });
+    .catch((error) => console.error(error));
+}
+async function getScopeDescriptions() {
+  await http
+    .get<Array<ScopeDescription>>("/api/info/scopes")
+    .then((response) => {
+      scopeDescriptions.value = response.data;
+    })
+    .catch((error) => console.error(error));
 }
 getAuthTokens();
+getScopeDescriptions();
 </script>
 
 <style scoped lang="scss">
 main {
   padding: 1rem;
+}
+.header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 .tokenList {
   list-style: none;
@@ -89,11 +188,21 @@ main {
 }
 .tokenElementLine {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr;
+  grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
   padding: 0.5rem;
   gap: 1rem;
   &:hover {
     cursor: pointer;
   }
+}
+.tokenDetail {
+  padding: 0 0.5rem 0.5rem;
+  h3 {
+    margin-bottom: 0.25rem;
+  }
+}
+.scopeList {
+  margin: 0;
+  padding-left: 1.25rem;
 }
 </style>

--- a/site/src/views/profile/TokenCreate.vue
+++ b/site/src/views/profile/TokenCreate.vue
@@ -16,12 +16,12 @@
           </TextInput>
         </div>
         <div class="column">
-          <TextInput
+          <NumberInput
             id="tokenExpiration"
-            v-model="newToken.tokenExpiration"
-            :disabled="true"
-            placeholder="Not implemented"
-            >Token Expiration</TextInput
+            v-model="newToken.expiresInDays"
+            :min="1"
+            placeholder="Leave empty for a token that never expires"
+            >Expires after (days)</NumberInput
           >
         </div>
       </div>
@@ -38,7 +38,7 @@
   </main>
   <main v-else>
     <CopyCode :code="newResponseTokenResponse.token"
-      >Your Token. Save not or its gone forever</CopyCode
+      >Your token. Copy it now — it is not shown again.</CopyCode
     >
   </main>
 </template>
@@ -47,46 +47,48 @@ import CopyCode from "@/components/core/code/CopyCode.vue";
 import ScopesSelector from "@/components/form/ScopesSelector.vue";
 import SubmitButton from "@/components/form/SubmitButton.vue";
 import TextInput from "@/components/form/text/TextInput.vue";
+import NumberInput from "@/components/form/NumberInput.vue";
 import RepositoryToActionList from "@/components/nr/repository/RepositoryToActionList.vue";
 import http from "@/http";
-import type { RepositoryActions, ScopeDescription } from "@/types/base";
+import type { ScopeDescription } from "@/types/base";
 import type { RepositoryToActions } from "@/types/repository";
-import { type NewAuthTokenResponse } from "@/types/user/token";
+import {
+  type NewAuthTokenRepositoryScopeRequest,
+  type NewAuthTokenResponse,
+} from "@/types/user/token";
 import { notify } from "@kyvg/vue3-notification";
 import { ref } from "vue";
-const newToken = ref({
+const newToken = ref<{
+  tokenName: string;
+  tokenDescription: string;
+  expiresInDays: number | undefined;
+}>({
   tokenName: "",
   tokenDescription: "",
-  tokenExpiration: "",
+  expiresInDays: undefined,
 });
 const newResponseTokenResponse = ref<NewAuthTokenResponse | undefined>(undefined);
 const repositoryScopes = ref<Array<RepositoryToActions>>([]);
 const scopes = ref<Array<ScopeDescription>>([]);
 async function createToken() {
-  const repositoryScopesRequest = [] as Array<{
-    repository_string: string;
-    actions: Array<RepositoryActions>;
-  }>;
-  for (const repositoryScope of repositoryScopes.value) {
-    repositoryScopesRequest.push({
-      repository_string: repositoryScope.repositoryId,
-      actions: repositoryScope.actions.asArray(),
-    });
-  }
+  // `repository_string`/`actions` are not the field names the API reads — it wants
+  // `repository_id`/`scopes` — so a token created with any repository scope was rejected outright.
+  const repositoryScopesRequest: Array<NewAuthTokenRepositoryScopeRequest> =
+    repositoryScopes.value.map((repositoryScope) => ({
+      repository_id: repositoryScope.repositoryId,
+      scopes: repositoryScope.actions.asArray(),
+    }));
   const scopesRequest = scopes.value.map((scope) => scope.key);
-  console.log(`Creating Token with Repository scopes ${JSON.stringify(repositoryScopesRequest)}`);
-  console.log(`Creating Token with Scopes ${JSON.stringify(scopesRequest)}`);
   const request = {
     name: newToken.value.tokenName,
     description: newToken.value.tokenDescription,
     repository_scopes: repositoryScopesRequest,
     scopes: scopesRequest,
+    expires_in_days: newToken.value.expiresInDays,
   };
-  console.log(`Creating Token with Request ${JSON.stringify(request)}`);
   await http
     .post<NewAuthTokenResponse>("/api/user/token/create", request)
     .then((response) => {
-      console.log(response.data);
       newResponseTokenResponse.value = response.data;
       notify({
         type: "success",


### PR DESCRIPTION
Closes #505. **SSO and TOTP (#475) follow in a separate PR** — they are a large self-contained feature and mixing them in would make neither reviewable.

## Scopes barely existed

Four: `ReadRepository`, `WriteRepository`, `EditRepository`, `UpdatePassword`. Nothing outside repository access consulted a scope **at all** — so a token minted to let CI publish one artifact could equally delete repositories, create users, rewrite storage settings and read every profile on the instance. The only thing in the way was the underlying user permission, which for an admin is nothing.

Sixteen now, grouped by what they touch, enforced at every route that has a permission check. Two properties worth stating explicitly:

- **A scope is a ceiling, not a grant.** Holding one still requires the user behind the token to have the permission, which is why offering an administrative scope to everyone is safe — a non-admin's token carrying `DeleteRepository` still cannot delete anything.
- **A session is bounded only by permissions.** Asking the browser UI to also carry scopes would mean it could do less than the user can.

The variant names are what gets written to `user_auth_token_scopes`, so renaming one silently invalidates every token carrying it. The four that shipped are pinned by a test.

## Bugs found while wiring it up

**An expired token still authenticated.** `expires_at` has been on the table since the schema was written and `get_by_token` never looked at it. The password-reset table next door does this correctly, which is what makes the omission easy to miss. There was also no way to *set* an expiry — the insert never wrote the column and the create form showed a disabled field reading "Not implemented".

**Every private repository was listed to anonymous callers.** The filter in `list_repositories` returned `true` in *both* arms, so it did nothing; names, storage names and visibility went to anyone who asked.

**Repository scopes on token creation had never worked.** The form posts `repository_string`/`actions`; the API reads `repository_id`/`scopes`. Any token created with a repository scope was rejected as a bad request.

**`find_by_id_and_user_id` was missing an `AND`** — `WHERE id = $1 user_id = $2` is not valid SQL, so fetching a single token always failed at the database.

**`get_config` hardcoded `Visibility::Private`**, making the Hidden/Public branch below it dead code — `sanitize_for_public_view` never ran and every non-editor got a 403 on every config read, however public the repository was. Visibility now comes from the database, and `RepositoryPageType` implements sanitization, since a landing page is written to be read.

**`ScopeDescription`'s `requires_admin`/`requires_user_manager`/`requires_system`** were filled from `Default` by the derive, so all three were always `false` and the UI could not distinguish an administrative scope. The macro emits them now.

## Token management

- **Revoke all tokens**, for yourself and — for an admin — for any user. "revoke" appeared nowhere in the codebase, so a leaked token could only be dealt with by its owner, assuming they still could.
- **Last-used tracking**, written at most once an hour so an authenticated read does not become a write against a hot row.
- The profile page now shows **scopes, expiry and last-used** — all already returned by the API, none of it displayed.

## Frontend guards

`requiresUserManager` and `requiresRepositoryManager` were declared on routes *and* in the `RouteMeta` augmentation, and read by nothing — every admin page rendered for any signed-in user. The server is still the real check; the guard stops the UI offering pages it knows will be refused.

Also fixed `NumberInput.vue`, which imported a `variables.scss` that does not exist. The build only survived because nothing referenced it; using it broke the build.

## Stale TODO removed

`// TODO: Secure this` on token generation. Generation has been 32 alphanumeric characters from OS entropy, SHA-256 hashed at rest, for some time — left in place the comment read as an open hole.

## Breaking

A token calling `/api/user/whoami` or `/api/user/me/permissions` now needs `ReadSelf`; one touching user management, storage, or repository create/delete needs the matching scope. Existing tokens keep working for everything they could already do through the repository routes (Maven/npm publish and fetch are unaffected).

## Verification
- `cargo test --all` with `STORAGE_TESTS_REQUIRE_ALL=1` and MinIO up — 88 passing
- `cargo clippy --all --all-targets -- -D warnings` clean
- `cargo +nightly fmt --all --check` clean
- `npm run type-check`, `npm run lint`, `npm run build` clean

The scope enforcement is not yet covered by per-route tests — that needs the request harness from Phase 8, which is where a "does this route actually reject a token without the scope" test belongs.