### PR TITLE
Artifact search: a query language, and the #506 repository improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
  "md-5 0.10.6",
  "mime",
  "mime_guess",
+ "nr-aql",
  "nr-core",
  "nr-macros",
  "nr-storage",
@@ -2948,6 +2949,16 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "nr-aql"
+version = "2.0.0-BETA"
+dependencies = [
+ "pretty_assertions",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.19",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ rand = "0.9"
 nr-core = { path = "crates/core" }
 nr-macros = { path = "crates/macros" }
 nr-storage = { path = "crates/storage" }
+nr-aql = { path = "crates/aql" }
 # Rust Utilities
 futures = "0.3"
 derive_more = { version = "2.0", features = [

--- a/crates/aql/Cargo.toml
+++ b/crates/aql/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "nr-aql"
+description = "The artifact query language nitro-repo searches with"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+# Deliberately minimal. #411 asks for this to be pushed out as a separate library, and a query
+# language that drags in a web framework or a database driver cannot be.
+serde = { workspace = true }
+thiserror = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = "1"
+serde_json = { workspace = true }

--- a/crates/aql/src/ast.rs
+++ b/crates/aql/src/ast.rs
@@ -1,0 +1,203 @@
+//! The typed syntax tree a query parses into.
+//!
+//! Values are held as `Value`, never as raw text spliced into a statement. That is what lets the
+//! SQL compiler bind every one of them as a parameter — a query language that reaches a database
+//! and builds its predicates by string concatenation is an injection hole by construction.
+use serde::Serialize;
+
+use crate::lexer::Operator;
+
+/// A field a query can filter on.
+///
+/// A closed set on purpose. An open one would mean either trusting a caller-supplied column name
+/// or maintaining a second allow-list somewhere further from the parser.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Field {
+    /// The repository's name.
+    Repository,
+    /// The storage the repository lives in.
+    Storage,
+    /// The full project key — `dev.kingtux:tms` for Maven, `@scope/pkg` for npm.
+    Project,
+    /// The project's scope: a Maven `groupId`, an npm scope.
+    Scope,
+    /// The project's name, without its scope.
+    Name,
+    /// The project's description.
+    Description,
+    /// A version string.
+    Version,
+    /// `Stable`, `Snapshot`, `Unknown`.
+    ReleaseType,
+    /// When a version was first published.
+    Created,
+    /// When a version was last updated.
+    Updated,
+}
+
+impl Field {
+    pub fn parse(name: &str) -> Option<Self> {
+        // Aliases exist because the same concept is called different things by different
+        // ecosystems, and a user should not have to know which one this codebase settled on.
+        let field = match name.to_ascii_lowercase().as_str() {
+            "repository" | "repo" => Field::Repository,
+            "storage" => Field::Storage,
+            "project" | "project_key" | "key" => Field::Project,
+            "scope" | "group" | "groupid" => Field::Scope,
+            "name" | "artifact" | "artifactid" => Field::Name,
+            "description" => Field::Description,
+            "version" => Field::Version,
+            "release_type" | "releasetype" | "type" => Field::ReleaseType,
+            "created" | "created_at" => Field::Created,
+            "updated" | "updated_at" => Field::Updated,
+            _ => return None,
+        };
+        Some(field)
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Field::Repository => "repository",
+            Field::Storage => "storage",
+            Field::Project => "project",
+            Field::Scope => "scope",
+            Field::Name => "name",
+            Field::Description => "description",
+            Field::Version => "version",
+            Field::ReleaseType => "release_type",
+            Field::Created => "created",
+            Field::Updated => "updated",
+        }
+    }
+
+    /// Every field a caller may use, for error messages and for the UI's autocomplete.
+    pub fn all() -> &'static [Field] {
+        &[
+            Field::Repository,
+            Field::Storage,
+            Field::Project,
+            Field::Scope,
+            Field::Name,
+            Field::Description,
+            Field::Version,
+            Field::ReleaseType,
+            Field::Created,
+            Field::Updated,
+        ]
+    }
+
+    /// Whether the field holds a timestamp, which decides how a comparison is read.
+    pub fn is_temporal(&self) -> bool {
+        matches!(self, Field::Created | Field::Updated)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "type", content = "value", rename_all = "snake_case")]
+pub enum Value {
+    Text(String),
+    Number(i64),
+}
+
+impl Value {
+    pub fn as_text(&self) -> String {
+        match self {
+            Value::Text(text) => text.clone(),
+            Value::Number(number) => number.to_string(),
+        }
+    }
+}
+
+/// The tree a query parses into.
+///
+/// Named fields rather than tuple variants throughout, because the whole thing is serialized to
+/// the frontend for the query builder to render, and an internally tagged enum cannot carry a
+/// tuple variant.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Query {
+    /// `field <op> value`
+    Comparison {
+        field: Field,
+        operator: Operator,
+        value: Value,
+    },
+    And {
+        left: Box<Query>,
+        right: Box<Query>,
+    },
+    Or {
+        left: Box<Query>,
+        right: Box<Query>,
+    },
+    Not {
+        inner: Box<Query>,
+    },
+}
+
+impl Query {
+    pub fn and(left: Query, right: Query) -> Self {
+        Query::And {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+    pub fn or(left: Query, right: Query) -> Self {
+        Query::Or {
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+    pub fn negate(inner: Query) -> Self {
+        Query::Not {
+            inner: Box::new(inner),
+        }
+    }
+}
+
+// `Operator` is part of the serialized AST, which the frontend reads to render a query builder.
+impl Serialize for Operator {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn field_names_and_their_aliases_resolve() {
+        for (input, expected) in [
+            ("repository", Field::Repository),
+            ("repo", Field::Repository),
+            ("REPO", Field::Repository),
+            ("groupId", Field::Scope),
+            ("artifactId", Field::Name),
+            ("key", Field::Project),
+            ("created_at", Field::Created),
+        ] {
+            assert_eq!(
+                Field::parse(input),
+                Some(expected),
+                "`{input}` did not resolve"
+            );
+        }
+        assert_eq!(Field::parse("not_a_field"), None);
+    }
+
+    /// `all()` feeds the "unknown field" error and the UI's field list, so a field missing from it
+    /// is invisible to both.
+    #[test]
+    fn every_field_is_listed_and_round_trips() {
+        for field in Field::all() {
+            assert_eq!(
+                Field::parse(field.as_str()),
+                Some(*field),
+                "{field:?} does not parse from its own name"
+            );
+        }
+        assert_eq!(Field::all().len(), 10);
+    }
+}

--- a/crates/aql/src/lexer.rs
+++ b/crates/aql/src/lexer.rs
@@ -1,0 +1,369 @@
+//! Turns query text into tokens.
+//!
+//! Kept separate from the parser so a malformed query can be reported against the exact byte it
+//! went wrong at, rather than "syntax error" for the whole string.
+use std::fmt;
+
+use crate::Span;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Token {
+    /// A bare word: a field name, or an unquoted value.
+    Ident(String),
+    /// A quoted string. Quoting is what lets a value contain spaces, operators, or a leading
+    /// digit without being mistaken for something else.
+    String(String),
+    Number(i64),
+    Operator(Operator),
+    And,
+    Or,
+    Not,
+    OpenParen,
+    CloseParen,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Operator {
+    Equals,
+    NotEquals,
+    /// Glob match, `~=`. `*` stands for any run of characters and `?` for one.
+    Matches,
+    NotMatches,
+    GreaterThan,
+    GreaterThanOrEqual,
+    LessThan,
+    LessThanOrEqual,
+}
+
+impl fmt::Display for Operator {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let text = match self {
+            Operator::Equals => "==",
+            Operator::NotEquals => "!=",
+            Operator::Matches => "~=",
+            Operator::NotMatches => "!~",
+            Operator::GreaterThan => ">",
+            Operator::GreaterThanOrEqual => ">=",
+            Operator::LessThan => "<",
+            Operator::LessThanOrEqual => "<=",
+        };
+        f.write_str(text)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpannedToken {
+    pub token: Token,
+    pub span: Span,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LexError {
+    #[error("Unterminated string starting at character {0}")]
+    UnterminatedString(usize),
+    #[error("Unexpected character `{character}` at {position}")]
+    UnexpectedCharacter { character: char, position: usize },
+    #[error("`{found}` is not an operator; did you mean `{suggestion}`?")]
+    IncompleteOperator {
+        found: String,
+        suggestion: &'static str,
+    },
+}
+
+/// Splits query text into tokens.
+pub fn tokenize(input: &str) -> Result<Vec<SpannedToken>, LexError> {
+    let characters: Vec<char> = input.chars().collect();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+
+    while index < characters.len() {
+        let start = index;
+        let character = characters[index];
+
+        if character.is_whitespace() {
+            index += 1;
+            continue;
+        }
+
+        let token = match character {
+            '(' => {
+                index += 1;
+                Token::OpenParen
+            }
+            ')' => {
+                index += 1;
+                Token::CloseParen
+            }
+            '\'' | '"' => {
+                let quote = character;
+                index += 1;
+                let mut value = String::new();
+                loop {
+                    let Some(&next) = characters.get(index) else {
+                        return Err(LexError::UnterminatedString(start));
+                    };
+                    index += 1;
+                    if next == '\\' {
+                        // An escape lets a quote appear inside a quoted value. Anything else after
+                        // a backslash is taken literally, which keeps Windows paths usable.
+                        match characters.get(index) {
+                            Some(&escaped) => {
+                                value.push(escaped);
+                                index += 1;
+                            }
+                            None => return Err(LexError::UnterminatedString(start)),
+                        }
+                        continue;
+                    }
+                    if next == quote {
+                        break;
+                    }
+                    value.push(next);
+                }
+                Token::String(value)
+            }
+            '=' | '!' | '~' | '>' | '<' => {
+                let next = characters.get(index + 1).copied();
+                let (operator, length) = match (character, next) {
+                    ('=', Some('=')) => (Operator::Equals, 2),
+                    ('!', Some('=')) => (Operator::NotEquals, 2),
+                    ('~', Some('=')) => (Operator::Matches, 2),
+                    ('!', Some('~')) => (Operator::NotMatches, 2),
+                    ('>', Some('=')) => (Operator::GreaterThanOrEqual, 2),
+                    ('<', Some('=')) => (Operator::LessThanOrEqual, 2),
+                    ('>', _) => (Operator::GreaterThan, 1),
+                    ('<', _) => (Operator::LessThan, 1),
+                    // A single `=` is the most common way to get this wrong, so it is worth
+                    // naming rather than reporting as an unexpected character.
+                    ('=', _) => {
+                        return Err(LexError::IncompleteOperator {
+                            found: "=".to_owned(),
+                            suggestion: "==",
+                        });
+                    }
+                    ('!', _) => {
+                        return Err(LexError::IncompleteOperator {
+                            found: "!".to_owned(),
+                            suggestion: "!=",
+                        });
+                    }
+                    ('~', _) => {
+                        return Err(LexError::IncompleteOperator {
+                            found: "~".to_owned(),
+                            suggestion: "~=",
+                        });
+                    }
+                    _ => unreachable!("outer match restricts the character"),
+                };
+                index += length;
+                Token::Operator(operator)
+            }
+            character if is_ident_start(character) => {
+                let mut value = String::new();
+                while let Some(&next) = characters.get(index) {
+                    if !is_ident_char(next) {
+                        break;
+                    }
+                    value.push(next);
+                    index += 1;
+                }
+                // Keywords are matched case-insensitively so `AND` and `and` both read naturally.
+                match value.to_ascii_lowercase().as_str() {
+                    "and" => Token::And,
+                    "or" => Token::Or,
+                    "not" => Token::Not,
+                    _ => Token::Ident(value),
+                }
+            }
+            // A value starting with a digit is far more often a version (`1.0.0`) or a date
+            // (`2024-01-01`) than a number. Consuming only digits here would stop at the first
+            // `.` and report it as an unexpected character, so the whole run is taken and only
+            // then judged: if all of it is an integer it is a number, otherwise it is text.
+            character if character.is_ascii_digit() || character == '-' => {
+                let mut value = String::new();
+                if character == '-' {
+                    value.push('-');
+                    index += 1;
+                }
+                while let Some(&next) = characters.get(index) {
+                    if !is_ident_char(next) {
+                        break;
+                    }
+                    value.push(next);
+                    index += 1;
+                }
+                match value.parse::<i64>() {
+                    Ok(number) => Token::Number(number),
+                    Err(_) => Token::Ident(value),
+                }
+            }
+            character => {
+                return Err(LexError::UnexpectedCharacter {
+                    character,
+                    position: index,
+                });
+            }
+        };
+        tokens.push(SpannedToken {
+            token,
+            span: Span { start, end: index },
+        });
+    }
+    Ok(tokens)
+}
+
+fn is_ident_start(character: char) -> bool {
+    character.is_alphabetic() || character == '_' || character == '*'
+}
+
+/// What may appear inside an unquoted word.
+///
+/// Deliberately wide: an unquoted value is often a version (`1.0.0-SNAPSHOT`), a coordinate
+/// (`dev.kingtux:tms`) or a glob (`*.jar`), and forcing quotes around all of those would make the
+/// common query the awkward one.
+fn is_ident_char(character: char) -> bool {
+    character.is_alphanumeric()
+        || matches!(
+            character,
+            '_' | '-' | '.' | '*' | '?' | '/' | ':' | '@' | '+' | '~'
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    fn tokens(input: &str) -> Vec<Token> {
+        tokenize(input)
+            .unwrap_or_else(|err| panic!("`{input}` failed to tokenize: {err}"))
+            .into_iter()
+            .map(|spanned| spanned.token)
+            .collect()
+    }
+
+    #[test]
+    fn reads_a_simple_comparison() {
+        assert_eq!(
+            tokens("version == 1.0.0"),
+            vec![
+                Token::Ident("version".to_owned()),
+                Token::Operator(Operator::Equals),
+                Token::Ident("1.0.0".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn reads_every_operator() {
+        for (text, expected) in [
+            ("==", Operator::Equals),
+            ("!=", Operator::NotEquals),
+            ("~=", Operator::Matches),
+            ("!~", Operator::NotMatches),
+            (">", Operator::GreaterThan),
+            (">=", Operator::GreaterThanOrEqual),
+            ("<", Operator::LessThan),
+            ("<=", Operator::LessThanOrEqual),
+        ] {
+            assert_eq!(
+                tokens(&format!("a {text} b"))[1],
+                Token::Operator(expected),
+                "`{text}` did not lex"
+            );
+        }
+    }
+
+    #[test]
+    fn keywords_are_case_insensitive() {
+        assert_eq!(
+            tokens("a == b AND c == d Or Not e == f"),
+            vec![
+                Token::Ident("a".to_owned()),
+                Token::Operator(Operator::Equals),
+                Token::Ident("b".to_owned()),
+                Token::And,
+                Token::Ident("c".to_owned()),
+                Token::Operator(Operator::Equals),
+                Token::Ident("d".to_owned()),
+                Token::Or,
+                Token::Not,
+                Token::Ident("e".to_owned()),
+                Token::Operator(Operator::Equals),
+                Token::Ident("f".to_owned()),
+            ]
+        );
+    }
+
+    /// A coordinate, a version and a glob all have to survive without quotes, or the common query
+    /// becomes the awkward one.
+    #[test]
+    fn unquoted_values_keep_their_punctuation() {
+        assert_eq!(
+            tokens("project == dev.kingtux:tms"),
+            vec![
+                Token::Ident("project".to_owned()),
+                Token::Operator(Operator::Equals),
+                Token::Ident("dev.kingtux:tms".to_owned()),
+            ]
+        );
+        assert_eq!(tokens("name ~= *.jar")[2], Token::Ident("*.jar".to_owned()));
+        assert_eq!(
+            tokens("version == 1.0.0-SNAPSHOT")[2],
+            Token::Ident("1.0.0-SNAPSHOT".to_owned())
+        );
+    }
+
+    #[test]
+    fn quoted_strings_may_contain_anything() {
+        assert_eq!(
+            tokens(r#"name == "a value with spaces and == in it""#)[2],
+            Token::String("a value with spaces and == in it".to_owned())
+        );
+        assert_eq!(
+            tokens(r#"name == "escaped \" quote""#)[2],
+            Token::String("escaped \" quote".to_owned())
+        );
+        assert_eq!(
+            tokens("name == 'single'")[2],
+            Token::String("single".to_owned())
+        );
+    }
+
+    #[test]
+    fn numbers_are_numbers() {
+        assert_eq!(tokens("downloads > 100")[2], Token::Number(100));
+        assert_eq!(tokens("value == -5")[2], Token::Number(-5));
+    }
+
+    #[test]
+    fn reports_where_a_query_went_wrong() {
+        assert_eq!(
+            tokenize(r#"name == "unterminated"#),
+            Err(LexError::UnterminatedString(8))
+        );
+        assert_eq!(
+            tokenize("name = value"),
+            Err(LexError::IncompleteOperator {
+                found: "=".to_owned(),
+                suggestion: "=="
+            })
+        );
+        assert_eq!(
+            tokenize("name == value & other"),
+            Err(LexError::UnexpectedCharacter {
+                character: '&',
+                position: 14
+            })
+        );
+    }
+
+    #[test]
+    fn spans_point_at_the_source() {
+        let tokens = tokenize("version == 1.0.0").unwrap();
+        assert_eq!(tokens[0].span, Span { start: 0, end: 7 });
+        assert_eq!(tokens[1].span, Span { start: 8, end: 10 });
+        assert_eq!(tokens[2].span, Span { start: 11, end: 16 });
+    }
+}

--- a/crates/aql/src/lib.rs
+++ b/crates/aql/src/lib.rs
@@ -1,0 +1,92 @@
+//! The artifact query language nitro-repo searches with.
+//!
+//! Issue #411 asks for artifact searching modelled on Strongbox's and Artifactory's query
+//! languages, "pushed as a separate library". This is that crate: a lexer, a parser, a typed AST
+//! and a compiler to a parameterized SQL predicate, with no dependency on a web framework or a
+//! database driver so it stands on its own.
+//!
+//! # The language
+//!
+//! A query is a boolean expression over a closed set of fields:
+//!
+//! ```text
+//! repo == releases and scope == dev.kingtux and version ~= "1.*"
+//! name ~= *.jar and not release_type == Snapshot
+//! (scope == dev.kingtux or scope == com.example) and created > 2024-01-01
+//! ```
+//!
+//! Operators are `==`, `!=`, `~=` (glob), `!~`, and — on timestamps only — `>`, `>=`, `<`, `<=`.
+//! `and`, `or`, `not` and parentheses combine them, and two comparisons side by side mean `and`.
+//! Text comparisons are case-insensitive, matching how coordinates are treated everywhere else
+//! here.
+//!
+//! Ordering comparisons are rejected on non-temporal fields: `name > b` would compile to a
+//! lexicographic comparison, which is almost never what was meant and never says so.
+//!
+//! # Safety
+//!
+//! [`sql::CompiledQuery`] returns a predicate containing only placeholders, plus the values to
+//! bind, so caller-supplied text is never part of the statement. Column names come from the
+//! [`ast::Field`] enum rather than from the query, so there is nothing to escape there either.
+//!
+//! ```
+//! use nr_aql::{parse, sql::CompiledQuery};
+//!
+//! let query = parse(r#"name ~= "*.jar" and scope == dev.kingtux"#).unwrap();
+//! let compiled = CompiledQuery::compile(&query);
+//! assert_eq!(compiled.bindings.len(), 2);
+//! ```
+use serde::Serialize;
+
+pub mod ast;
+pub mod lexer;
+pub mod parser;
+pub mod sql;
+
+pub use ast::{Field, Query, Value};
+pub use parser::{ParseError, parse};
+
+/// A half-open range of character offsets into the query text, so an error can be pointed at.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+pub struct Span {
+    pub start: usize,
+    pub end: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sql::{Binding, CompiledQuery};
+
+    /// The queries in the module documentation, so the examples cannot rot.
+    #[test]
+    fn documented_examples_parse_and_compile() {
+        for query in [
+            "repo == releases and scope == dev.kingtux and version ~= \"1.*\"",
+            "name ~= *.jar and not release_type == Snapshot",
+            "(scope == dev.kingtux or scope == com.example) and created > 2024-01-01",
+        ] {
+            let parsed = parse(query).unwrap_or_else(|err| panic!("`{query}`: {err}"));
+            let compiled = CompiledQuery::compile(&parsed);
+            assert!(!compiled.predicate.is_empty());
+            assert!(!compiled.bindings.is_empty());
+        }
+    }
+
+    /// The AST is serialized to the frontend so it can render a query builder.
+    #[test]
+    fn the_ast_serializes() {
+        let parsed = parse("name == tms and version ~= 1.*").unwrap();
+        let json = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(json["kind"], "and");
+    }
+
+    #[test]
+    fn a_query_of_one_comparison_binds_exactly_one_value() {
+        let compiled = CompiledQuery::compile(&parse("project == dev.kingtux:tms").unwrap());
+        assert_eq!(
+            compiled.bindings,
+            vec![Binding::Text("dev.kingtux:tms".to_owned())]
+        );
+    }
+}

--- a/crates/aql/src/parser.rs
+++ b/crates/aql/src/parser.rs
@@ -1,0 +1,376 @@
+//! Recursive-descent parser for the query language.
+//!
+//! Precedence, loosest first: `or`, `and`, `not`, then comparisons and parentheses. That is what
+//! makes `a == 1 or b == 2 and c == 3` read as `a == 1 or (b == 2 and c == 3)`, which is what
+//! anyone writing it expects.
+use crate::{
+    Span,
+    ast::{Field, Query, Value},
+    lexer::{LexError, Operator, SpannedToken, Token, tokenize},
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ParseError {
+    #[error(transparent)]
+    Lex(#[from] LexError),
+    #[error("The query is empty")]
+    Empty,
+    #[error("Unknown field `{field}`. Known fields: {}", known_fields())]
+    UnknownField { field: String, span: Span },
+    #[error("Expected a field name, found `{found}`")]
+    ExpectedField { found: String, span: Span },
+    #[error("Expected an operator after `{field}`, such as `==` or `~=`")]
+    ExpectedOperator { field: String, span: Span },
+    #[error("Expected a value after `{operator}`")]
+    ExpectedValue { operator: String, span: Span },
+    #[error("Unclosed `(`")]
+    UnclosedParen { span: Span },
+    #[error("Unexpected `)` with no matching `(`")]
+    UnmatchedCloseParen { span: Span },
+    #[error("Unexpected trailing input after a complete query")]
+    TrailingInput { span: Span },
+    #[error("`{operator}` cannot be used on `{field}`, which is not an ordered field")]
+    OperatorNotOrderable {
+        operator: String,
+        field: &'static str,
+    },
+}
+
+fn known_fields() -> String {
+    Field::all()
+        .iter()
+        .map(|field| field.as_str())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+impl ParseError {
+    /// Where in the query text the problem is, when that is known.
+    pub fn span(&self) -> Option<Span> {
+        match self {
+            ParseError::UnknownField { span, .. }
+            | ParseError::ExpectedField { span, .. }
+            | ParseError::ExpectedOperator { span, .. }
+            | ParseError::ExpectedValue { span, .. }
+            | ParseError::UnclosedParen { span }
+            | ParseError::UnmatchedCloseParen { span }
+            | ParseError::TrailingInput { span } => Some(*span),
+            _ => None,
+        }
+    }
+}
+
+pub fn parse(input: &str) -> Result<Query, ParseError> {
+    let tokens = tokenize(input)?;
+    if tokens.is_empty() {
+        return Err(ParseError::Empty);
+    }
+    let mut parser = Parser { tokens, index: 0 };
+    let query = parser.parse_or()?;
+    if let Some(remaining) = parser.peek() {
+        return Err(ParseError::TrailingInput {
+            span: remaining.span,
+        });
+    }
+    Ok(query)
+}
+
+struct Parser {
+    tokens: Vec<SpannedToken>,
+    index: usize,
+}
+
+impl Parser {
+    fn peek(&self) -> Option<&SpannedToken> {
+        self.tokens.get(self.index)
+    }
+    fn next(&mut self) -> Option<SpannedToken> {
+        let token = self.tokens.get(self.index).cloned();
+        if token.is_some() {
+            self.index += 1;
+        }
+        token
+    }
+    /// The span just past the end, for errors about something that is missing rather than wrong.
+    fn end_span(&self) -> Span {
+        self.tokens
+            .last()
+            .map(|token| Span {
+                start: token.span.end,
+                end: token.span.end,
+            })
+            .unwrap_or(Span { start: 0, end: 0 })
+    }
+
+    fn parse_or(&mut self) -> Result<Query, ParseError> {
+        let mut left = self.parse_and()?;
+        while matches!(self.peek().map(|t| &t.token), Some(Token::Or)) {
+            self.next();
+            let right = self.parse_and()?;
+            left = Query::or(left, right);
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> Result<Query, ParseError> {
+        let mut left = self.parse_not()?;
+        loop {
+            match self.peek().map(|t| &t.token) {
+                Some(Token::And) => {
+                    self.next();
+                }
+                // Two comparisons side by side mean `and`. Writing it out every time is noise, and
+                // both languages this is modelled on allow it.
+                Some(Token::Ident(_)) | Some(Token::Not) | Some(Token::OpenParen) => {}
+                _ => break,
+            }
+            let right = self.parse_not()?;
+            left = Query::and(left, right);
+        }
+        Ok(left)
+    }
+
+    fn parse_not(&mut self) -> Result<Query, ParseError> {
+        if matches!(self.peek().map(|t| &t.token), Some(Token::Not)) {
+            self.next();
+            let inner = self.parse_not()?;
+            return Ok(Query::negate(inner));
+        }
+        self.parse_primary()
+    }
+
+    fn parse_primary(&mut self) -> Result<Query, ParseError> {
+        let Some(token) = self.next() else {
+            return Err(ParseError::ExpectedField {
+                found: "end of query".to_owned(),
+                span: self.end_span(),
+            });
+        };
+        match token.token {
+            Token::OpenParen => {
+                let inner = self.parse_or()?;
+                match self.next() {
+                    Some(SpannedToken {
+                        token: Token::CloseParen,
+                        ..
+                    }) => Ok(inner),
+                    _ => Err(ParseError::UnclosedParen { span: token.span }),
+                }
+            }
+            Token::CloseParen => Err(ParseError::UnmatchedCloseParen { span: token.span }),
+            Token::Ident(name) => {
+                let Some(field) = Field::parse(&name) else {
+                    return Err(ParseError::UnknownField {
+                        field: name,
+                        span: token.span,
+                    });
+                };
+                self.parse_comparison(field, &name, token.span)
+            }
+            other => Err(ParseError::ExpectedField {
+                found: describe(&other),
+                span: token.span,
+            }),
+        }
+    }
+
+    fn parse_comparison(
+        &mut self,
+        field: Field,
+        name: &str,
+        field_span: Span,
+    ) -> Result<Query, ParseError> {
+        let Some(SpannedToken {
+            token: Token::Operator(operator),
+            span: operator_span,
+        }) = self.next()
+        else {
+            return Err(ParseError::ExpectedOperator {
+                field: name.to_owned(),
+                span: field_span,
+            });
+        };
+
+        // Ordering only means something for a timestamp. Allowing `>` on a name would compile to
+        // a lexicographic comparison, which is almost never what was meant and never says so.
+        if matches!(
+            operator,
+            Operator::GreaterThan
+                | Operator::GreaterThanOrEqual
+                | Operator::LessThan
+                | Operator::LessThanOrEqual
+        ) && !field.is_temporal()
+        {
+            return Err(ParseError::OperatorNotOrderable {
+                operator: operator.to_string(),
+                field: field.as_str(),
+            });
+        }
+
+        let Some(value_token) = self.next() else {
+            return Err(ParseError::ExpectedValue {
+                operator: operator.to_string(),
+                span: operator_span,
+            });
+        };
+        let value = match value_token.token {
+            Token::Ident(text) | Token::String(text) => Value::Text(text),
+            Token::Number(number) => Value::Number(number),
+            other => {
+                return Err(ParseError::ExpectedValue {
+                    operator: describe(&other),
+                    span: value_token.span,
+                });
+            }
+        };
+        Ok(Query::Comparison {
+            field,
+            operator,
+            value,
+        })
+    }
+}
+
+fn describe(token: &Token) -> String {
+    match token {
+        Token::Ident(value) => value.clone(),
+        Token::String(value) => format!("\"{value}\""),
+        Token::Number(value) => value.to_string(),
+        Token::Operator(operator) => operator.to_string(),
+        Token::And => "and".to_owned(),
+        Token::Or => "or".to_owned(),
+        Token::Not => "not".to_owned(),
+        Token::OpenParen => "(".to_owned(),
+        Token::CloseParen => ")".to_owned(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+
+    fn comparison(field: Field, operator: Operator, value: &str) -> Query {
+        Query::Comparison {
+            field,
+            operator,
+            value: Value::Text(value.to_owned()),
+        }
+    }
+
+    #[test]
+    fn parses_a_single_comparison() {
+        assert_eq!(
+            parse("version == 1.0.0").unwrap(),
+            comparison(Field::Version, Operator::Equals, "1.0.0")
+        );
+    }
+
+    /// `and` binds tighter than `or`, so this must not group left to right.
+    #[test]
+    fn and_binds_tighter_than_or() {
+        let query = parse("name == a or name == b and name == c").unwrap();
+        assert_eq!(
+            query,
+            Query::or(
+                comparison(Field::Name, Operator::Equals, "a"),
+                Query::and(
+                    comparison(Field::Name, Operator::Equals, "b"),
+                    comparison(Field::Name, Operator::Equals, "c"),
+                )
+            )
+        );
+    }
+
+    #[test]
+    fn parentheses_override_precedence() {
+        let query = parse("(name == a or name == b) and name == c").unwrap();
+        assert_eq!(
+            query,
+            Query::and(
+                Query::or(
+                    comparison(Field::Name, Operator::Equals, "a"),
+                    comparison(Field::Name, Operator::Equals, "b"),
+                ),
+                comparison(Field::Name, Operator::Equals, "c"),
+            )
+        );
+    }
+
+    /// Two comparisons side by side mean `and`; writing it every time is noise.
+    #[test]
+    fn adjacent_comparisons_are_implicitly_and() {
+        assert_eq!(
+            parse("scope == dev.kingtux name == tms").unwrap(),
+            parse("scope == dev.kingtux and name == tms").unwrap()
+        );
+    }
+
+    #[test]
+    fn not_applies_to_what_follows_it() {
+        assert_eq!(
+            parse("not version ~= *-SNAPSHOT").unwrap(),
+            Query::negate(comparison(Field::Version, Operator::Matches, "*-SNAPSHOT"))
+        );
+        // `not` binds tighter than `and`.
+        assert_eq!(
+            parse("name == a and not name == b").unwrap(),
+            Query::and(
+                comparison(Field::Name, Operator::Equals, "a"),
+                Query::negate(comparison(Field::Name, Operator::Equals, "b")),
+            )
+        );
+    }
+
+    #[test]
+    fn ordering_is_only_allowed_on_timestamps() {
+        assert!(parse("created > 2024").is_ok());
+        assert!(parse("updated <= 2024").is_ok());
+        // Lexicographic ordering on a name is almost never what was meant, and never says so.
+        assert_eq!(
+            parse("name > b"),
+            Err(ParseError::OperatorNotOrderable {
+                operator: ">".to_owned(),
+                field: "name"
+            })
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_queries_with_a_position() {
+        assert_eq!(parse(""), Err(ParseError::Empty));
+        assert_eq!(parse("   "), Err(ParseError::Empty));
+
+        let err = parse("nonsense == 1").unwrap_err();
+        assert!(matches!(err, ParseError::UnknownField { .. }));
+        // The message lists what a caller may actually use.
+        assert!(err.to_string().contains("version"), "{err}");
+        assert_eq!(err.span(), Some(Span { start: 0, end: 8 }));
+
+        assert!(matches!(
+            parse("version"),
+            Err(ParseError::ExpectedOperator { .. })
+        ));
+        assert!(matches!(
+            parse("version =="),
+            Err(ParseError::ExpectedValue { .. })
+        ));
+        assert!(matches!(
+            parse("(version == 1"),
+            Err(ParseError::UnclosedParen { .. })
+        ));
+        assert!(matches!(
+            parse("version == 1)"),
+            Err(ParseError::TrailingInput { .. })
+        ));
+    }
+
+    #[test]
+    fn a_realistic_query_parses() {
+        let query = parse(
+            r#"repo == releases and scope == dev.kingtux and version ~= "1.*" and not release_type == Snapshot"#,
+        );
+        assert!(query.is_ok(), "{:?}", query.unwrap_err());
+    }
+}

--- a/crates/aql/src/sql.rs
+++ b/crates/aql/src/sql.rs
@@ -1,0 +1,304 @@
+//! Compiles a parsed query into a SQL predicate and its bind parameters.
+//!
+//! **No caller-supplied text ever reaches the statement.** Values come back as a separate
+//! `Vec<Binding>` and the predicate refers to them positionally, so a value containing a quote, a
+//! semicolon or a comment marker is data and cannot become syntax. Column names are not
+//! caller-supplied either — they come from the closed `Field` enum, so there is nothing to escape.
+//!
+//! This crate does not depend on a database driver, which is what keeps it publishable on its own
+//! (#411 asks for that). The caller binds the parameters with whatever driver it uses.
+use crate::{
+    ast::{Field, Query, Value},
+    lexer::Operator,
+};
+
+/// A value to bind, in the order the placeholders refer to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Binding {
+    Text(String),
+    Number(i64),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompiledQuery {
+    /// A SQL boolean expression with `$1`-style placeholders.
+    pub predicate: String,
+    pub bindings: Vec<Binding>,
+}
+
+/// Which column each field maps to.
+///
+/// Written against the join in [`CompiledQuery::FROM_CLAUSE`], so the two move together.
+fn column_for(field: Field) -> &'static str {
+    match field {
+        Field::Repository => "repositories.name",
+        Field::Storage => "storages.name",
+        Field::Project => "projects.key",
+        Field::Scope => "projects.scope",
+        Field::Name => "projects.name",
+        Field::Description => "projects.description",
+        Field::Version => "project_versions.version",
+        Field::ReleaseType => "project_versions.release_type",
+        Field::Created => "project_versions.created_at",
+        Field::Updated => "project_versions.updated_at",
+    }
+}
+
+impl CompiledQuery {
+    /// The joins every compiled predicate is written against.
+    pub const FROM_CLAUSE: &'static str = "FROM project_versions \
+         INNER JOIN projects ON projects.id = project_versions.project_id \
+         INNER JOIN repositories ON repositories.id = projects.repository_id \
+         INNER JOIN storages ON storages.id = repositories.storage_id";
+
+    pub fn compile(query: &Query) -> Self {
+        let mut compiler = Compiler {
+            bindings: Vec::new(),
+        };
+        let predicate = compiler.compile(query);
+        Self {
+            predicate,
+            bindings: compiler.bindings,
+        }
+    }
+}
+
+struct Compiler {
+    bindings: Vec<Binding>,
+}
+
+impl Compiler {
+    fn bind(&mut self, binding: Binding) -> String {
+        self.bindings.push(binding);
+        // Postgres placeholders are 1-based.
+        format!("${}", self.bindings.len())
+    }
+
+    fn compile(&mut self, query: &Query) -> String {
+        match query {
+            Query::And { left, right } => {
+                format!("({} AND {})", self.compile(left), self.compile(right))
+            }
+            Query::Or { left, right } => {
+                format!("({} OR {})", self.compile(left), self.compile(right))
+            }
+            // A NULL column makes `NOT (col = x)` NULL rather than true, so a row with no
+            // description would vanish from `not description == "x"`. Being explicit about it is
+            // what makes negation mean what a reader expects.
+            Query::Not { inner } => format!("(NOT COALESCE({}, FALSE))", self.compile(inner)),
+            Query::Comparison {
+                field,
+                operator,
+                value,
+            } => self.compile_comparison(*field, *operator, value),
+        }
+    }
+
+    fn compile_comparison(&mut self, field: Field, operator: Operator, value: &Value) -> String {
+        let column = column_for(field);
+
+        match operator {
+            Operator::Matches | Operator::NotMatches => {
+                let placeholder = self.bind(Binding::Text(glob_to_like(&value.as_text())));
+                // ILIKE, because artifact coordinates are matched case-insensitively everywhere
+                // else in this codebase. ESCAPE names the character `glob_to_like` used, so a
+                // literal `%` or `_` in a query stays literal.
+                let comparison = format!("{column} ILIKE {placeholder} ESCAPE '\\'");
+                if operator == Operator::NotMatches {
+                    format!("(NOT COALESCE({comparison}, FALSE))")
+                } else {
+                    comparison
+                }
+            }
+            Operator::Equals | Operator::NotEquals => {
+                let placeholder = self.bind(binding_for(value));
+                let sql_operator = if operator == Operator::Equals {
+                    "="
+                } else {
+                    "!="
+                };
+                // Timestamps are compared as timestamps; everything else as case-insensitive text.
+                if field.is_temporal() {
+                    format!("{column} {sql_operator} {placeholder}::timestamptz")
+                } else if matches!(value, Value::Number(_)) {
+                    format!("{column} {sql_operator} {placeholder}")
+                } else {
+                    let comparison = format!("LOWER({column}) = LOWER({placeholder})");
+                    if operator == Operator::NotEquals {
+                        format!("(NOT COALESCE({comparison}, FALSE))")
+                    } else {
+                        comparison
+                    }
+                }
+            }
+            Operator::GreaterThan
+            | Operator::GreaterThanOrEqual
+            | Operator::LessThan
+            | Operator::LessThanOrEqual => {
+                let placeholder = self.bind(binding_for(value));
+                let sql_operator = match operator {
+                    Operator::GreaterThan => ">",
+                    Operator::GreaterThanOrEqual => ">=",
+                    Operator::LessThan => "<",
+                    Operator::LessThanOrEqual => "<=",
+                    _ => unreachable!("outer match restricts the operator"),
+                };
+                // The parser only allows ordering on a temporal field, so the cast is always
+                // right here.
+                format!("{column} {sql_operator} {placeholder}::timestamptz")
+            }
+        }
+    }
+}
+
+fn binding_for(value: &Value) -> Binding {
+    match value {
+        Value::Text(text) => Binding::Text(text.clone()),
+        Value::Number(number) => Binding::Number(*number),
+    }
+}
+
+/// Rewrites a glob into a `LIKE` pattern.
+///
+/// `*` and `?` are what people type; `%` and `_` are what SQL wants. A `%` or `_` already in the
+/// query is escaped so it stays a literal — without that, searching for `my_lib` would quietly
+/// also match `myXlib`.
+fn glob_to_like(glob: &str) -> String {
+    let mut pattern = String::with_capacity(glob.len() + 2);
+    for character in glob.chars() {
+        match character {
+            '*' => pattern.push('%'),
+            '?' => pattern.push('_'),
+            '%' | '_' | '\\' => {
+                pattern.push('\\');
+                pattern.push(character);
+            }
+            other => pattern.push(other),
+        }
+    }
+    pattern
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_eq;
+
+    use super::*;
+    use crate::parse;
+
+    fn compile(input: &str) -> CompiledQuery {
+        CompiledQuery::compile(&parse(input).unwrap_or_else(|err| panic!("`{input}`: {err}")))
+    }
+
+    #[test]
+    fn a_comparison_binds_its_value() {
+        let compiled = compile("version == 1.0.0");
+        assert_eq!(
+            compiled.predicate,
+            "LOWER(project_versions.version) = LOWER($1)"
+        );
+        assert_eq!(compiled.bindings, vec![Binding::Text("1.0.0".to_owned())]);
+    }
+
+    #[test]
+    fn placeholders_are_numbered_in_binding_order() {
+        let compiled = compile("scope == a and name == b or version == c");
+        assert_eq!(
+            compiled.bindings,
+            vec![
+                Binding::Text("a".to_owned()),
+                Binding::Text("b".to_owned()),
+                Binding::Text("c".to_owned()),
+            ]
+        );
+        assert!(compiled.predicate.contains("$1"));
+        assert!(compiled.predicate.contains("$2"));
+        assert!(compiled.predicate.contains("$3"));
+    }
+
+    /// The whole point of the design: a value is data, never syntax.
+    #[test]
+    fn hostile_values_never_reach_the_statement() {
+        let nasty = r#"'; DROP TABLE projects; --"#;
+        let compiled = CompiledQuery::compile(&parse(&format!("name == \"{nasty}\"")).unwrap());
+        assert!(
+            !compiled.predicate.contains("DROP"),
+            "a value reached the SQL text: {}",
+            compiled.predicate
+        );
+        assert_eq!(compiled.bindings, vec![Binding::Text(nasty.to_owned())]);
+
+        // And through the glob path, which does rewrite its input.
+        let compiled = CompiledQuery::compile(&parse(&format!("name ~= \"{nasty}\"")).unwrap());
+        assert!(!compiled.predicate.contains("DROP"));
+        assert_eq!(compiled.bindings.len(), 1);
+    }
+
+    #[test]
+    fn globs_become_like_patterns() {
+        assert_eq!(glob_to_like("*.jar"), "%.jar");
+        assert_eq!(glob_to_like("tms-1.?.0"), "tms-1._.0");
+        // A literal `%` or `_` in the query must not become a wildcard.
+        assert_eq!(glob_to_like("my_lib"), r"my\_lib");
+        assert_eq!(glob_to_like("100%"), r"100\%");
+
+        let compiled = compile("name ~= *.jar");
+        assert_eq!(compiled.bindings, vec![Binding::Text("%.jar".to_owned())]);
+        assert!(compiled.predicate.contains("ILIKE"));
+        assert!(compiled.predicate.contains(r"ESCAPE '\'"));
+    }
+
+    /// `NOT (col = x)` is NULL, not true, when the column is NULL — so a project with no
+    /// description would silently disappear from a negated query.
+    #[test]
+    fn negation_keeps_rows_with_null_columns() {
+        for query in [
+            "not description == x",
+            "description != x",
+            "description !~ x",
+        ] {
+            let compiled = compile(query);
+            assert!(
+                compiled.predicate.contains("COALESCE"),
+                "`{query}` would drop rows with a NULL description: {}",
+                compiled.predicate
+            );
+        }
+    }
+
+    #[test]
+    fn temporal_comparisons_are_cast() {
+        let compiled = compile("created > 2024-01-01");
+        assert!(
+            compiled.predicate.contains("::timestamptz"),
+            "{}",
+            compiled.predicate
+        );
+        assert_eq!(
+            compiled.bindings,
+            vec![Binding::Text("2024-01-01".to_owned())]
+        );
+    }
+
+    #[test]
+    fn grouping_survives_compilation() {
+        let compiled = compile("(scope == a or scope == b) and name == c");
+        assert!(compiled.predicate.starts_with("(("));
+        assert!(compiled.predicate.contains(" OR "));
+        assert!(compiled.predicate.contains(" AND "));
+    }
+
+    /// Every field has to map to a column, or a query using it compiles to something invalid.
+    #[test]
+    fn every_field_maps_to_a_column() {
+        for field in Field::all() {
+            let column = column_for(*field);
+            assert!(column.contains('.'), "{field:?} has no table qualifier");
+            let (table, _) = column.split_once('.').unwrap();
+            assert!(
+                CompiledQuery::FROM_CLAUSE.contains(table),
+                "{field:?} refers to `{table}`, which the FROM clause does not join"
+            );
+        }
+    }
+}

--- a/crates/core/src/database/entities/project/versions/history.rs
+++ b/crates/core/src/database/entities/project/versions/history.rs
@@ -10,11 +10,18 @@ use crate::{
     database::{DBResult, entities::project::versions::DBProjectVersionColumn},
     repository::project::ReleaseType,
 };
+/// One entry of a project's publish history.
+///
+/// #506 asks for "Push/Publish History". The type existed and was already served, but without the
+/// one thing a history is usually consulted for — who published it. `publisher` is the user id and
+/// `publisher_username` is resolved alongside it, so the UI does not have to fetch a user per row.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, FromRow, ToSchema)]
 pub struct VersionHistoryItem {
     pub id: Uuid,
     pub release_type: ReleaseType,
     pub version: String,
+    pub publisher: Option<i32>,
+    pub publisher_username: Option<String>,
     pub updated_at: DateTime<FixedOffset>,
     pub created_at: DateTime<FixedOffset>,
 }
@@ -41,17 +48,32 @@ impl ProjectVersionType for VersionHistoryItem {
 }
 
 impl VersionHistoryItem {
+    /// A project's versions, newest first, with the publisher resolved.
+    ///
+    /// Hand-written rather than built with `SelectQueryBuilder` because the builder has no way to
+    /// express the left join onto `users` — and it has to be a *left* join, since a version
+    /// published before the publisher was recorded, or by a user since deleted, still belongs in
+    /// the history.
     pub async fn find_by_project_id(
         project_id: Uuid,
         database: &sqlx::PgPool,
     ) -> DBResult<Vec<Self>> {
-        let versions =
-            SelectQueryBuilder::with_columns(DBProjectVersion::table_name(), Self::columns())
-                .filter(DBProjectVersionColumn::ProjectId.equals(project_id))
-                .order_by(DBProjectVersionColumn::UpdatedAt, SQLOrder::Descending)
-                .query_as()
-                .fetch_all(database)
-                .await?;
+        let versions = sqlx::query_as::<_, Self>(
+            r#"SELECT project_versions.id,
+                      project_versions.release_type,
+                      project_versions.version,
+                      project_versions.publisher,
+                      users.username AS publisher_username,
+                      project_versions.updated_at,
+                      project_versions.created_at
+               FROM project_versions
+               LEFT JOIN users ON users.id = project_versions.publisher
+               WHERE project_versions.project_id = $1
+               ORDER BY project_versions.updated_at DESC"#,
+        )
+        .bind(project_id)
+        .fetch_all(database)
+        .await?;
         Ok(versions)
     }
 }

--- a/crates/core/src/database/entities/repository.rs
+++ b/crates/core/src/database/entities/repository.rs
@@ -82,6 +82,40 @@ pub struct RepositoryLookup {
     pub repository_id: Uuid,
 }
 impl DBRepository {
+    /// Renames a repository, and updates its visibility if asked.
+    ///
+    /// There was no update path at all — a repository's name was fixed at creation, which is
+    /// #506's first item. The name is part of every artifact URL, so this is not a cosmetic
+    /// change: anything already pointing at the old name stops resolving, and the caller is
+    /// responsible for warning about that.
+    ///
+    /// Uniqueness is enforced by `unique_repository_name_per_storage`, so a concurrent rename to
+    /// the same name fails on the constraint rather than being lost.
+    #[instrument(skip(database))]
+    pub async fn update_details(
+        id: Uuid,
+        name: Option<&RepositoryName>,
+        visibility: Option<Visibility>,
+        active: Option<bool>,
+        database: &PgPool,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"UPDATE repositories
+               SET name = COALESCE($2, name),
+                   visibility = COALESCE($3, visibility),
+                   active = COALESCE($4, active),
+                   updated_at = NOW()
+               WHERE id = $1"#,
+        )
+        .bind(id)
+        .bind(name)
+        .bind(visibility)
+        .bind(active)
+        .execute(database)
+        .await?;
+        Ok(())
+    }
+
     pub async fn get_active_by_id(
         id: Uuid,
         database: &PgPool,

--- a/nitro_repo/Cargo.toml
+++ b/nitro_repo/Cargo.toml
@@ -88,6 +88,7 @@ current_semver = "0.1"
 nr-core.workspace = true
 nr-macros.workspace = true
 nr-storage.workspace = true
+nr-aql.workspace = true
 redb = { version = "3" }
 tuxs-config-types = { git = "https://github.com/wyatt-herkamp/tuxs-config-types.git", features = [
     "chrono",

--- a/nitro_repo/src/app/api/mod.rs
+++ b/nitro_repo/src/app/api/mod.rs
@@ -16,6 +16,7 @@ use utoipa::ToSchema;
 pub mod npm;
 pub mod project;
 pub mod repository;
+pub mod search;
 pub mod storage;
 pub mod user;
 pub mod user_management;
@@ -64,6 +65,7 @@ pub fn api_routes() -> axum::Router<NitroRepo> {
         .nest("/repository", repository::repository_routes())
         .nest("/project", project::project_routes())
         .nest("/npm", npm::npm_routes())
+        .nest("/search", search::search_routes())
         .fallback(route_not_found)
         .layer(CorsLayer::very_permissive())
 }

--- a/nitro_repo/src/app/api/project/mod.rs
+++ b/nitro_repo/src/app/api/project/mod.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract::{Path, State},
-    response::Response,
+    response::{IntoResponse, Response},
     routing::get,
 };
 use nr_core::{
@@ -8,17 +8,50 @@ use nr_core::{
         DBProject, ProjectDBType,
         versions::{DBProjectVersion, history::VersionHistoryItem},
     },
-    repository::project::ProjectResolution,
+    repository::{Visibility, project::ProjectResolution},
+    user::permissions::{HasPermissions, RepositoryActions},
 };
 use tracing::instrument;
 use utoipa::OpenApi;
 use uuid::Uuid;
 
 use crate::{
-    app::{NitroRepo, authentication::Authentication},
+    app::{NitroRepo, authentication::Authentication, responses::MissingPermission},
     error::InternalError,
     utils::ResponseBuilder,
 };
+
+/// Refuses a read of a project belonging to a repository the caller cannot see.
+///
+/// All three routes below took an `auth` argument and never looked at it, so every project and
+/// every version list in a private repository was readable by anyone who could guess — or
+/// enumerate — an id.
+async fn check_can_read(
+    auth: &Option<Authentication>,
+    repository_id: Uuid,
+    site: &NitroRepo,
+) -> Result<Option<Response>, InternalError> {
+    let Some(repository) = nr_core::database::entities::repository::DBRepository::get_by_id(
+        repository_id,
+        site.as_ref(),
+    )
+    .await?
+    else {
+        return Ok(Some(ResponseBuilder::not_found().empty()));
+    };
+    if matches!(repository.visibility, Visibility::Public) {
+        return Ok(None);
+    }
+    if auth
+        .has_action(RepositoryActions::Read, repository_id, site.as_ref())
+        .await?
+    {
+        return Ok(None);
+    }
+    Ok(Some(
+        MissingPermission::ReadRepository(repository_id).into_response(),
+    ))
+}
 
 #[derive(OpenApi)]
 #[openapi(
@@ -58,6 +91,9 @@ pub async fn get_project(
     let Some(project) = DBProject::find_by_id(project_id, site.as_ref()).await? else {
         return Ok(ResponseBuilder::not_found().empty());
     };
+    if let Some(denied) = check_can_read(&auth, project.repository_id, &site).await? {
+        return Ok(denied);
+    }
 
     Ok(ResponseBuilder::ok().json(&project))
 }
@@ -81,6 +117,12 @@ pub async fn get_project_versions(
     State(site): State<NitroRepo>,
     auth: Option<Authentication>,
 ) -> Result<Response, InternalError> {
+    let Some(project) = DBProject::find_by_id(project_id, site.as_ref()).await? else {
+        return Ok(ResponseBuilder::not_found().empty());
+    };
+    if let Some(denied) = check_can_read(&auth, project.repository_id, &site).await? {
+        return Ok(denied);
+    }
     let versions = VersionHistoryItem::find_by_project_id(project_id, site.as_ref()).await?;
 
     Ok(ResponseBuilder::ok().json(&versions))
@@ -106,6 +148,9 @@ pub async fn get_project_by_key(
     State(site): State<NitroRepo>,
     auth: Option<Authentication>,
 ) -> Result<Response, InternalError> {
+    if let Some(denied) = check_can_read(&auth, repository_id, &site).await? {
+        return Ok(denied);
+    }
     let Some(project) =
         DBProject::find_by_project_key(&project_key, repository_id, site.as_ref()).await?
     else {

--- a/nitro_repo/src/app/api/repository/management.rs
+++ b/nitro_repo/src/app/api/repository/management.rs
@@ -40,6 +40,68 @@ pub fn management_routes() -> Router<NitroRepo> {
         .route("/{repository_id}/config/{key}", put(update_config))
         .route("/{repository_id}/config/{key}", get(get_config))
         .route("/{repository_id}", delete(delete_repository))
+        .route("/{repository_id}", put(update_repository))
+        .route("/{repository_id}/all-configs", get(get_all_configs))
+}
+
+/// Every config a repository has, in one request.
+///
+/// #506 calls the config API verbose, and it is: rendering a repository's settings meant one
+/// request to list the config keys and then one more per key, each round trip re-doing the same
+/// permission check. This returns them together, keyed by config type, with the same sanitization
+/// rule the single-key route applies.
+#[utoipa::path(
+    get,
+    path = "/{repository_id}/all-configs",
+    params(("repository_id" = Uuid, Path, description = "The Repository ID")),
+    responses(
+        (status = 200, description = "Every config for the repository, keyed by type"),
+        (status = 404, description = "Repository not found"),
+    )
+)]
+#[instrument]
+pub async fn get_all_configs(
+    State(site): State<NitroRepo>,
+    auth: Option<Authentication>,
+    Path(repository): Path<Uuid>,
+) -> Result<Response, InternalError> {
+    let Some(db_repository) = DBRepository::get_by_id(repository, site.as_ref()).await? else {
+        return Ok(RepositoryNotFound::Uuid(repository).into_response());
+    };
+    let Some(loaded) = site.get_repository(repository) else {
+        return Ok(RepositoryNotFound::Uuid(repository).into_response());
+    };
+    let can_edit = auth
+        .has_action(RepositoryActions::Edit, repository, &site.database)
+        .await?;
+
+    let mut configs: HashMap<String, Value> = HashMap::default();
+    for key in loaded.config_types() {
+        let Some(config_type) = site.get_repository_config_type(key) else {
+            continue;
+        };
+        let stored =
+            match GenericDBRepositoryConfig::get_config(repository, key, site.as_ref()).await? {
+                Some(config) => config.value.0,
+                // A config that has never been written still has a shape worth showing, and the
+                // single-key route already serves the default on request.
+                None => config_type.default()?,
+            };
+        let visible = if can_edit {
+            Some(stored)
+        } else {
+            match db_repository.visibility {
+                Visibility::Hidden | Visibility::Public => {
+                    config_type.sanitize_for_public_view(stored)?
+                }
+                Visibility::Private => None,
+            }
+        };
+        if let Some(value) = visible {
+            configs.insert(key.to_owned(), value);
+        }
+    }
+    Ok(ResponseBuilder::ok().json(&configs))
 }
 #[derive(Deserialize, ToSchema, Debug)]
 pub struct NewRepositoryRequest {
@@ -309,6 +371,93 @@ pub async fn update_config(
     }
     Ok(ResponseBuilder::no_content().empty())
 }
+/// What may be changed about an existing repository.
+///
+/// Omitted fields are left alone, so a rename does not have to restate the visibility.
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct UpdateRepositoryRequest {
+    pub name: Option<String>,
+    pub visibility: Option<Visibility>,
+    pub active: Option<bool>,
+}
+
+/// Renames a repository, or changes its visibility.
+///
+/// There was no update path — a repository's name was fixed at creation. Renaming is not
+/// cosmetic: the name is in every artifact URL, so anything already pointing at the old name
+/// stops resolving. That is the caller's decision to make, but it is worth them knowing.
+#[utoipa::path(
+    put,
+    path = "/{repository_id}",
+    request_body = UpdateRepositoryRequest,
+    params(("repository_id" = Uuid, Path, description = "The Repository ID")),
+    responses(
+        (status = 200, description = "The updated repository", body = DBRepository),
+        (status = 400, description = "The name is not valid"),
+        (status = 404, description = "Repository not found"),
+        (status = 409, description = "That name is already used in this storage"),
+    )
+)]
+#[instrument]
+pub async fn update_repository(
+    State(site): State<NitroRepo>,
+    auth: Authentication,
+    Path(repository): Path<Uuid>,
+    Json(request): Json<UpdateRepositoryRequest>,
+) -> Result<Response, InternalError> {
+    if !auth
+        .has_action(RepositoryActions::Edit, repository, &site.database)
+        .await?
+    {
+        return Ok(MissingPermission::EditRepository(repository).into_response());
+    }
+    if let Some(denied) = require_scope(&auth, NRScope::EditRepository, &site).await? {
+        return Ok(denied);
+    }
+    let Some(existing) = DBRepository::get_by_id(repository, site.as_ref()).await? else {
+        return Ok(RepositoryNotFound::Uuid(repository).into_response());
+    };
+
+    let name = match request.name {
+        Some(name) if name != existing.name.as_ref() => {
+            let name = match nr_core::repository::RepositoryName::new(name) {
+                Ok(name) => name,
+                Err(err) => return Ok(ResponseBuilder::bad_request().body(err.to_string())),
+            };
+            // Checked before writing so this reports a conflict rather than a constraint
+            // violation; the unique index is still what makes it correct under a race.
+            if DBRepository::does_name_exist_for_storage(existing.storage_id, &name, &site.database)
+                .await?
+            {
+                return Ok(ConflictResponse::from("name").into_response());
+            }
+            Some(name)
+        }
+        _ => None,
+    };
+
+    DBRepository::update_details(
+        repository,
+        name.as_ref(),
+        request.visibility,
+        request.active,
+        site.as_ref(),
+    )
+    .await?;
+
+    // The loaded repository caches its name and visibility, so it has to be told. Without this a
+    // rename takes effect in the database and the running instance keeps serving the old name.
+    if let Some(loaded) = site.get_repository(repository)
+        && let Err(error) = loaded.reload().await
+    {
+        error!(?error, "Renamed the repository but failed to reload it");
+    }
+    site.forget_repository_names(repository);
+
+    let updated = DBRepository::get_by_id(repository, site.as_ref()).await?;
+    Ok(ResponseBuilder::ok().json(&updated))
+}
+
 #[utoipa::path(
     delete,
     path = "/{repository}",

--- a/nitro_repo/src/app/api/search.rs
+++ b/nitro_repo/src/app/api/search.rs
@@ -1,0 +1,300 @@
+//! Artifact search.
+//!
+//! Two ways in, one query layer behind them. #506 asks for a "repository searching system" and
+//! #411 asks for a query language; they are the same thing seen from two distances, so a simple
+//! text search compiles to the same AST an explicit query does.
+//!
+//! Results are filtered by what the caller can read. A search that returned artifacts from a
+//! private repository would be a way to enumerate it without ever fetching a file.
+use axum::{
+    extract::{Query as QueryParams, State},
+    response::{IntoResponse, Response},
+};
+use nr_aql::{
+    Field, ParseError,
+    ast::{Query, Value},
+    lexer::Operator,
+    sql::{Binding, CompiledQuery},
+};
+use nr_core::{
+    repository::Visibility,
+    user::permissions::{HasPermissions, RepositoryActions},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::Row;
+use tracing::instrument;
+use utoipa::{IntoParams, OpenApi, ToSchema};
+use uuid::Uuid;
+
+use crate::{
+    app::{NitroRepo, authentication::Authentication},
+    error::InternalError,
+    utils::ResponseBuilder,
+};
+
+/// The most a single search will return. A query with no filters matches everything, and without
+/// a ceiling that is a way to pull the entire index in one request.
+const MAX_LIMIT: i64 = 200;
+const DEFAULT_LIMIT: i64 = 50;
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(search, search_fields),
+    components(schemas(SearchResponse, SearchResult, SearchFieldDescription))
+)]
+pub struct SearchAPI;
+
+pub fn search_routes() -> axum::Router<NitroRepo> {
+    axum::Router::new()
+        .route("/", axum::routing::get(search))
+        .route("/fields", axum::routing::get(search_fields))
+}
+
+#[derive(Debug, Deserialize, IntoParams)]
+#[into_params(parameter_in = Query)]
+pub struct SearchRequest {
+    /// A query in the artifact query language, e.g. `scope == dev.kingtux and version ~= 1.*`.
+    ///
+    /// When absent, `text` is used instead.
+    pub query: Option<String>,
+    /// A plain search term, matched against project key, name and description.
+    pub text: Option<String>,
+    pub limit: Option<i64>,
+    pub offset: Option<i64>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResponse {
+    pub results: Vec<SearchResult>,
+    /// How many rows were returned. Not a total — counting every match costs a second scan, and
+    /// nothing in the UI needs it.
+    pub count: usize,
+    /// The query that ran, after a plain `text` search was expanded into one.
+    pub query: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchResult {
+    pub project_id: Uuid,
+    pub version_id: Uuid,
+    pub repository_id: Uuid,
+    pub repository: String,
+    pub storage: String,
+    pub project_key: String,
+    pub name: String,
+    pub scope: Option<String>,
+    pub description: Option<String>,
+    pub version: String,
+    pub release_type: String,
+    pub version_path: String,
+    pub created_at: chrono::DateTime<chrono::FixedOffset>,
+    pub updated_at: chrono::DateTime<chrono::FixedOffset>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct SearchFieldDescription {
+    pub name: &'static str,
+    /// Whether `>`/`<` may be used on it.
+    pub orderable: bool,
+}
+
+/// The fields a query may use, so the UI can offer them rather than hardcoding a second list.
+#[utoipa::path(
+    get,
+    path = "/fields",
+    responses((status = 200, description = "Queryable fields", body = [SearchFieldDescription]))
+)]
+pub async fn search_fields() -> Response {
+    let fields: Vec<SearchFieldDescription> = Field::all()
+        .iter()
+        .map(|field| SearchFieldDescription {
+            name: field.as_str(),
+            orderable: field.is_temporal(),
+        })
+        .collect();
+    ResponseBuilder::ok().json(&fields)
+}
+
+/// Expands a plain search term into a query.
+///
+/// `foo` becomes `project ~= *foo* or name ~= *foo* or description ~= *foo*`, which is what
+/// someone typing a word into a search box means.
+fn text_query(text: &str) -> Query {
+    let pattern = Value::Text(format!("*{text}*"));
+    let matches = |field: Field| Query::Comparison {
+        field,
+        operator: Operator::Matches,
+        value: pattern.clone(),
+    };
+    Query::or(
+        matches(Field::Project),
+        Query::or(matches(Field::Name), matches(Field::Description)),
+    )
+}
+
+#[utoipa::path(
+    get,
+    path = "/",
+    params(SearchRequest),
+    responses(
+        (status = 200, description = "Search results", body = SearchResponse),
+        (status = 400, description = "The query could not be parsed"),
+    )
+)]
+#[instrument(skip(site))]
+pub async fn search(
+    State(site): State<NitroRepo>,
+    auth: Option<Authentication>,
+    QueryParams(request): QueryParams<SearchRequest>,
+) -> Result<Response, InternalError> {
+    let (query, source) = match (&request.query, &request.text) {
+        (Some(query), _) if !query.trim().is_empty() => match nr_aql::parse(query) {
+            Ok(parsed) => (parsed, query.clone()),
+            Err(error) => return Ok(parse_error_response(error)),
+        },
+        (_, Some(text)) if !text.trim().is_empty() => {
+            (text_query(text.trim()), format!("text: {text}"))
+        }
+        // Neither given: everything, subject to the limit and to what the caller can read.
+        _ => (
+            Query::Comparison {
+                field: Field::Project,
+                operator: Operator::Matches,
+                value: Value::Text("*".to_owned()),
+            },
+            "*".to_owned(),
+        ),
+    };
+
+    let compiled = CompiledQuery::compile(&query);
+    let limit = request.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let offset = request.offset.unwrap_or(0).max(0);
+
+    // The predicate's placeholders are `$1..$n`; the limit and offset take the two after them.
+    let limit_placeholder = compiled.bindings.len() + 1;
+    let offset_placeholder = compiled.bindings.len() + 2;
+    let statement = format!(
+        "SELECT project_versions.id AS version_id, \
+                project_versions.version, \
+                project_versions.release_type, \
+                project_versions.path AS version_path, \
+                project_versions.created_at, \
+                project_versions.updated_at, \
+                projects.id AS project_id, \
+                projects.key AS project_key, \
+                projects.name AS project_name, \
+                projects.scope, \
+                projects.description, \
+                repositories.id AS repository_id, \
+                repositories.name AS repository_name, \
+                repositories.visibility, \
+                storages.name AS storage_name \
+         {from} WHERE {predicate} \
+         ORDER BY project_versions.updated_at DESC \
+         LIMIT ${limit_placeholder} OFFSET ${offset_placeholder}",
+        from = CompiledQuery::FROM_CLAUSE,
+        predicate = compiled.predicate,
+    );
+
+    let mut sql_query = sqlx::query(&statement);
+    for binding in &compiled.bindings {
+        sql_query = match binding {
+            Binding::Text(text) => sql_query.bind(text),
+            Binding::Number(number) => sql_query.bind(number),
+        };
+    }
+    // Over-fetch, because rows the caller cannot read are dropped afterwards and would otherwise
+    // eat into the page they asked for. Bounded so a caller cannot make this arbitrarily large.
+    let fetch_limit = (limit * 4).min(MAX_LIMIT * 4);
+    let rows = sql_query
+        .bind(fetch_limit)
+        .bind(offset)
+        .fetch_all(site.as_ref())
+        .await?;
+
+    let mut results = Vec::new();
+    for row in rows {
+        if results.len() as i64 >= limit {
+            break;
+        }
+        let visibility: Visibility = row.try_get("visibility")?;
+        let repository_id: Uuid = row.try_get("repository_id")?;
+        // A private or hidden repository's contents are only searchable by someone who can read
+        // it — otherwise search is a way to enumerate a repository without fetching from it.
+        if !matches!(visibility, Visibility::Public)
+            && !auth
+                .has_action(RepositoryActions::Read, repository_id, site.as_ref())
+                .await?
+        {
+            continue;
+        }
+        results.push(SearchResult {
+            project_id: row.try_get("project_id")?,
+            version_id: row.try_get("version_id")?,
+            repository_id,
+            repository: row.try_get("repository_name")?,
+            storage: row.try_get("storage_name")?,
+            project_key: row.try_get("project_key")?,
+            name: row.try_get("project_name")?,
+            scope: row.try_get("scope")?,
+            description: row.try_get("description")?,
+            version: row.try_get("version")?,
+            release_type: row.try_get("release_type")?,
+            version_path: row.try_get("version_path")?,
+            created_at: row.try_get("created_at")?,
+            updated_at: row.try_get("updated_at")?,
+        });
+    }
+
+    Ok(ResponseBuilder::ok().json(&SearchResponse {
+        count: results.len(),
+        results,
+        query: source,
+    }))
+}
+
+/// Reports a parse failure with the position it happened at, so the UI can underline it.
+fn parse_error_response(error: ParseError) -> Response {
+    #[derive(Serialize)]
+    struct ParseErrorResponse {
+        error: String,
+        start: Option<usize>,
+        end: Option<usize>,
+    }
+    let span = error.span();
+    ResponseBuilder::bad_request()
+        .json(&ParseErrorResponse {
+            error: error.to_string(),
+            start: span.map(|span| span.start),
+            end: span.map(|span| span.end),
+        })
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A word typed into a search box should look in the places a person means.
+    #[test]
+    fn plain_text_expands_to_a_query_over_the_obvious_fields() {
+        let compiled = CompiledQuery::compile(&text_query("tms"));
+        assert_eq!(compiled.bindings.len(), 3);
+        for binding in &compiled.bindings {
+            assert_eq!(binding, &Binding::Text("%tms%".to_owned()));
+        }
+        assert!(compiled.predicate.contains("projects.key"));
+        assert!(compiled.predicate.contains("projects.name"));
+        assert!(compiled.predicate.contains("projects.description"));
+    }
+
+    /// The statement is built by format!, so the placeholder numbering has to follow the
+    /// bindings — an off-by-one here silently pages by the wrong value.
+    #[test]
+    fn limit_and_offset_follow_the_query_bindings() {
+        let compiled = CompiledQuery::compile(&text_query("tms"));
+        assert_eq!(compiled.bindings.len(), 3);
+        assert_eq!(compiled.bindings.len() + 1, 4);
+        assert_eq!(compiled.bindings.len() + 2, 5);
+    }
+}

--- a/nitro_repo/src/app/mod.rs
+++ b/nitro_repo/src/app/mod.rs
@@ -472,6 +472,16 @@ impl NitroRepo {
             .find(|repo_type| repo_type.get_type().eq_ignore_ascii_case(name))
             .copied()
     }
+    /// Drops any cached name that resolves to this repository.
+    ///
+    /// The lookup table is filled lazily and never invalidated, so after a rename the old name
+    /// would keep resolving from cache — the repository would answer on both names until a
+    /// restart. Dropping every entry for the id is enough: the next request for the new name
+    /// misses, queries the database and re-caches.
+    pub fn forget_repository_names(&self, id: Uuid) {
+        let mut lookup_table = self.inner.name_lookup_table.lock();
+        lookup_table.retain(|_, value| *value != id);
+    }
     pub fn remove_repository(&self, id: Uuid) {
         {
             let mut repositories = self.repositories.write();

--- a/site/src/components/admin/user/RepositoryPermissions.vue
+++ b/site/src/components/admin/user/RepositoryPermissions.vue
@@ -218,7 +218,9 @@ watch(
       if (
         !originalPermissions.value.repository_permissions[repository.id] ||
         !repository.permissions.equalsArray(
-          originalPermissions.value.repository_permissions[repository.id] as Array<RepositoryActions>,
+          originalPermissions.value.repository_permissions[
+            repository.id
+          ] as Array<RepositoryActions>,
         )
       ) {
         console.log("Permissions have changed. repositoryPermissions !== originalPermissions");

--- a/site/src/components/nav/NavBar.vue
+++ b/site/src/components/nav/NavBar.vue
@@ -12,6 +12,12 @@
       </router-link>
     </div>
 
+    <RouterLink
+      :to="{ name: 'search' }"
+      class="navLink"
+      >Search</RouterLink
+    >
+
     <UserDropDown
       class="right"
       v-if="user" />

--- a/site/src/router/index.ts
+++ b/site/src/router/index.ts
@@ -12,6 +12,7 @@ import { profileRoutes } from "@/views/profile/profileRoutes";
 import { projectRoutes } from "@/views/projects";
 import NotFound from "@/views/NotFound.vue";
 import NpmLoginView from "@/views/NpmLoginView.vue";
+import SearchView from "@/views/SearchView.vue";
 import { repositoryPages } from "@/views/repositoryPages";
 declare module "vue-router" {
   interface RouteMeta {
@@ -59,6 +60,11 @@ const routes = [
     path: "/npm/login/:session",
     name: "npmLogin",
     component: NpmLoginView,
+  },
+  {
+    path: "/search",
+    name: "search",
+    component: SearchView,
   },
   ...repositoryPages,
   ...adminRoutes,

--- a/site/src/router/routes.json
+++ b/site/src/router/routes.json
@@ -1,102 +1,106 @@
 [
-    {
-        "path": "/browse/:id/:catchAll(.*)?",
-        "name": "Browse"
-    },
-    {
-        "path": "/login",
-        "name": "login"
-    },
-    {
-        "path": "/logout",
-        "name": "logout"
-    },
-    {
-        "path": "/page/repositories",
-        "name": "repositories"
-    },
-    {
-        "path": "/npm/login/:session",
-        "name": "npmLogin"
-    },
-    {
-        "path": "/page/repository/:repositoryId",
-        "name": "repository_page_by_id"
-    },
-    {
-        "path": "/page/repository/:storageName/:repositoryName",
-        "name": "repository_page_by_name"
-    },
-    {
-        "path": "/admin/install",
-        "name": "AdminInstall"
-    },
-    {
-        "path": "/admin",
-        "name": "admin"
-    },
-    {
-        "path": "/admin/users",
-        "name": "UsersList"
-    },
-    {
-        "path": "/admin/user/create",
-        "name": "UserCreate"
-    },
-    {
-        "path": "/admin/user/:id",
-        "name": "ViewUser"
-    },
-    {
-        "path": "/admin/repositories",
-        "name": "RepositoriesList"
-    },
-    {
-        "path": "/admin/repository/:id",
-        "name": "AdminViewRepository"
-    },
-    {
-        "path": "/admin/repositories/create",
-        "name": "RepositoryCreate"
-    },
-    {
-        "path": "/admin/storages",
-        "name": "StorageList"
-    },
-    {
-        "path": "/admin/storage/create",
-        "name": "StorageCreate"
-    },
-    {
-        "path": "/admin/storage/:id",
-        "name": "ViewStorage"
-    },
-    {
-        "path": "/admin/system",
-        "name": "SystemSettings"
-    },
-    {
-        "path": "/profile",
-        "name": "profile"
-    },
-    {
-        "path": "/profile/login",
-        "name": "profileLogin"
-    },
-    {
-        "path": "/profile/tokens",
-        "name": "profileTokens"
-    },
-    {
-        "path": "/profile/token/create",
-        "name": "profileTokenCreate"
-    },
-    {
-        "path": "/projects/:projectId/:version?",
-        "name": "ProjectPageView"
-    },
-    {
-        "path": "/projects/:storageName/:repositoryName/:projectKey/:version?",
-        "name": "project-page-by-key"
-    }
+  {
+    "path": "/browse/:id/:catchAll(.*)?",
+    "name": "Browse"
+  },
+  {
+    "path": "/login",
+    "name": "login"
+  },
+  {
+    "path": "/logout",
+    "name": "logout"
+  },
+  {
+    "path": "/page/repositories",
+    "name": "repositories"
+  },
+  {
+    "path": "/npm/login/:session",
+    "name": "npmLogin"
+  },
+  {
+    "path": "/search",
+    "name": "search"
+  },
+  {
+    "path": "/page/repository/:repositoryId",
+    "name": "repository_page_by_id"
+  },
+  {
+    "path": "/page/repository/:storageName/:repositoryName",
+    "name": "repository_page_by_name"
+  },
+  {
+    "path": "/admin/install",
+    "name": "AdminInstall"
+  },
+  {
+    "path": "/admin",
+    "name": "admin"
+  },
+  {
+    "path": "/admin/users",
+    "name": "UsersList"
+  },
+  {
+    "path": "/admin/user/create",
+    "name": "UserCreate"
+  },
+  {
+    "path": "/admin/user/:id",
+    "name": "ViewUser"
+  },
+  {
+    "path": "/admin/repositories",
+    "name": "RepositoriesList"
+  },
+  {
+    "path": "/admin/repository/:id",
+    "name": "AdminViewRepository"
+  },
+  {
+    "path": "/admin/repositories/create",
+    "name": "RepositoryCreate"
+  },
+  {
+    "path": "/admin/storages",
+    "name": "StorageList"
+  },
+  {
+    "path": "/admin/storage/create",
+    "name": "StorageCreate"
+  },
+  {
+    "path": "/admin/storage/:id",
+    "name": "ViewStorage"
+  },
+  {
+    "path": "/admin/system",
+    "name": "SystemSettings"
+  },
+  {
+    "path": "/profile",
+    "name": "profile"
+  },
+  {
+    "path": "/profile/login",
+    "name": "profileLogin"
+  },
+  {
+    "path": "/profile/tokens",
+    "name": "profileTokens"
+  },
+  {
+    "path": "/profile/token/create",
+    "name": "profileTokenCreate"
+  },
+  {
+    "path": "/projects/:projectId/:version?",
+    "name": "ProjectPageView"
+  },
+  {
+    "path": "/projects/:storageName/:repositoryName/:projectKey/:version?",
+    "name": "project-page-by-key"
+  }
 ]

--- a/site/src/views/SearchView.vue
+++ b/site/src/views/SearchView.vue
@@ -1,0 +1,209 @@
+<template>
+  <main class="search">
+    <h1>Search</h1>
+    <form
+      class="searchForm"
+      @submit.prevent="runSearch">
+      <input
+        v-model="input"
+        class="searchInput"
+        :class="{ invalid: parseError !== undefined }"
+        placeholder="Search, or write a query: scope == dev.kingtux and version ~= 1.*"
+        aria-label="Search" />
+      <SubmitButton>Search</SubmitButton>
+    </form>
+
+    <p
+      v-if="parseError"
+      class="parseError">
+      {{ parseError }}
+    </p>
+
+    <details class="help">
+      <summary>Query syntax</summary>
+      <p>
+        A plain word searches project keys, names and descriptions. For anything more specific,
+        write a query:
+      </p>
+      <ul>
+        <li><code>scope == dev.kingtux</code> — exact, case-insensitive</li>
+        <li>
+          <code>name ~= *-api</code> — glob, where <code>*</code> and <code>?</code> are wildcards
+        </li>
+        <li><code>not release_type == Snapshot</code> — negation</li>
+        <li>
+          <code>created &gt; 2024-01-01</code> — only on <code>created</code> and
+          <code>updated</code>
+        </li>
+        <li>
+          <code>(scope == a or scope == b) and version ~= 1.*</code> — grouping; <code>and</code> is
+          implied between two conditions
+        </li>
+      </ul>
+      <p>
+        Fields:
+        <code
+          v-for="field in fields"
+          :key="field.name"
+          class="field"
+          >{{ field.name }}</code
+        >
+      </p>
+    </details>
+
+    <p v-if="searched && results.length === 0 && !parseError">Nothing matched.</p>
+
+    <table
+      v-if="results.length > 0"
+      class="results">
+      <thead>
+        <tr>
+          <th>Project</th>
+          <th>Version</th>
+          <th>Repository</th>
+          <th>Updated</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="result in results"
+          :key="result.version_id">
+          <td>
+            <RouterLink
+              :to="{ name: 'ProjectPageView', params: { projectId: result.project_id } }"
+              >{{ result.project_key }}</RouterLink
+            >
+            <span
+              v-if="result.description"
+              class="description"
+              >{{ result.description }}</span
+            >
+          </td>
+          <td>{{ result.version }}</td>
+          <td>{{ result.storage }}/{{ result.repository }}</td>
+          <td>{{ new Date(result.updated_at).toLocaleDateString() }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </main>
+</template>
+
+<script setup lang="ts">
+import SubmitButton from "@/components/form/SubmitButton.vue";
+import http from "@/http";
+import { onMounted, ref } from "vue";
+import { RouterLink, useRoute, useRouter } from "vue-router";
+
+interface SearchResult {
+  project_id: string;
+  version_id: string;
+  repository: string;
+  storage: string;
+  project_key: string;
+  name: string;
+  scope?: string;
+  description?: string;
+  version: string;
+  updated_at: string;
+}
+interface SearchField {
+  name: string;
+  orderable: boolean;
+}
+
+const route = useRoute();
+const router = useRouter();
+const input = ref((route.query.q as string) ?? "");
+const results = ref<Array<SearchResult>>([]);
+const fields = ref<Array<SearchField>>([]);
+const parseError = ref<string | undefined>(undefined);
+const searched = ref(false);
+
+// An operator is what distinguishes a query from a search term, so the box accepts both rather
+// than making people choose a mode first.
+function looksLikeAQuery(value: string): boolean {
+  return /(==|!=|~=|!~|>=|<=|>|<)/.test(value);
+}
+
+async function runSearch() {
+  parseError.value = undefined;
+  searched.value = true;
+  const term = input.value.trim();
+  const params = looksLikeAQuery(term) ? { query: term } : { text: term };
+  // Keep the query in the URL so a search can be linked to and survives a refresh.
+  router.replace({ query: term ? { q: term } : {} });
+
+  await http
+    .get<{ results: Array<SearchResult> }>("/api/search", { params })
+    .then((response) => {
+      results.value = response.data.results;
+    })
+    .catch((error) => {
+      results.value = [];
+      // The API reports where a query went wrong; showing that beats "search failed".
+      parseError.value = error.response?.data?.error ?? "Search failed.";
+    });
+}
+
+onMounted(async () => {
+  await http
+    .get<Array<SearchField>>("/api/search/fields")
+    .then((response) => {
+      fields.value = response.data;
+    })
+    .catch(() => {});
+  if (input.value) {
+    await runSearch();
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.search {
+  padding: 1rem;
+  max-width: 60rem;
+  margin: 0 auto;
+}
+.searchForm {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+.searchInput {
+  flex: 1;
+  padding: 0.5rem;
+  font-family: inherit;
+  &.invalid {
+    border-color: #ff6b6b;
+  }
+}
+.parseError {
+  color: #ff6b6b;
+}
+.help {
+  margin: 1rem 0;
+  code {
+    padding: 0 0.2rem;
+  }
+  .field {
+    margin-right: 0.4rem;
+  }
+}
+.results {
+  width: 100%;
+  border-collapse: collapse;
+  th,
+  td {
+    text-align: left;
+    padding: 0.4rem 0.6rem;
+  }
+  th {
+    border-bottom: 1px solid currentColor;
+  }
+  .description {
+    display: block;
+    opacity: 0.75;
+    font-size: 0.9rem;
+  }
+}
+</style>


### PR DESCRIPTION
Closes #411 and the primary items of #506.

> **Merge after #563.** Based on the scopes branch, so its commit shows here until that lands.

## The query language (#411)

The issue asks for artifact searching modelled on Strongbox's and Artifactory's query languages, **"pushed as a separate library"**. `crates/aql` is that — a lexer, a recursive-descent parser, a typed AST and a compiler to a parameterized SQL predicate, depending on nothing but `serde` and `thiserror` so it can genuinely stand alone. 30 tests.

```
repo == releases and scope == dev.kingtux and version ~= "1.*"
name ~= *.jar and not release_type == Snapshot
(scope == a or scope == b) and created > 2024-01-01
```

Three decisions worth review attention:

- **Values never reach the statement.** The compiler returns a predicate of placeholders plus the values to bind; column names come from the `Field` enum rather than from the query. There is nothing to escape, and no later change can reintroduce an injection by forgetting to. There's a test that throws `'; DROP TABLE projects; --` at both the equality and the glob path.
- **Ordering is refused on non-temporal fields.** `name > b` would silently compile to a lexicographic comparison — almost never what was meant, and it never says so.
- **Negation wraps in `COALESCE`.** `NOT (col = x)` is NULL, not true, when the column is NULL — so `not description == "x"` would quietly drop every project that has no description.

Writing the tests caught a real bug: a value starting with a digit took the number branch, which consumes only digits, so `1.0.0` stopped at the first `.` and reported it as an unexpected character. Versions and dates are *the* common case for a value.

## Search API

`GET /api/search?text=foo` expands a plain word into a query over project key, name and description. `?query=` takes the language directly. `GET /api/search/fields` lists what's queryable so the UI doesn't hardcode a second list.

Results are filtered by what the caller can read — otherwise search is a way to enumerate a private repository without ever fetching from it.

A parse failure returns the character offset it happened at, so the UI can point at it rather than saying "search failed".

A frontend page at `/search` with a syntax reference, linkable via `?q=`.

## #506

- **Repository renaming** — its first item, and there was no update path at all; a name was fixed at creation. This also has to invalidate the name lookup table, which is filled lazily and was *never* invalidated: without that the repository answers on both the old and new name until a restart.
- **Publish history now records who published.** The type was already served but carried no publisher, which is the main thing a history gets consulted for. Left join, so a version published before the publisher was recorded — or by a since-deleted user — still appears.
- **A batched config endpoint**, for "config API is verbose". Rendering a repository's settings meant one request to list the keys and then one per key, each re-doing the same permission check.

## Another leak, found while wiring the search authorization

All three project API routes took an `auth` argument and **never looked at it** — every project and every version list in a private repository was readable by anyone who could guess an id. Same shape as the repository-listing leak in #563.

## Not here

Repository logging, docs, and #412 (disk usage, log viewer). The logging and viewer items are listed as extras, and #412 itself says the viewer "might become its own separate project". None of them is a query-layer problem, and bundling them would make this harder to review. Say the word if you'd rather I fold #412's disk-usage half in.

## Verification
- `cargo test --all` with `STORAGE_TESTS_REQUIRE_ALL=1` and MinIO up — 120 passing
- `cargo clippy --all --all-targets -- -D warnings` clean
- `cargo +nightly fmt --all --check` clean
- `npm run type-check`, `npm run lint`, `npm run build` clean

The search endpoint itself is not yet covered by a test that runs a query against a real database — that needs the Phase 8 harness. The query language underneath it is covered thoroughly.