### PR TITLE
Testing: a seed command, an integration harness, and the four bugs they found

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -43,6 +43,11 @@ jobs:
         run: cargo test --all
         env:
           STORAGE_TESTS_REQUIRE_ALL: 1
+          # The integration tests skip when there is no database, so that a developer without one
+          # is not blocked. Postgres is up here, so make a skip an error — otherwise the end-to-end
+          # suite silently stops running and nobody notices.
+          NITRO_TESTS_REQUIRE_DB: 1
+          NITRO_TEST_DATABASE_URL: postgres://postgres:password@localhost/nr_tests
       - name: Service logs
         if: failure()
         run: docker compose -f docker-compose.dev.yml logs

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -48,6 +48,9 @@ jobs:
           # suite silently stops running and nobody notices.
           NITRO_TESTS_REQUIRE_DB: 1
           NITRO_TEST_DATABASE_URL: postgres://postgres:password@localhost/nr_tests
+          # `TestCore` reads this one. It normally comes from `nr_tests.env`, which is gitignored
+          # — it holds whatever local database a developer uses — so it does not exist here.
+          DATABASE_URL: postgres://postgres:password@localhost/nr_tests
       - name: Service logs
         if: failure()
         run: docker compose -f docker-compose.dev.yml logs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,27 +1,112 @@
-# Requirements to Contribute
+# Contributing
 
-1. Rust 1.56 or newer installed
-2. Mysql C++ Driver/Connector installed
-3. Mysql Database Ready for use
-4. For SSL openssl library installed
-5. Node 16 installed and NPM installed
-6. Lots of Patience.
+## What you need
 
-# Configuring nitro repo.
+- **Rust** — the toolchain is pinned in `rust-toolchain.toml`, so `rustup` picks it up. Formatting
+  additionally needs a nightly (`rustup toolchain install nightly`): `rustfmt.toml` sets
+  `imports_granularity` and `group_imports`, which stable rustfmt ignores *without saying so*, so
+  formatting on stable and on nightly disagree and fight each other.
+- **Node** — the version is in `site/.node-version`.
+- **Docker** — for Postgres and MinIO. You can point at your own instead; see below.
+- **[`just`](https://github.com/casey/just)** — optional, but every command below has a recipe.
 
-1. Copy example.env to your working directory of the application and name it .env
-2. The only one you will need to edit will be the `DATABASE_URL` and BIND_URL if that port is already in use
+There is no MySQL and no C++ connector. That requirement, along with the Node 16 and the `.env` file
+this document used to describe, predates the 2.0 rewrite by several years.
 
-# Development Frontend Only
+## Backing services
 
-1. Follow all steps up to this point only changing the cargo build command
-   to `cargo build --release --features dev-frontend`
-2. Then add a .env.local inside the site directory and add the value `VITE_API_URL=http://127.0.0.1:6742` Changing the
-   URL if necessary.
-3. You can at this point execute `npm run dev` with the backend executable running and work on the frontend
+```sh
+just services-up
+```
 
-# Development Full Stack or Backend
+That starts MinIO and creates the test bucket. Postgres sits behind a profile, because
+`nr_tests.env` points at `localhost:5432` and plenty of people already run one there — a second
+would just fail to bind the port. If you need one:
 
-1. I recommend following the Frontend development steps because using the frontend development mode will be easier
-2. Ignore the --release argument. Because you are doing development. 
+```sh
+docker compose -f docker-compose.dev.yml --profile postgres up -d --wait postgres
+```
 
+`nr_tests.env` holds the `DATABASE_URL` the tests use. Point it wherever you like.
+
+## Running the tests
+
+```sh
+just test             # everything a laptop can run
+just test-all         # the same, but a skipped backend or a missing database is a failure
+just test-integration # only the end-to-end suite
+```
+
+Tests that need a service they cannot reach **skip with a message** rather than failing, so you are
+never blocked by a backend you are not working on. CI sets `STORAGE_TESTS_REQUIRE_ALL=1` and
+`NITRO_TESTS_REQUIRE_DB=1`, which turns every skip into a failure — otherwise a suite could quietly
+stop running and nobody would notice.
+
+The integration tests each create their own database and storage directory, and drive the real
+router in-process. They do not bind a port, so they run in parallel and there is no server to start.
+
+## Running it
+
+```sh
+cargo run -p nitro_repo -- save-config --config nitro_repo.toml
+$EDITOR nitro_repo.toml     # at minimum, the [database] section
+cargo run -p nitro_repo -- start --config nitro_repo.toml
+```
+
+Then open the instance and create the first administrator.
+
+### Filling it with something to look at
+
+An empty instance is hard to judge — browsing, search, badges and metadata merging all behave
+differently with one artifact than with forty. This deploys a suite of Maven artifacts and npm
+packages over the real protocols:
+
+```sh
+cargo run -p nitro_repo -- seed --config seed.toml --write-example
+$EDITOR seed.toml           # the password, and the storage path
+just seed seed.toml
+```
+
+Re-running is safe; anything already present is left alone.
+
+## Frontend
+
+```sh
+cd site
+npm install
+npm run dev
+```
+
+The dev server expects a backend on `http://localhost:6742`. If yours is elsewhere, put
+`VITE_API_URL=http://host:port` in `site/.env.local`.
+
+Two things under `site/` are **generated** — do not edit them by hand:
+
+- `src/router/routes.json`, from the router. The backend reads it to decide which paths get the
+  SPA's index.html, so a route missing from it is a hard 404 on refresh. `npm run generate-routes`.
+- `src/types/api.d.ts`, from the OpenAPI document.
+  `npm run export-openapi && npm run generate-api-types`.
+
+## Before you open a pull request
+
+```sh
+just fmt      # cargo +nightly fmt --all, and prettier over site/
+just lint     # clippy with -D warnings
+just test-all
+cd site && npm run type-check && npm run lint && npm run build
+```
+
+CI runs all of these. `deprecated = "deny"` is set workspace-wide, so a deprecation is a build
+failure rather than a warning you can leave for later.
+
+## Layout
+
+| Path              | What it is                                                                    |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `nitro_repo/`     | The server: HTTP, repository types, authentication. `main.rs` is only the CLI  |
+| `crates/core/`    | Shared types, the database entities, and the migrations                       |
+| `crates/storage/` | Storage backends — Local, FileSystemV2, S3                                    |
+| `crates/aql/`     | The query language behind search. Depends on nothing but serde and thiserror  |
+| `crates/macros/`  | Macros the other crates use                                                   |
+| `crates/nr-api/`  | A client for the API                                                          |
+| `site/`           | The frontend                                                                  |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,6 +1738,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,7 +2378,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -2910,6 +2920,7 @@ dependencies = [
  "current_semver",
  "derive_more",
  "digestible",
+ "flate2",
  "flume 0.12.0",
  "futures",
  "futures-util",
@@ -2954,6 +2965,7 @@ dependencies = [
  "sha2 0.11.0",
  "sqlx",
  "strum 0.28.0",
+ "tar",
  "tempfile",
  "thiserror 2.0.19",
  "tokio",
@@ -3673,7 +3685,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.43",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror 2.0.19",
  "tokio",
  "tracing",
@@ -3712,7 +3724,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -4935,6 +4947,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5849,7 +5872,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6160,6 +6183,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xmlparser"

--- a/README.md
+++ b/README.md
@@ -1,29 +1,68 @@
-# nitro_repo [![Documentation](https://img.shields.io/static/v1?label=nitro-repo.kingtux.dev&message=Here&style=for-the-badge&color=green)](https://nitro-repo.kingtux.dev/) [![Powered By Actix](https://img.shields.io/badge/Powered%20By-Actix-red?style=for-the-badge&logo=rust)](https://github.com/actix/actix-web)
+# nitro_repo [![Documentation](https://img.shields.io/static/v1?label=nitro-repo.kingtux.dev&message=Here&style=for-the-badge&color=green)](https://nitro-repo.kingtux.dev/) [![Powered By Axum](https://img.shields.io/badge/Powered%20By-Axum-black?style=for-the-badge&logo=rust)](https://github.com/tokio-rs/axum)
 
 [![issues](https://img.shields.io/github/issues/wherkamp/nitro_repo/help%20wanted)](https://github.com/wherkamp/nitro_repo/issues)
 
-Nitro Repo is an open source free artifact manager. Written with a Rust back end and a Vue front end to create a fast
-and modern experience.
+Nitro Repo is a free and open source artifact manager, with a Rust backend and a Vue frontend.
+
+> The badge said "Powered By Actix" until recently. 2.0 moved to Axum and Sea-ORM to SQLx; the badge
+> had simply never caught up.
 
 ### History
 
-After years of using Nexus and then a bit of time of using StrongBox I decided I should design my own Artifact Manager
-to create a fast and modern experience.
+After years of using Nexus, and a while on Strongbox, I decided to design my own artifact manager for
+a faster and more modern experience.
 
-### Technical Design
+### What it does
 
-- Backend or the heart of nitro_repo
-  - SQLX for Postgres
-  - Axum for HTTP Server
+- **Maven** — hosted and proxy repositories, generated `maven-metadata.xml` (including timestamped
+  snapshots), checksum verification on upload and generation on demand, and enforced push rules.
+- **npm** — a hosted registry: scoped packages, dist-tags, publish, unpublish, deprecate, search,
+  and both login flows including the browser one npm 9+ defaults to.
+- **Storage** — the local filesystem, a self-contained object format (FileSystemV2), or S3 and
+  anything S3-compatible.
+- **Search** — a small query language (`crates/aql`) over projects and versions, exposed both as
+  plain text search and as a full query syntax.
+
+### Technical design
+
+- Backend
+  - Axum for the HTTP server
+  - SQLx against Postgres
+  - utoipa for the OpenAPI document, from which the frontend's types are generated
 - Frontend
-  - Vue
+  - Vue 3
   - Vite
 
 ### Crates
-- crates/core
-  - Lays out some shared data types between different modules.
-- crates/macros
-  - Macros used by the other crates. To prevent writing so much code
-- crates/storages
-  - This layer provides different ways storing the artifacts that nitro-repo hosts
 
+| Path              | What it is                                                                    |
+| ----------------- | ----------------------------------------------------------------------------- |
+| `nitro_repo/`     | The server: HTTP, repository types, authentication. `main.rs` is only the CLI  |
+| `crates/core/`    | Shared types, the database entities, and the migrations                       |
+| `crates/storage/` | Storage backends — Local, FileSystemV2, S3                                    |
+| `crates/aql/`     | The query language behind search. Depends on nothing but serde and thiserror  |
+| `crates/macros/`  | Macros the other crates use                                                   |
+| `crates/nr-api/`  | A client for the API                                                          |
+
+### Running it
+
+The published image, with a volume for its data:
+
+```sh
+docker compose up -d
+```
+
+Building it yourself, and everything else you would need to work on it, is in
+[CONTRIBUTING.md](CONTRIBUTING.md). To fill an instance with something to look at,
+`nitro_repo seed --config seed.toml` deploys a suite of artifacts over the real protocols.
+
+### Status
+
+2.0 is in beta. Breaking changes are still on the table.
+
+### Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=wyatt-herkamp/nitro_repo)](https://github.com/wyatt-herkamp/nitro_repo/graphs/contributors)
+
+Thanks to everyone who has sent a patch. Contributions of any size are welcome —
+[CONTRIBUTING.md](CONTRIBUTING.md) has what you need to get a working environment.

--- a/crates/aql/src/sql.rs
+++ b/crates/aql/src/sql.rs
@@ -103,7 +103,13 @@ impl Compiler {
                 // ILIKE, because artifact coordinates are matched case-insensitively everywhere
                 // else in this codebase. ESCAPE names the character `glob_to_like` used, so a
                 // literal `%` or `_` in a query stays literal.
-                let comparison = format!("{column} ILIKE {placeholder} ESCAPE '\\'");
+                //
+                // `COLLATE "C"` is not cosmetic: `projects.key` carries a nondeterministic ICU
+                // collation (`ignorecase`), and Postgres refuses LIKE and ILIKE against those with
+                // `nondeterministic collations are not supported for ILIKE`. Forcing a
+                // deterministic collation on the operand is what makes the pattern match legal;
+                // ILIKE still supplies the case-insensitivity the collation was there for.
+                let comparison = format!("{column} COLLATE \"C\" ILIKE {placeholder} ESCAPE '\\'");
                 if operator == Operator::NotMatches {
                     format!("(NOT COALESCE({comparison}, FALSE))")
                 } else {
@@ -245,6 +251,14 @@ mod tests {
         let compiled = compile("name ~= *.jar");
         assert_eq!(compiled.bindings, vec![Binding::Text("%.jar".to_owned())]);
         assert!(compiled.predicate.contains("ILIKE"));
+        // `projects.key` carries a nondeterministic collation in the real schema, and Postgres
+        // rejects LIKE/ILIKE against those outright. Without this the query compiles, passes every
+        // unit test here, and then fails at runtime against an actual database.
+        assert!(
+            compiled.predicate.contains(r#"COLLATE "C""#),
+            "glob comparisons must force a deterministic collation: {}",
+            compiled.predicate
+        );
         assert!(compiled.predicate.contains(r"ESCAPE '\'"));
     }
 

--- a/crates/core/migrations/20260801150000_release_type_text.down.sql
+++ b/crates/core/migrations/20260801150000_release_type_text.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE project_versions
+    ALTER COLUMN release_type TYPE VARCHAR(255);

--- a/crates/core/migrations/20260801150000_release_type_text.up.sql
+++ b/crates/core/migrations/20260801150000_release_type_text.up.sql
@@ -1,0 +1,16 @@
+-- `project_versions.release_type` was created as VARCHAR(255) while `ReleaseType` declares
+-- `#[sqlx(type_name = "TEXT")]`. sqlx checks the column's type OID when decoding, so every read of
+-- a row carrying this column failed with:
+--
+--     mismatched types; Rust type `ReleaseType` (as SQL type `TEXT`) is not compatible with
+--     SQL type `VARCHAR`
+--
+-- which is why nothing that lists Maven versions ever returned any. It went unnoticed because
+-- `post_pom_upload` only *logged* its errors until Phase 4 made them returned, so a deploy reported
+-- 201 while its version registration had failed.
+--
+-- Every other enum-backed column in this schema is already TEXT; this brings the last one in line.
+-- In Postgres the two are the same storage — varchar(n) is text plus a length check — so no data
+-- moves and nothing is truncated.
+ALTER TABLE project_versions
+    ALTER COLUMN release_type TYPE TEXT;

--- a/crates/core/src/testing/env_file.rs
+++ b/crates/core/src/testing/env_file.rs
@@ -1,11 +1,12 @@
 use std::path::PathBuf;
 
 use ahash::{HashMap, HashMapExt};
-use tracing::{debug, info, instrument};
+use tracing::{debug, instrument};
+
 #[instrument]
 pub fn find_file(dir: PathBuf, file_name: &str) -> Option<PathBuf> {
     let env_file = dir.join(file_name);
-    info!("Checking for file: {:?}", env_file);
+    debug!("Checking for file: {:?}", env_file);
     if env_file.exists() {
         return Some(env_file);
     }
@@ -13,29 +14,58 @@ pub fn find_file(dir: PathBuf, file_name: &str) -> Option<PathBuf> {
     debug!("Checking parent: {:?}", parent);
     find_file(parent.to_path_buf(), file_name)
 }
+
 #[derive(Debug)]
 pub struct EnvFile {
-    pub file: PathBuf,
+    /// `None` when there was no file and the values come from the environment alone.
+    pub file: Option<PathBuf>,
     pub key_values: HashMap<String, String>,
 }
+
 impl EnvFile {
+    /// Loads a `key=value` file, falling back to the process environment.
+    ///
+    /// A missing file is not an error. `nr_tests.env` is gitignored — it holds whatever local
+    /// database a developer happens to use — so it does not exist in CI, and this used to fail with
+    /// "File not found" before [`Self::get`] ever got the chance to read `DATABASE_URL` from the
+    /// environment. Every test built on `TestCore` was therefore unrunnable anywhere but a machine
+    /// that had the file.
     pub fn load(file_name: &str) -> anyhow::Result<Self> {
         let current_dir = std::env::current_dir()?;
-        let file =
-            find_file(current_dir, file_name).ok_or_else(|| anyhow::anyhow!("File not found"))?;
+        let Some(file) = find_file(current_dir, file_name) else {
+            debug!("No {file_name}; using the environment only");
+            return Ok(Self {
+                file: None,
+                key_values: HashMap::new(),
+            });
+        };
+
         let file_contents = std::fs::read_to_string(&file)?;
         let mut key_values = HashMap::new();
         for line in file_contents.lines() {
-            let (key, value) = line.split_once('=').unwrap();
+            let line = line.trim();
+            // Blank lines and comments used to reach `split_once(..).unwrap()` and panic.
+            if line.is_empty() || line.starts_with('#') {
+                continue;
+            }
+            let Some((key, value)) = line.split_once('=') else {
+                debug!("Ignoring a line with no `=`: {line}");
+                continue;
+            };
+            key_values.insert(key.trim().to_owned(), value.trim().to_owned());
+        }
 
-            key_values.insert(key.to_string(), value.to_string());
-        }
-        Ok(Self { file, key_values })
+        Ok(Self {
+            file: Some(file),
+            key_values,
+        })
     }
+
+    /// The environment wins over the file, so CI can override without editing anything.
     pub fn get(&self, key: &str) -> Option<String> {
-        if let Ok(key) = std::env::var(key) {
-            return Some(key);
+        if let Ok(value) = std::env::var(key) {
+            return Some(value);
         }
-        self.key_values.get(key).map(|s| s.to_owned())
+        self.key_values.get(key).map(|value| value.to_owned())
     }
 }

--- a/crates/core/src/testing/mod.rs
+++ b/crates/core/src/testing/mod.rs
@@ -59,7 +59,14 @@ impl TestCore {
         }
     }
     async fn connect(env_file: &EnvFile) -> anyhow::Result<PgPool> {
-        let env = env_file.get("DATABASE_URL").unwrap();
+        // An error rather than an `unwrap`, so a caller with no database configured can skip
+        // instead of panicking with an unexplained `Option::unwrap`.
+        let env = env_file.get("DATABASE_URL").ok_or_else(|| {
+            anyhow::anyhow!(
+                "No DATABASE_URL. Set it in the environment, or put it in an `nr_tests.env` \
+                 alongside the workspace root."
+            )
+        })?;
         debug!("Connecting to database {}", env);
         let db = PgPool::connect(&env).await?;
         Ok(db)

--- a/crates/core/tests/database.rs
+++ b/crates/core/tests/database.rs
@@ -1,0 +1,248 @@
+//! Database-level tests. (#502)
+//!
+//! `TestCore` has existed the whole time with exactly one `#[ignore]`d self-test, so no entity
+//! method was ever executed against Postgres. Both of the defects these cover were invisible to the
+//! unit tests: one because it only appears with more than one row present, the other because it
+//! only appears when a value is decoded back out of a real column.
+//!
+//! Like the server's integration tests, these skip when there is no database, unless
+//! `NITRO_TESTS_REQUIRE_DB=1` — which CI sets, so a skip there is a failure.
+
+use nr_core::{
+    database::entities::project::{
+        NewProject,
+        versions::{DBProjectVersion, NewVersion, UpdateProjectVersion},
+    },
+    repository::project::{ReleaseType, VersionData},
+    testing::TestCore,
+};
+use sqlx::PgPool;
+use tokio::sync::Mutex;
+use uuid::Uuid;
+
+/// Serializes the migration run.
+///
+/// `TestCore::new` runs the migrations every time. These tests run in parallel against one shared
+/// database, so several of them tried to create the same types at once and collided on
+/// `pg_type_typname_nsp_index`. Only the setup is serialized — the pool itself must stay per-test,
+/// because each `#[tokio::test]` has its own runtime and a pool created in one dies when that
+/// runtime shuts down.
+static MIGRATIONS: Mutex<()> = Mutex::const_new(());
+
+/// `None` when there is no database to use.
+async fn core(function_path: &str) -> Option<PgPool> {
+    let result = {
+        let _guard = MIGRATIONS.lock().await;
+        TestCore::new(function_path.to_owned()).await
+    };
+
+    match result {
+        Ok((core, _entry)) => Some(core.db),
+        Err(error) => {
+            if std::env::var("NITRO_TESTS_REQUIRE_DB").as_deref() == Ok("1") {
+                panic!(
+                    "{function_path} needs a database and NITRO_TESTS_REQUIRE_DB=1 was set: {error}"
+                );
+            }
+            eprintln!("skipping {function_path}: no test database ({error})");
+            None
+        }
+    }
+}
+
+/// A storage and a repository for a project to hang off.
+///
+/// Written as raw SQL because creating a repository lives in the server crate, not here — this only
+/// needs the rows to satisfy the foreign keys.
+async fn repository(db: &PgPool) -> Uuid {
+    let unique = Uuid::new_v4();
+    let storage_id: Uuid = sqlx::query_scalar(
+        r#"INSERT INTO storages (storage_type, name, config)
+           VALUES ('Local', $1, '{"path": "/tmp/nitro-core-tests"}'::jsonb)
+           RETURNING id"#,
+    )
+    .bind(format!("test-storage-{unique}"))
+    .fetch_one(db)
+    .await
+    .expect("the test storage should insert");
+
+    sqlx::query_scalar(
+        r#"INSERT INTO repositories (id, storage_id, name, repository_type, active)
+           VALUES ($1, $2, $3, 'maven', true)
+           RETURNING id"#,
+    )
+    .bind(unique)
+    .bind(storage_id)
+    .bind(format!("test-repo-{unique}"))
+    .fetch_one(db)
+    .await
+    .expect("the test repository should insert")
+}
+
+async fn project(db: &PgPool, repository: Uuid) -> Uuid {
+    let unique = Uuid::new_v4();
+    NewProject {
+        scope: Some("dev.kingtux".to_owned()),
+        project_key: format!("dev.kingtux:test-{unique}"),
+        name: format!("test-{unique}"),
+        description: None,
+        repository,
+        storage_path: format!("dev/kingtux/test-{unique}"),
+    }
+    .insert(db)
+    .await
+    .expect("the project should insert")
+    .id
+}
+
+async fn version(db: &PgPool, project_id: Uuid, version: &str) -> Uuid {
+    NewVersion {
+        project_id,
+        version: version.to_owned(),
+        release_type: ReleaseType::Stable,
+        version_path: format!("dev/kingtux/test/{version}"),
+        publisher: None,
+        version_page: None,
+        extra: VersionData::default(),
+    }
+    .insert(db)
+    .await
+    .expect("the version should insert")
+    .id
+}
+
+/// Reads one version straight out of the table, bypassing every helper.
+///
+/// The point of the unfiltered-UPDATE regression is that a row's *id* was rewritten, so looking it
+/// up by anything other than its id would not notice.
+async fn version_by_id(db: &PgPool, id: Uuid) -> Option<DBProjectVersion> {
+    sqlx::query_as("SELECT * FROM project_versions WHERE id = $1")
+        .bind(id)
+        .fetch_optional(db)
+        .await
+        .expect("query")
+}
+
+/// The regression for the unfiltered UPDATE.
+///
+/// `UpdateProjectVersion::update` passed the target id to `set` rather than `filter`, producing an
+/// `UPDATE ... SET id = $1` with no `WHERE` at all — it rewrote the primary key of *every* version
+/// in the table. With one row it silently looked fine, which is why it survived: this needs two.
+#[tokio::test]
+async fn updating_one_version_leaves_the_others_alone() {
+    let Some(db) = core("database::updating_one_version_leaves_the_others_alone").await else {
+        return;
+    };
+
+    let repository = repository(&db).await;
+    let project_id = project(&db, repository).await;
+    let first = version(&db, project_id, "1.0.0").await;
+    let second = version(&db, project_id, "2.0.0").await;
+
+    UpdateProjectVersion {
+        release_type: Some(ReleaseType::Unknown),
+        ..Default::default()
+    }
+    .update(first, &db)
+    .await
+    .expect("the update should succeed");
+
+    let updated = version_by_id(&db, first)
+        .await
+        .expect("the updated version should still exist under its own id");
+    assert_eq!(updated.release_type, ReleaseType::Unknown);
+    assert_eq!(updated.version, "1.0.0");
+
+    let untouched = version_by_id(&db, second)
+        .await
+        .expect("the other version should still exist — an unfiltered UPDATE rewrites its id");
+    assert_eq!(
+        untouched.release_type,
+        ReleaseType::Stable,
+        "updating one version must not change another"
+    );
+    assert_eq!(untouched.version, "2.0.0");
+}
+
+/// The regression for the column type mismatch.
+///
+/// `project_versions.release_type` was VARCHAR(255) while `ReleaseType` declares
+/// `#[sqlx(type_name = "TEXT")]`. sqlx checks the column's type OID when decoding, so *reading* a
+/// version failed even though writing one worked. Nothing that listed Maven versions returned any,
+/// and the deploy still reported success.
+#[tokio::test]
+async fn every_release_type_survives_a_round_trip() {
+    let Some(db) = core("database::every_release_type_survives_a_round_trip").await else {
+        return;
+    };
+
+    let repository = repository(&db).await;
+    let project_id = project(&db, repository).await;
+
+    for (index, release_type) in [
+        ReleaseType::Stable,
+        ReleaseType::Beta,
+        ReleaseType::Alpha,
+        ReleaseType::Snapshot,
+        ReleaseType::ReleaseCandidate,
+        ReleaseType::Unknown,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        let version_string = format!("1.0.{index}");
+        NewVersion {
+            project_id,
+            version: version_string.clone(),
+            release_type: release_type.clone(),
+            version_path: format!("dev/kingtux/test/{version_string}"),
+            publisher: None,
+            version_page: None,
+            extra: VersionData::default(),
+        }
+        .insert(&db)
+        .await
+        .expect("the version should insert");
+
+        // The decode is the point. Inserting worked before the fix; reading back did not.
+        let found = DBProjectVersion::find_by_version_and_project(&version_string, project_id, &db)
+            .await
+            .unwrap_or_else(|error| {
+                panic!("reading back a {release_type:?} version failed: {error}")
+            })
+            .expect("the version should be found");
+
+        assert_eq!(found.release_type, release_type);
+    }
+}
+
+/// Versions come back newest-first. Without an `ORDER BY` this is whatever Postgres happens to
+/// return, which is what made npm's `dist-tags.latest` nondeterministic.
+#[tokio::test]
+async fn versions_are_returned_in_a_defined_order() {
+    let Some(db) = core("database::versions_are_returned_in_a_defined_order").await else {
+        return;
+    };
+
+    let repository = repository(&db).await;
+    let project_id = project(&db, repository).await;
+
+    version(&db, project_id, "1.0.0").await;
+    version(&db, project_id, "1.1.0").await;
+    version(&db, project_id, "2.0.0").await;
+
+    let first = DBProjectVersion::get_all_versions(project_id, &db)
+        .await
+        .expect("query");
+    let second = DBProjectVersion::get_all_versions(project_id, &db)
+        .await
+        .expect("query");
+
+    assert_eq!(first.len(), 3);
+    let first: Vec<&str> = first.iter().map(|value| value.version.as_str()).collect();
+    let second: Vec<&str> = second.iter().map(|value| value.version.as_str()).collect();
+    assert_eq!(
+        first, second,
+        "two identical queries must return the same order"
+    );
+}

--- a/justfile
+++ b/justfile
@@ -18,12 +18,22 @@ services-up:
 services-down:
     docker compose -f docker-compose.dev.yml down
 
-# Backends with no service running are skipped with a warning. Run `just services-up` first, or
-# `just test-all` to make a skipped backend a failure instead.
+# Backends with no service running are skipped with a warning, and so are the integration tests
+# when there is no database. Run `just services-up` first, or `just test-all` to make a skip a
+# failure instead.
 test:
     cargo test --all
 test-all:
-    STORAGE_TESTS_REQUIRE_ALL=1 cargo test --all
+    STORAGE_TESTS_REQUIRE_ALL=1 NITRO_TESTS_REQUIRE_DB=1 cargo test --all
+
+# The end-to-end suite on its own: real Maven and npm requests against the real router, each test
+# in its own database.
+test-integration:
+    NITRO_TESTS_REQUIRE_DB=1 cargo test -p nitro_repo --test maven --test npm --test authorization
+
+# Fills a running instance with a suite of artifacts, over the real protocols.
+seed config="seed.example.toml":
+    cargo run -p nitro_repo -- seed --config {{config}}
 
 lint:
     cargo clippy --all --all-targets -- -D warnings

--- a/nitro_repo/Cargo.toml
+++ b/nitro_repo/Cargo.toml
@@ -130,6 +130,8 @@ url = "2"
 serde_urlencoded = "0.7"
 inquire = "0.9"
 serde_path_to_error = "0.1"
+tar = "0.4.46"
+flate2 = "1.1.9"
 [features]
 default = ["utoipa-scalar"]
 frontend = []

--- a/nitro_repo/Cargo.toml
+++ b/nitro_repo/Cargo.toml
@@ -8,7 +8,10 @@ repository.workspace = true
 build = "build.rs"
 
 [dev-dependencies]
+http-body-util.workspace = true
 pretty_assertions = "1.4"
+tempfile = "3"
+tower = { version = "0.5", features = ["util"] }
 [dependencies]
 # Web
 axum = { version = "0.8", features = ["macros", "tokio", "ws"] }

--- a/nitro_repo/src/app/config.rs
+++ b/nitro_repo/src/app/config.rs
@@ -6,7 +6,7 @@ use strum::EnumIs;
 use tuxs_config_types::size_config::InvalidSizeError;
 use utoipa::ToSchema;
 mod max_upload;
-mod security;
+pub mod security;
 pub use max_upload::*;
 pub use security::*;
 

--- a/nitro_repo/src/app/web.rs
+++ b/nitro_repo/src/app/web.rs
@@ -33,7 +33,7 @@ use crate::app::request_logging::AppTracingLayer;
 
 const POWERED_BY_HEADER: HeaderName = HeaderName::from_static("x-powered-by");
 const POWERED_BY_VALUE: HeaderValue = HeaderValue::from_static("Nitro Repo");
-pub(crate) async fn start(config_path: Option<PathBuf>) -> anyhow::Result<()> {
+pub async fn start(config_path: Option<PathBuf>) -> anyhow::Result<()> {
     let NitroRepoConfig {
         web_server,
         database,
@@ -71,31 +71,7 @@ pub(crate) async fn start(config_path: Option<PathBuf>) -> anyhow::Result<()> {
     site.start_session_cleaner();
 
     let cloned_site = site.clone();
-    let auth_layer = AuthenticationLayer::from(site.clone());
-    let mut app = Router::new()
-        // `/repositories/{storage}/{repository}/{*path}` is the canonical artifact URL — it is what
-        // `repositoryUrl()` in the frontend hands to Maven and npm. `/storages` used to be nested
-        // with the identical router, which served every artifact under a second URL that nothing
-        // generated and that reads as if it addressed the storage API.
-        .nest("/repositories", crate::repository::repository_router())
-        .nest("/api", api::api_routes())
-        .nest("/badge", super::badge::badge_routes())
-        .fallback(super::frontend::frontend_request)
-        .with_state(site.clone());
-
-    if open_api_routes {
-        info!("OpenAPI routes enabled");
-        app = app.merge(open_api::build_router())
-    }
-    let body_limit: DefaultBodyLimit = max_upload.into();
-    let app = app
-        .layer(auth_layer)
-        .layer(SetResponseHeaderLayer::if_not_present(
-            POWERED_BY_HEADER,
-            POWERED_BY_VALUE,
-        ))
-        .layer(AppTracingLayer(site.clone()))
-        .layer(body_limit);
+    let app = build_app(site.clone(), open_api_routes, max_upload.into());
 
     if let Some(tls) = tls {
         debug!("Starting TLS server");
@@ -112,6 +88,38 @@ pub(crate) async fn start(config_path: Option<PathBuf>) -> anyhow::Result<()> {
     drop(logger);
     Ok(())
 }
+/// Assembles the whole application router.
+///
+/// Separate from [`start`] so the integration tests can drive the real router in-process, with the
+/// real middleware stack, rather than starting a server on a port and talking to it over TCP. A
+/// test that builds its own router tests its own router.
+pub fn build_app(site: NitroRepo, open_api_routes: bool, body_limit: DefaultBodyLimit) -> Router {
+    let auth_layer = AuthenticationLayer::from(site.clone());
+    let mut app = Router::new()
+        // `/repositories/{storage}/{repository}/{*path}` is the canonical artifact URL — it is what
+        // `repositoryUrl()` in the frontend hands to Maven and npm. `/storages` used to be nested
+        // with the identical router, which served every artifact under a second URL that nothing
+        // generated and that reads as if it addressed the storage API.
+        .nest("/repositories", crate::repository::repository_router())
+        .nest("/api", api::api_routes())
+        .nest("/badge", super::badge::badge_routes())
+        .fallback(super::frontend::frontend_request)
+        .with_state(site.clone());
+
+    if open_api_routes {
+        info!("OpenAPI routes enabled");
+        app = app.merge(open_api::build_router())
+    }
+
+    app.layer(auth_layer)
+        .layer(SetResponseHeaderLayer::if_not_present(
+            POWERED_BY_HEADER,
+            POWERED_BY_VALUE,
+        ))
+        .layer(AppTracingLayer(site.clone()))
+        .layer(body_limit)
+}
+
 async fn start_app(app: Router, bind: String, site: NitroRepo) -> anyhow::Result<()> {
     let listener = TcpListener::bind(bind).await?;
     tracing::debug!("listening on {}", listener.local_addr()?);

--- a/nitro_repo/src/config_editor.rs
+++ b/nitro_repo/src/config_editor.rs
@@ -1,10 +1,9 @@
 use std::path::PathBuf;
 
 use inquire::{Text, validator::Validation};
+use nitro_repo::app::config::ReadConfigType;
 use nr_core::database::DatabaseConfig;
 use sqlx::{Connection, PgConnection, postgres::PgConnectOptions};
-
-use crate::app::config::ReadConfigType;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum ConfigSection {

--- a/nitro_repo/src/exporter.rs
+++ b/nitro_repo/src/exporter.rs
@@ -3,9 +3,8 @@ use std::{
     path::PathBuf,
 };
 
+use nitro_repo::app::{REPOSITORY_CONFIG_TYPES, REPOSITORY_TYPES};
 use utoipa::OpenApi;
-
-use crate::app::{REPOSITORY_CONFIG_TYPES, REPOSITORY_TYPES};
 
 pub fn export_repository_configs(path: PathBuf) -> anyhow::Result<()> {
     if !path.exists() {
@@ -73,7 +72,7 @@ pub fn export_openapi(path: PathBuf) -> anyhow::Result<()> {
         path
     };
 
-    let open_api = crate::app::open_api::ApiDoc::openapi();
+    let open_api = nitro_repo::app::open_api::ApiDoc::openapi();
     let file = File::create(&path)?;
     serde_json::to_writer_pretty(file, &open_api)?;
     println!("Exported OpenAPI to {}", path.display());

--- a/nitro_repo/src/lib.rs
+++ b/nitro_repo/src/lib.rs
@@ -1,0 +1,15 @@
+//! The nitro_repo server.
+//!
+//! This crate was a binary with no library target, which meant nothing outside `main.rs` could
+//! reach the router, the state, or the deploy handlers — so there was no way to write an
+//! integration test that exercised a real request. `tests/` now builds the same router `start`
+//! serves and drives it in-process.
+//!
+//! `main.rs` is the CLI; everything it needs lives here.
+
+pub mod app;
+pub mod error;
+pub mod logging;
+pub mod repository;
+pub mod seed;
+pub mod utils;

--- a/nitro_repo/src/main.rs
+++ b/nitro_repo/src/main.rs
@@ -12,6 +12,7 @@ pub mod error;
 mod exporter;
 pub mod logging;
 pub mod repository;
+mod seed;
 pub mod utils;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum ExportOptions {
@@ -67,6 +68,19 @@ enum SubCommands {
         export: ExportOptions,
         location: PathBuf,
     },
+    /// Deploy a suite of fixture artifacts into a running instance
+    ///
+    /// Uses the real Maven and npm protocols rather than writing to the database, so a seed run is
+    /// also a smoke test of the deploy paths. Re-running it is safe: anything already present is
+    /// left alone.
+    Seed {
+        /// The seed configuration file
+        #[clap(short, long, default_value = "seed.toml")]
+        config: PathBuf,
+        /// Write an example configuration to `--config` instead of running
+        #[clap(long, default_value = "false")]
+        write_example: bool,
+    },
 }
 fn main() -> anyhow::Result<()> {
     // For Some Reason Lettre fails if this is not installed
@@ -92,6 +106,11 @@ fn main() -> anyhow::Result<()> {
             ExportOptions::RepositoryTypes => exporter::export_repository_types(location),
             ExportOptions::OpenAPI => exporter::export_openapi(location),
         },
+
+        SubCommands::Seed {
+            config,
+            write_example,
+        } => seed::seed(config, write_example),
 
         SubCommands::Config { config, section } => {
             let tokio = tokio::runtime::Builder::new_current_thread()

--- a/nitro_repo/src/main.rs
+++ b/nitro_repo/src/main.rs
@@ -3,17 +3,13 @@ use std::{
     sync::atomic::{AtomicUsize, Ordering},
 };
 
-use app::config::NitroRepoConfig;
 use clap::{Parser, Subcommand};
 use config_editor::ConfigSection;
-pub mod app;
+// The application itself lives in the library target; this file is only the CLI.
+use nitro_repo::{app, app::config::NitroRepoConfig, seed};
+
 mod config_editor;
-pub mod error;
 mod exporter;
-pub mod logging;
-pub mod repository;
-mod seed;
-pub mod utils;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum ExportOptions {
     /// The Repository Config Types

--- a/nitro_repo/src/repository/maven/hosted.rs
+++ b/nitro_repo/src/repository/maven/hosted.rs
@@ -498,13 +498,20 @@ impl Repository for MavenHosted {
     }
     #[instrument(fields(repository_type = "maven/hosted"))]
     async fn reload(&self) -> Result<(), RepositoryFactoryError> {
-        let Some(is_active) = DBRepository::get_active_by_id(self.id, self.site.as_ref()).await?
-        else {
+        // The whole row, not just `active`: this read `get_active_by_id` and never refreshed the
+        // cached `visibility`, so making a repository private took effect in the database and in
+        // `/api/repository/list` while the running repository carried on serving its files to
+        // anyone — until a restart. The artifact bytes are the most sensitive thing here, so this
+        // was the worst of the visibility leaks.
+        let Some(repository) = DBRepository::get_by_id(self.id, self.site.as_ref()).await? else {
             error!("Failed to get repository");
             self.0.active.store(false, atomic::Ordering::Relaxed);
             return Ok(());
         };
-        self.0.active.store(is_active, atomic::Ordering::Relaxed);
+        self.0
+            .active
+            .store(repository.active, atomic::Ordering::Relaxed);
+        *self.0.visibility.write() = repository.visibility;
 
         let push_rules_db = get_repository_config_or_default::<
             MavenPushRulesConfigType,

--- a/nitro_repo/src/repository/maven/proxy.rs
+++ b/nitro_repo/src/repository/maven/proxy.rs
@@ -461,6 +461,15 @@ impl Repository for MavenProxy {
     }
     #[instrument(fields(repository_type = "maven/proxy"))]
     async fn reload(&self) -> Result<(), RepositoryFactoryError> {
+        // Same as the hosted repository: without this the cached visibility never changes, and a
+        // proxy made private keeps serving whatever it has cached.
+        if let Some(repository) = DBRepository::get_by_id(self.id, self.site.as_ref()).await? {
+            self.0
+                .active
+                .store(repository.active, std::sync::atomic::Ordering::Relaxed);
+            *self.0.visibility.write() = repository.visibility;
+        }
+
         let project_config_db =
             get_repository_config_or_default::<ProjectConfigType, ProjectConfig>(
                 self.id,

--- a/nitro_repo/src/repository/mod.rs
+++ b/nitro_repo/src/repository/mod.rs
@@ -23,7 +23,7 @@ pub mod prelude {
 }
 use nr_macros::DynRepositoryHandler;
 use nr_storage::DynStorage;
-mod staging;
+pub mod staging;
 pub use staging::*;
 mod repo_http;
 pub use repo_http::*;

--- a/nitro_repo/src/repository/npm/types/request.rs
+++ b/nitro_repo/src/repository/npm/types/request.rs
@@ -244,8 +244,17 @@ impl GetPath {
             debug!(?name, ?version, "Version info");
             return Ok(GetPath::VersionInfo { name, version });
         }
-        if length == 5 {
-            let file = components[4].to_string();
+        // What npm actually requests for a scoped package is
+        // `@scope/package/-/package-1.0.0.tgz` — four components, with the *unscoped* name in the
+        // filename (`@babel/core/-/core-7.24.0.tgz`). Only the five-component form was handled, so
+        // every real scoped tarball download answered 404: `npm install @scope/pkg` resolved the
+        // packument and then failed to fetch what the packument pointed at.
+        //
+        // The five-component form, where the scope is repeated in the filename, is still accepted.
+        // The tarball URL is whatever the publishing client wrote into `dist.tarball`, so a stored
+        // packument may carry one.
+        if length == 4 || length == 5 {
+            let file = components[length - 1].to_string();
             let version = extract_version_from_file(&file, &name)
                 .ok_or(NPMRegistryError::InvalidGetRequest)?;
             return Ok(GetPath::GetTar {
@@ -362,6 +371,54 @@ pub mod tests {
 
     use super::{GetPath, extract_version_from_file};
 
+    /// Both tarball URL shapes have to resolve to `GetTar`.
+    ///
+    /// The scoped branch checked for five components and read index four, when the path has four —
+    /// so every scoped tarball download 404'd and `npm install @scope/pkg` failed after resolving
+    /// the packument. Unscoped, one component shorter, was always correct.
+    #[test]
+    pub fn tarball_paths_resolve_for_both_name_shapes() {
+        let scoped = GetPath::try_from(StoragePath::from("@nitro/example/-/example-1.0.0.tgz"))
+            .expect("a scoped tarball path should resolve");
+        assert_eq!(
+            scoped,
+            GetPath::GetTar {
+                name: "@nitro/example".to_owned(),
+                version: "1.0.0".to_owned(),
+                file: "example-1.0.0.tgz".to_owned(),
+            }
+        );
+
+        let unscoped = GetPath::try_from(StoragePath::from("example/-/example-1.0.0.tgz"))
+            .expect("an unscoped tarball path should resolve");
+        assert_eq!(
+            unscoped,
+            GetPath::GetTar {
+                name: "example".to_owned(),
+                version: "1.0.0".to_owned(),
+                file: "example-1.0.0.tgz".to_owned(),
+            }
+        );
+    }
+
+    /// The shorter scoped paths must keep meaning what they meant.
+    #[test]
+    pub fn scoped_package_and_version_paths_still_resolve() {
+        assert_eq!(
+            GetPath::try_from(StoragePath::from("@nitro/example")).unwrap(),
+            GetPath::GetPackageInfo {
+                name: "@nitro/example".to_owned()
+            }
+        );
+        assert_eq!(
+            GetPath::try_from(StoragePath::from("@nitro/example/1.0.0")).unwrap(),
+            GetPath::VersionInfo {
+                name: "@nitro/example".to_owned(),
+                version: "1.0.0".to_owned(),
+            }
+        );
+    }
+
     /// A hyphen in the version is the common case for a prerelease, and a hyphen in the name is
     /// the common case for everything else.
     #[test]
@@ -450,6 +507,16 @@ pub mod tests {
     pub fn tests() {
         let tests = vec![
             (
+                // The shape npm actually requests: the filename is unscoped.
+                StoragePath::from("@nr/mylib/-/mylib-1.0.0.tgz"),
+                GetPath::GetTar {
+                    name: "@nr/mylib".to_string(),
+                    version: "1.0.0".to_string(),
+                    file: "mylib-1.0.0.tgz".to_string(),
+                },
+            ),
+            (
+                // The scope-repeated form, still accepted because a stored packument may carry it.
                 StoragePath::from("@nr/mylib/-/@nr/mylib-1.0.0.tgz"),
                 GetPath::GetTar {
                     name: "@nr/mylib".to_string(),

--- a/nitro_repo/src/seed/artifacts.rs
+++ b/nitro_repo/src/seed/artifacts.rs
@@ -1,0 +1,285 @@
+//! Generates the actual bytes a client would upload.
+//!
+//! These are real artifacts, not placeholder blobs: a jar is a real zip with a manifest, a POM is
+//! real XML, and an npm tarball is a real gzipped tar with the `package/` prefix npm expects. That
+//! matters — a seeded instance should be indistinguishable from one that real `mvn deploy` and
+//! `npm publish` runs produced, or it will not exercise the code paths those clients hit.
+
+use std::io::Write;
+
+use flate2::{Compression, write::GzEncoder};
+use sha1::Sha1;
+use sha2::{Digest, Sha512};
+use zip::{ZipWriter, write::SimpleFileOptions};
+
+use super::config::MavenProject;
+
+/// A POM for one version of a project.
+pub fn pom(project: &MavenProject, version: &str) -> String {
+    let mut dependencies = String::new();
+    for dependency in &project.dependencies {
+        let parts: Vec<&str> = dependency.split(':').collect();
+        if parts.len() != 3 {
+            continue;
+        }
+        dependencies.push_str(&format!(
+            "        <dependency>\n            <groupId>{}</groupId>\n            <artifactId>{}</artifactId>\n            <version>{}</version>\n        </dependency>\n",
+            escape(parts[0]),
+            escape(parts[1]),
+            escape(parts[2]),
+        ));
+    }
+
+    let description = project
+        .description
+        .as_deref()
+        .map(|value| format!("    <description>{}</description>\n", escape(value)))
+        .unwrap_or_default();
+
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>{group}</groupId>
+    <artifactId>{artifact}</artifactId>
+    <version>{version}</version>
+    <packaging>jar</packaging>
+    <name>{artifact}</name>
+{description}    <dependencies>
+{dependencies}    </dependencies>
+</project>
+"#,
+        group = escape(&project.group_id),
+        artifact = escape(&project.artifact_id),
+        version = escape(version),
+        description = description,
+        dependencies = dependencies,
+    )
+}
+
+/// A jar: a real zip holding a manifest and a marker file, so it opens in any zip tool.
+pub fn jar(
+    project: &MavenProject,
+    version: &str,
+    classifier: Option<&str>,
+) -> anyhow::Result<Vec<u8>> {
+    let mut buffer = Vec::new();
+    {
+        let mut zip = ZipWriter::new(std::io::Cursor::new(&mut buffer));
+        let options = SimpleFileOptions::default();
+
+        zip.start_file("META-INF/MANIFEST.MF", options)?;
+        write!(
+            zip,
+            "Manifest-Version: 1.0\r\nCreated-By: nitro_repo seed\r\nImplementation-Title: {}\r\nImplementation-Version: {}\r\n\r\n",
+            project.artifact_id, version
+        )?;
+
+        let name = match classifier {
+            // Distinct content per classifier, so the sources and javadoc jars are not byte-identical
+            // to the main one — identical bytes would hide any bug that mixes them up.
+            Some(classifier) => format!("{}-{}.txt", project.artifact_id, classifier),
+            None => format!("{}.txt", project.artifact_id),
+        };
+        zip.start_file(name, options)?;
+        writeln!(
+            zip,
+            "{}:{}:{}{}",
+            project.group_id,
+            project.artifact_id,
+            version,
+            classifier
+                .map(|value| format!(":{value}"))
+                .unwrap_or_default()
+        )?;
+
+        zip.finish()?;
+    }
+    Ok(buffer)
+}
+
+/// A `package.json` for one version of an npm package.
+pub fn package_json(name: &str, version: &str, description: Option<&str>) -> serde_json::Value {
+    serde_json::json!({
+        "name": name,
+        "version": version,
+        "description": description.unwrap_or("Seeded by nitro_repo"),
+        "main": "index.js",
+        "license": "MIT",
+        "scripts": { "test": "echo \"no tests\" && exit 0" },
+    })
+}
+
+/// An npm tarball: gzipped tar, every entry under `package/`, which is what npm produces and what
+/// every client expects when it unpacks one.
+pub fn npm_tarball(
+    name: &str,
+    version: &str,
+    description: Option<&str>,
+) -> anyhow::Result<Vec<u8>> {
+    let manifest = serde_json::to_vec_pretty(&package_json(name, version, description))?;
+    let readme = format!(
+        "# {name}\n\n{}\n\nVersion {version}.\n",
+        description.unwrap_or("")
+    );
+    let index = format!("module.exports = {{ name: {name:?}, version: {version:?} }};\n");
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append(&mut builder, "package/package.json", &manifest)?;
+        append(&mut builder, "package/README.md", readme.as_bytes())?;
+        append(&mut builder, "package/index.js", index.as_bytes())?;
+        builder.finish()?;
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes)?;
+    Ok(encoder.finish()?)
+}
+
+fn append<W: Write>(builder: &mut tar::Builder<W>, path: &str, data: &[u8]) -> anyhow::Result<()> {
+    let mut header = tar::Header::new_gnu();
+    header.set_size(data.len() as u64);
+    header.set_mode(0o644);
+    // A fixed mtime keeps the tarball byte-reproducible, so re-running a seed produces the same
+    // integrity hash rather than a new one every time.
+    header.set_mtime(0);
+    header.set_cksum();
+    builder.append_data(&mut header, path, data)?;
+    Ok(())
+}
+
+/// The `integrity` string npm sends: SSRI, base64 of the raw sha512 digest.
+pub fn integrity(data: &[u8]) -> String {
+    use base64::{Engine, engine::general_purpose::STANDARD};
+    let digest = Sha512::digest(data);
+    format!("sha512-{}", STANDARD.encode(digest))
+}
+
+/// The `shasum` npm sends alongside it: hex sha1.
+pub fn shasum(data: &[u8]) -> String {
+    let digest = Sha1::digest(data);
+    hex(&digest)
+}
+
+pub fn sha1_hex(data: &[u8]) -> String {
+    hex(&Sha1::digest(data))
+}
+
+pub fn md5_hex(data: &[u8]) -> String {
+    hex(&md5::Md5::digest(data))
+}
+
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut out, byte| {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{byte:02x}");
+        out
+    })
+}
+
+fn escape(value: &str) -> String {
+    value
+        .replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn project() -> MavenProject {
+        MavenProject {
+            repository: "local/releases".to_owned(),
+            group_id: "dev.kingtux".to_owned(),
+            artifact_id: "tms".to_owned(),
+            versions: vec!["1.0.0".to_owned()],
+            description: Some("Example".to_owned()),
+            classifiers: vec![],
+            dependencies: vec!["org.slf4j:slf4j-api:2.0.13".to_owned()],
+        }
+    }
+
+    /// The server parses what this writes, so it has to be a POM `maven-rs` accepts — not merely
+    /// well-formed XML.
+    #[test]
+    fn the_generated_pom_parses() {
+        let text = pom(&project(), "1.0.0");
+        // Parsed exactly the way the server parses an uploaded POM (`maven/utils.rs`), so this
+        // proves the deploy path would accept it — not merely that it is well-formed XML.
+        let parsed: maven_rs::pom::Pom =
+            maven_rs::quick_xml::de::from_str(&text).expect("the seed's POM should parse");
+        assert_eq!(parsed.group_id.as_deref(), Some("dev.kingtux"));
+        assert_eq!(parsed.artifact_id, "tms");
+        assert_eq!(parsed.version.as_deref(), Some("1.0.0"));
+    }
+
+    #[test]
+    fn the_generated_jar_is_a_readable_zip() {
+        let bytes = jar(&project(), "1.0.0", None).expect("builds");
+        let mut archive =
+            zip::ZipArchive::new(std::io::Cursor::new(bytes)).expect("should be a valid zip");
+        assert!(archive.by_name("META-INF/MANIFEST.MF").is_ok());
+    }
+
+    /// Classified jars must differ from the main one, or a bug that serves the wrong classifier
+    /// would be invisible.
+    #[test]
+    fn classified_jars_differ_from_the_main_jar() {
+        let main = jar(&project(), "1.0.0", None).unwrap();
+        let sources = jar(&project(), "1.0.0", Some("sources")).unwrap();
+        assert_ne!(main, sources);
+    }
+
+    #[test]
+    fn the_npm_tarball_unpacks_with_a_package_prefix() {
+        let bytes = npm_tarball("@nitro/example", "1.0.0", Some("Example")).expect("builds");
+        let decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(bytes));
+        let mut archive = tar::Archive::new(decoder);
+
+        let paths: Vec<String> = archive
+            .entries()
+            .expect("entries")
+            .map(|entry| entry.unwrap().path().unwrap().display().to_string())
+            .collect();
+
+        assert!(
+            paths.contains(&"package/package.json".to_owned()),
+            "{paths:?}"
+        );
+        assert!(paths.contains(&"package/index.js".to_owned()), "{paths:?}");
+    }
+
+    /// The server verifies both of these on publish, so a seed that computed them differently would
+    /// be rejected — and the failure would read as a server bug rather than a seed bug. Pinned
+    /// against known digests of a fixed input rather than against a re-run of the same code, which
+    /// would pass no matter what the code did.
+    #[test]
+    fn integrity_and_shasum_match_their_algorithms() {
+        // The canonical SHA-1 and SHA-512 of the empty string.
+        assert_eq!(shasum(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        assert_eq!(
+            integrity(b""),
+            "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg=="
+        );
+    }
+
+    #[test]
+    fn checksum_helpers_agree_with_known_digests() {
+        assert_eq!(sha1_hex(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
+        assert_eq!(md5_hex(b""), "d41d8cd98f00b204e9800998ecf8427e");
+    }
+
+    /// A tarball must be byte-identical across runs, so re-seeding does not produce a new integrity
+    /// hash for content that has not changed.
+    #[test]
+    fn tarballs_are_reproducible() {
+        let first = npm_tarball("@nitro/example", "1.0.0", Some("Example")).unwrap();
+        let second = npm_tarball("@nitro/example", "1.0.0", Some("Example")).unwrap();
+        assert_eq!(first, second);
+    }
+}

--- a/nitro_repo/src/seed/config.rs
+++ b/nitro_repo/src/seed/config.rs
@@ -1,0 +1,205 @@
+//! The seed configuration file.
+//!
+//! Everything is declarative and idempotent: running the same file twice against the same instance
+//! should leave it in the same state, so a seed can be re-run after a change without tearing the
+//! instance down first.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeedConfig {
+    /// The base URL of the running instance, e.g. `http://localhost:6742`.
+    pub url: String,
+    pub auth: SeedAuth,
+    /// Storages to create if they are missing.
+    #[serde(default)]
+    pub storages: Vec<SeedStorage>,
+    /// Repositories to create if they are missing.
+    #[serde(default)]
+    pub repositories: Vec<SeedRepository>,
+    /// Maven artifacts to deploy.
+    #[serde(default)]
+    pub maven: Vec<MavenProject>,
+    /// npm packages to publish.
+    #[serde(default)]
+    pub npm: Vec<NpmPackage>,
+}
+
+/// How to authenticate.
+///
+/// A token is preferred — it is what a CI job would use, and it exercises the token path rather than
+/// the session one. Basic auth is accepted because it is what `mvn deploy` sends, and seeding a
+/// fresh instance with only the installed admin account is the common case.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SeedAuth {
+    Token { token: String },
+    Basic { username: String, password: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeedStorage {
+    pub name: String,
+    /// Matches the `StorageTypeConfig` tag: `Local`, `FileSystemV2` or `S3`.
+    #[serde(rename = "type")]
+    pub storage_type: String,
+    /// The backend's own settings, passed through untouched.
+    pub settings: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SeedRepository {
+    pub storage: String,
+    pub name: String,
+    /// `maven` or `npm`.
+    #[serde(rename = "type")]
+    pub repository_type: String,
+    /// Defaults to public so a seeded instance can be browsed without signing in.
+    #[serde(default = "default_visibility")]
+    pub visibility: String,
+}
+
+fn default_visibility() -> String {
+    "Public".to_owned()
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MavenProject {
+    /// `{storage}/{repository}`.
+    pub repository: String,
+    #[serde(alias = "group")]
+    pub group_id: String,
+    #[serde(alias = "artifact")]
+    pub artifact_id: String,
+    pub versions: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// Extra classified artifacts to deploy beside the main jar, e.g. `["sources", "javadoc"]`.
+    #[serde(default = "default_classifiers")]
+    pub classifiers: Vec<String>,
+    /// Dependencies to write into the generated POM, as `groupId:artifactId:version`.
+    #[serde(default)]
+    pub dependencies: Vec<String>,
+}
+
+fn default_classifiers() -> Vec<String> {
+    vec!["sources".to_owned(), "javadoc".to_owned()]
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NpmPackage {
+    /// `{storage}/{repository}`.
+    pub repository: String,
+    /// Including the scope, e.g. `@nitro/example`.
+    pub name: String,
+    pub versions: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    /// `{ "latest": "1.2.0", "next": "2.0.0-beta.1" }`. `latest` is set automatically to the last
+    /// version published if it is not given here.
+    #[serde(default)]
+    pub dist_tags: std::collections::BTreeMap<String, String>,
+}
+
+impl SeedConfig {
+    /// The suite written by `seed --write-example`.
+    ///
+    /// Deliberately covers the shapes that have broken before: a scoped npm package, a snapshot
+    /// version, a prerelease, a dotted npm name, and a multi-version artifact so
+    /// `maven-metadata.xml` has something to merge.
+    pub fn example() -> Self {
+        Self {
+            url: "http://localhost:6742".to_owned(),
+            auth: SeedAuth::Basic {
+                username: "admin".to_owned(),
+                password: "changeme".to_owned(),
+            },
+            storages: vec![SeedStorage {
+                name: "local".to_owned(),
+                storage_type: "Local".to_owned(),
+                settings: serde_json::json!({ "path": "./storage/local" }),
+            }],
+            repositories: vec![
+                SeedRepository {
+                    storage: "local".to_owned(),
+                    name: "releases".to_owned(),
+                    repository_type: "maven".to_owned(),
+                    visibility: "Public".to_owned(),
+                },
+                SeedRepository {
+                    storage: "local".to_owned(),
+                    name: "snapshots".to_owned(),
+                    repository_type: "maven".to_owned(),
+                    visibility: "Public".to_owned(),
+                },
+                SeedRepository {
+                    storage: "local".to_owned(),
+                    name: "npm".to_owned(),
+                    repository_type: "npm".to_owned(),
+                    visibility: "Public".to_owned(),
+                },
+            ],
+            maven: vec![
+                MavenProject {
+                    repository: "local/releases".to_owned(),
+                    group_id: "dev.kingtux".to_owned(),
+                    artifact_id: "tms".to_owned(),
+                    versions: vec![
+                        "1.0.0".to_owned(),
+                        "1.0.1".to_owned(),
+                        "1.1.0".to_owned(),
+                        "2.0.0-beta.1".to_owned(),
+                    ],
+                    description: Some("A seeded example artifact".to_owned()),
+                    classifiers: default_classifiers(),
+                    dependencies: vec!["org.slf4j:slf4j-api:2.0.13".to_owned()],
+                },
+                MavenProject {
+                    repository: "local/releases".to_owned(),
+                    group_id: "dev.kingtux.tools".to_owned(),
+                    artifact_id: "nested-example".to_owned(),
+                    versions: vec!["0.1.0".to_owned()],
+                    description: Some("A deeper group id, to exercise nested paths".to_owned()),
+                    classifiers: vec![],
+                    dependencies: vec!["dev.kingtux:tms:1.1.0".to_owned()],
+                },
+                MavenProject {
+                    repository: "local/snapshots".to_owned(),
+                    group_id: "dev.kingtux".to_owned(),
+                    artifact_id: "tms".to_owned(),
+                    versions: vec!["1.2.0-SNAPSHOT".to_owned()],
+                    description: Some("Snapshot deploys, for maven-metadata.xml".to_owned()),
+                    classifiers: default_classifiers(),
+                    dependencies: vec![],
+                },
+            ],
+            npm: vec![
+                NpmPackage {
+                    repository: "local/npm".to_owned(),
+                    name: "@nitro/example".to_owned(),
+                    versions: vec!["1.0.0".to_owned(), "1.0.1".to_owned(), "1.1.0".to_owned()],
+                    description: Some("A scoped package".to_owned()),
+                    dist_tags: Default::default(),
+                },
+                NpmPackage {
+                    repository: "local/npm".to_owned(),
+                    // A dotted, unscoped name: `validate_name` used to reject these outright, so
+                    // `lodash.merge` could not be published.
+                    name: "nitro.helpers".to_owned(),
+                    versions: vec!["0.1.0".to_owned(), "0.2.0".to_owned()],
+                    description: Some("An unscoped package with a dot in its name".to_owned()),
+                    dist_tags: Default::default(),
+                },
+                NpmPackage {
+                    repository: "local/npm".to_owned(),
+                    name: "@nitro/prerelease".to_owned(),
+                    versions: vec!["1.0.0".to_owned(), "2.0.0-beta.1".to_owned()],
+                    description: Some("Prerelease versions, and a non-latest dist-tag".to_owned()),
+                    dist_tags: [("next".to_owned(), "2.0.0-beta.1".to_owned())]
+                        .into_iter()
+                        .collect(),
+                },
+            ],
+        }
+    }
+}

--- a/nitro_repo/src/seed/mod.rs
+++ b/nitro_repo/src/seed/mod.rs
@@ -1,0 +1,619 @@
+//! Populates a running instance with a suite of real artifacts.
+//!
+//! This exists because there was no way to get a realistic amount of content into an instance
+//! without doing it by hand. Browsing, search, badges, `maven-metadata.xml` merging and the project
+//! pages all behave differently with one artifact than with forty, and most of the defects found
+//! during this work only showed up with more than one version present.
+//!
+//! Deploys go over the real protocols — `PUT` of a jar with its sibling `.sha1`/`.md5`, and an npm
+//! packument with a base64 `_attachments` entry — rather than writing to the database, so a seed
+//! run is also a smoke test of the deploy paths.
+
+use std::{collections::BTreeMap, path::PathBuf, time::Duration};
+
+use base64::{Engine, engine::general_purpose::STANDARD};
+use reqwest::{Client, StatusCode};
+use serde_json::json;
+use tracing::{info, warn};
+
+pub mod artifacts;
+pub mod config;
+
+use config::{MavenProject, NpmPackage, SeedAuth, SeedConfig, SeedRepository, SeedStorage};
+
+pub struct Seeder {
+    client: Client,
+    base: String,
+    auth: SeedAuth,
+    /// Set after signing in with a username and password.
+    ///
+    /// The API routes accept a session or a bearer token but *not* basic auth, while the deploy
+    /// endpoints accept basic (that is what `mvn deploy` sends). So a password-configured seed has
+    /// to hold both: a session for creating storages and repositories, and basic for the uploads.
+    session: Option<String>,
+    /// Counts what happened, so the run ends with something to assert on.
+    pub summary: Summary,
+}
+
+#[derive(Debug, Default)]
+pub struct Summary {
+    pub storages_created: usize,
+    pub repositories_created: usize,
+    pub files_uploaded: usize,
+    pub packages_published: usize,
+    pub skipped: usize,
+}
+
+impl Seeder {
+    pub fn new(config: &SeedConfig) -> anyhow::Result<Self> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(60))
+            .user_agent(concat!("nitro_repo-seed/", env!("CARGO_PKG_VERSION")))
+            .build()?;
+
+        Ok(Self {
+            client,
+            base: config.url.trim_end_matches('/').to_owned(),
+            auth: config.auth.clone(),
+            session: None,
+            summary: Summary::default(),
+        })
+    }
+
+    /// Credentials for the deploy endpoints, which is what a Maven or npm client would send.
+    fn authorize(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match &self.auth {
+            SeedAuth::Token { token } => request.bearer_auth(token),
+            SeedAuth::Basic { username, password } => request.basic_auth(username, Some(password)),
+        }
+    }
+
+    /// Credentials for `/api/...`, which refuses basic auth.
+    fn authorize_api(&self, request: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        match (&self.auth, &self.session) {
+            (SeedAuth::Token { token }, _) => request.bearer_auth(token),
+            (_, Some(session)) => request.header("Authorization", format!("Session {session}")),
+            // Unreachable in practice: `sign_in` runs before anything calls this, and fails loudly.
+            (SeedAuth::Basic { .. }, None) => request,
+        }
+    }
+
+    /// Exchanges a username and password for a session.
+    ///
+    /// A token-configured seed skips this — a token already works everywhere.
+    async fn sign_in(&mut self) -> anyhow::Result<()> {
+        let SeedAuth::Basic { username, password } = &self.auth else {
+            return Ok(());
+        };
+
+        let response = self
+            .client
+            .post(format!("{}/api/user/login", self.base))
+            .json(&json!({ "email_or_username": username, "password": password }))
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            anyhow::bail!(
+                "Could not sign in as `{username}`: {status}. Check the credentials in the config, \
+                 and that the instance has been installed."
+            );
+        }
+
+        let body: serde_json::Value = response.json().await?;
+        let Some(session) = body
+            .get("session")
+            .and_then(|value| value.get("session_id"))
+            .and_then(|value| value.as_str())
+        else {
+            anyhow::bail!("Signed in, but the response carried no session id");
+        };
+
+        self.session = Some(session.to_owned());
+        Ok(())
+    }
+
+    pub async fn run(&mut self, config: &SeedConfig) -> anyhow::Result<()> {
+        self.check_reachable().await?;
+        self.sign_in().await?;
+
+        for storage in &config.storages {
+            self.ensure_storage(storage).await?;
+        }
+        for repository in &config.repositories {
+            self.ensure_repository(repository).await?;
+        }
+        for project in &config.maven {
+            self.deploy_maven(project).await?;
+        }
+        for package in &config.npm {
+            self.publish_npm(package).await?;
+        }
+
+        Ok(())
+    }
+
+    /// Fails early with something readable. Without this, a wrong URL surfaces as a connection
+    /// error on the first deploy, several steps in.
+    async fn check_reachable(&self) -> anyhow::Result<()> {
+        let response = self
+            .client
+            .get(format!("{}/api/info", self.base))
+            .send()
+            .await
+            .map_err(|error| {
+                anyhow::anyhow!("Could not reach {} — is it running? ({error})", self.base)
+            })?;
+
+        if !response.status().is_success() {
+            anyhow::bail!(
+                "{}/api/info returned {}. Check the URL points at a nitro_repo instance.",
+                self.base,
+                response.status()
+            );
+        }
+        Ok(())
+    }
+
+    async fn ensure_storage(&mut self, storage: &SeedStorage) -> anyhow::Result<()> {
+        let existing = self
+            .authorize_api(self.client.get(format!("{}/api/storage/list", self.base)))
+            .send()
+            .await?;
+
+        if existing.status() == StatusCode::UNAUTHORIZED
+            || existing.status() == StatusCode::FORBIDDEN
+        {
+            anyhow::bail!("Not authorised to list storages. Check the credentials in the config.");
+        }
+
+        let storages: Vec<serde_json::Value> = existing.json().await.unwrap_or_default();
+        if storages
+            .iter()
+            .any(|value| value.get("name").and_then(|n| n.as_str()) == Some(&storage.name))
+        {
+            info!(name = %storage.name, "Storage already exists");
+            self.summary.skipped += 1;
+            return Ok(());
+        }
+
+        let response = self
+            .authorize_api(
+                self.client
+                    .post(format!(
+                        "{}/api/storage/new/{}",
+                        self.base, storage.storage_type
+                    ))
+                    .json(&json!({
+                        "name": storage.name,
+                        "config": { "type": storage.storage_type, "settings": storage.settings },
+                    })),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Could not create storage `{}`: {status} {body}",
+                storage.name
+            );
+        }
+
+        info!(name = %storage.name, "Created storage");
+        self.summary.storages_created += 1;
+        Ok(())
+    }
+
+    async fn ensure_repository(&mut self, repository: &SeedRepository) -> anyhow::Result<()> {
+        // The find-by-name endpoint answers 404 when there is no such repository, which is the
+        // cheapest existence check available and does not need the whole list.
+        let lookup = self
+            .authorize_api(self.client.get(format!(
+                "{}/api/repository/find-id/{}/{}",
+                self.base, repository.storage, repository.name
+            )))
+            .send()
+            .await?;
+
+        if lookup.status().is_success() {
+            info!(name = %repository.name, "Repository already exists");
+            self.summary.skipped += 1;
+            return Ok(());
+        }
+
+        let storages: Vec<serde_json::Value> = self
+            .authorize_api(self.client.get(format!("{}/api/storage/list", self.base)))
+            .send()
+            .await?
+            .json()
+            .await
+            .unwrap_or_default();
+
+        let Some(storage_id) = storages
+            .iter()
+            .find(|value| value.get("name").and_then(|n| n.as_str()) == Some(&repository.storage))
+            .and_then(|value| value.get("id"))
+            .and_then(|value| value.as_str())
+        else {
+            anyhow::bail!(
+                "Repository `{}` wants storage `{}`, which does not exist. Add it under [[storages]].",
+                repository.name,
+                repository.storage
+            );
+        };
+
+        let response = self
+            .authorize_api(
+                self.client
+                    .post(format!(
+                        "{}/api/repository/new/{}",
+                        self.base, repository.repository_type
+                    ))
+                    // `configs` carries the type-specific config keyed by config name. Both
+                    // repository types currently have only a `Hosted` variant; a proxy would be
+                    // configured after creation.
+                    .json(&json!({
+                        "name": repository.name,
+                        "storage": storage_id,
+                        "configs": {
+                            repository.repository_type.clone(): { "type": "Hosted" },
+                        },
+                    })),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!(
+                "Could not create repository `{}`: {status} {body}",
+                repository.name
+            );
+        }
+
+        let created: serde_json::Value = response.json().await.unwrap_or_default();
+
+        // Visibility is not part of the create request, so it is a follow-up. A seeded instance
+        // should be browsable without signing in, which is the point of defaulting to Public.
+        if let Some(id) = created.get("id").and_then(|value| value.as_str())
+            && repository.visibility != "Private"
+        {
+            let updated = self
+                .authorize_api(
+                    self.client
+                        .put(format!("{}/api/repository/{id}", self.base))
+                        .json(&json!({ "visibility": repository.visibility })),
+                )
+                .send()
+                .await?;
+            if !updated.status().is_success() {
+                warn!(
+                    name = %repository.name,
+                    status = %updated.status(),
+                    "Created the repository but could not set its visibility"
+                );
+            }
+        }
+
+        info!(name = %repository.name, "Created repository");
+        self.summary.repositories_created += 1;
+        Ok(())
+    }
+
+    /// Uploads one file plus the `.sha1` and `.md5` a Maven client sends beside it.
+    ///
+    /// The checksums are not decoration — the server verifies an uploaded checksum against what it
+    /// computed, so getting them wrong here is caught immediately rather than producing a repository
+    /// full of artifacts nothing can validate.
+    async fn put_maven_file(
+        &mut self,
+        repository: &str,
+        path: &str,
+        data: Vec<u8>,
+        content_type: &str,
+    ) -> anyhow::Result<()> {
+        let sha1 = artifacts::sha1_hex(&data);
+        let md5 = artifacts::md5_hex(&data);
+
+        self.put_raw(repository, path, data, content_type).await?;
+        self.put_raw(
+            repository,
+            &format!("{path}.sha1"),
+            sha1.into_bytes(),
+            "text/plain",
+        )
+        .await?;
+        self.put_raw(
+            repository,
+            &format!("{path}.md5"),
+            md5.into_bytes(),
+            "text/plain",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn put_raw(
+        &mut self,
+        repository: &str,
+        path: &str,
+        data: Vec<u8>,
+        content_type: &str,
+    ) -> anyhow::Result<()> {
+        let url = format!("{}/repositories/{}/{}", self.base, repository, path);
+        let response = self
+            .authorize(
+                self.client
+                    .put(&url)
+                    .header("Content-Type", content_type)
+                    .body(data),
+            )
+            .send()
+            .await?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("PUT {url} failed: {status} {body}");
+        }
+
+        self.summary.files_uploaded += 1;
+        Ok(())
+    }
+
+    async fn deploy_maven(&mut self, project: &MavenProject) -> anyhow::Result<()> {
+        let group_path = project.group_id.replace('.', "/");
+
+        for version in &project.versions {
+            let base = format!("{group_path}/{}/{version}", project.artifact_id);
+
+            // A real `mvn deploy` of a snapshot does not upload `artifact-1.2.0-SNAPSHOT.jar` — it
+            // uploads a timestamped build, `artifact-1.2.0-20260801.224723-1.jar`, and the
+            // repository's snapshot metadata points at the newest. The plain name is what a local
+            // `mvn install` produces, and deploying that leaves the snapshot metadata with nothing
+            // to describe. Two builds go up so `<snapshotVersions>` has more than one to pick from.
+            let builds: Vec<Option<String>> = if version.ends_with("-SNAPSHOT") {
+                let stamp = chrono::Local::now().format("%Y%m%d.%H%M%S").to_string();
+                vec![Some(format!("{stamp}-1")), Some(format!("{stamp}-2"))]
+            } else {
+                vec![None]
+            };
+
+            for build in &builds {
+                let file_version = match build {
+                    Some(build) => format!("{}-{build}", version.trim_end_matches("-SNAPSHOT")),
+                    None => version.clone(),
+                };
+                self.deploy_maven_build(project, version, &base, &file_version)
+                    .await?;
+            }
+
+            info!(
+                repository = %project.repository,
+                artifact = %format!("{}:{}:{version}", project.group_id, project.artifact_id),
+                builds = builds.len(),
+                "Deployed"
+            );
+        }
+
+        Ok(())
+    }
+
+    /// Uploads one build of one version: the POM, the main jar, and any classified jars.
+    async fn deploy_maven_build(
+        &mut self,
+        project: &MavenProject,
+        version: &str,
+        base: &str,
+        file_version: &str,
+    ) -> anyhow::Result<()> {
+        let stem = format!("{}-{file_version}", project.artifact_id);
+
+        // The POM carries the logical version (`1.2.0-SNAPSHOT`) even when the file it is stored
+        // under is timestamped. That is what Maven writes, and what the server reads to decide
+        // which project a deploy belongs to.
+        let pom = artifacts::pom(project, version);
+        self.put_maven_file(
+            &project.repository,
+            &format!("{base}/{stem}.pom"),
+            pom.into_bytes(),
+            "application/xml",
+        )
+        .await?;
+
+        let jar = artifacts::jar(project, version, None)?;
+        self.put_maven_file(
+            &project.repository,
+            &format!("{base}/{stem}.jar"),
+            jar,
+            "application/java-archive",
+        )
+        .await?;
+
+        for classifier in &project.classifiers {
+            let jar = artifacts::jar(project, version, Some(classifier))?;
+            self.put_maven_file(
+                &project.repository,
+                &format!("{base}/{stem}-{classifier}.jar"),
+                jar,
+                "application/java-archive",
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn publish_npm(&mut self, package: &NpmPackage) -> anyhow::Result<()> {
+        let mut dist_tags = package.dist_tags.clone();
+
+        for version in &package.versions {
+            let tarball =
+                artifacts::npm_tarball(&package.name, version, package.description.as_deref())?;
+            let integrity = artifacts::integrity(&tarball);
+            let shasum = artifacts::shasum(&tarball);
+
+            // npm names the attachment by the *unscoped* filename, and the tarball URL by the full
+            // package path. Getting these the wrong way round is exactly the mismatch that made
+            // scoped packages unusable before Phase 3.
+            let unscoped = package.name.rsplit('/').next().unwrap_or(&package.name);
+            let file_name = format!("{unscoped}-{version}.tgz");
+            let tarball_url = format!(
+                "{}/repositories/{}/{}/-/{file_name}",
+                self.base, package.repository, package.name
+            );
+
+            let mut manifest =
+                artifacts::package_json(&package.name, version, package.description.as_deref());
+            if let Some(object) = manifest.as_object_mut() {
+                object.insert(
+                    "_id".to_owned(),
+                    json!(format!("{}@{version}", package.name)),
+                );
+                object.insert(
+                    "dist".to_owned(),
+                    json!({
+                        "integrity": integrity,
+                        "shasum": shasum,
+                        "tarball": tarball_url,
+                    }),
+                );
+                object.insert("_nodeVersion".to_owned(), json!("20.0.0"));
+                object.insert("_npmVersion".to_owned(), json!("10.0.0"));
+                object.insert("readme".to_owned(), json!(format!("# {}", package.name)));
+                object.insert("readmeFilename".to_owned(), json!("README.md"));
+            }
+
+            let mut versions = BTreeMap::new();
+            versions.insert(version.clone(), manifest);
+
+            let mut attachments = BTreeMap::new();
+            attachments.insert(
+                file_name,
+                json!({
+                    "content_type": "application/octet-stream",
+                    "data": STANDARD.encode(&tarball),
+                    "length": tarball.len(),
+                }),
+            );
+
+            let body = json!({
+                "_id": package.name,
+                "name": package.name,
+                "description": package.description,
+                "versions": versions,
+                "_attachments": attachments,
+            });
+
+            let url = format!(
+                "{}/repositories/{}/{}",
+                self.base, package.repository, package.name
+            );
+            let response = self
+                .authorize(
+                    self.client
+                        .put(&url)
+                        .header("npm-command", "publish")
+                        .json(&body),
+                )
+                .send()
+                .await?;
+
+            let status = response.status();
+            if status == StatusCode::CONFLICT {
+                // Re-running a seed is expected to be safe; a version that is already there is not
+                // an error, and overwriting it is exactly what the publish path refuses to do.
+                warn!(package = %package.name, %version, "Already published, leaving it alone");
+                self.summary.skipped += 1;
+            } else if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                anyhow::bail!(
+                    "Publishing {}@{version} failed: {status} {body}",
+                    package.name
+                );
+            } else {
+                info!(package = %package.name, %version, "Published");
+                self.summary.packages_published += 1;
+            }
+
+            dist_tags
+                .entry("latest".to_owned())
+                .or_insert(version.clone());
+            // Later versions win the implicit `latest`, matching what npm does.
+            if !package.dist_tags.contains_key("latest") {
+                dist_tags.insert("latest".to_owned(), version.clone());
+            }
+        }
+
+        for (tag, version) in &dist_tags {
+            let url = format!(
+                "{}/repositories/{}/-/package/{}/dist-tags/{tag}",
+                self.base, package.repository, package.name
+            );
+            let response = self
+                .authorize(self.client.put(&url).json(version))
+                .send()
+                .await?;
+            if !response.status().is_success() {
+                warn!(
+                    package = %package.name,
+                    %tag,
+                    status = %response.status(),
+                    "Could not set dist-tag"
+                );
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Entry point for the `seed` subcommand.
+pub fn seed(config_path: PathBuf, write_example: bool) -> anyhow::Result<()> {
+    if write_example {
+        let example = SeedConfig::example();
+        let rendered = toml::to_string_pretty(&example)?;
+        std::fs::write(&config_path, rendered)?;
+        println!("Wrote an example seed config to {}", config_path.display());
+        return Ok(());
+    }
+
+    if !config_path.exists() {
+        anyhow::bail!(
+            "{} does not exist. Run `nitro_repo seed --config {} --write-example` to create one.",
+            config_path.display(),
+            config_path.display()
+        );
+    }
+
+    let config: SeedConfig = toml::from_str(&std::fs::read_to_string(&config_path)?)?;
+
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()?;
+
+    runtime.block_on(async {
+        let mut seeder = Seeder::new(&config)?;
+        seeder.run(&config).await?;
+
+        let summary = &seeder.summary;
+        println!(
+            "Seeded {}: {} storage(s), {} repositor(ies), {} file(s), {} package version(s){}",
+            config.url,
+            summary.storages_created,
+            summary.repositories_created,
+            summary.files_uploaded,
+            summary.packages_published,
+            if summary.skipped > 0 {
+                format!(", {} already present", summary.skipped)
+            } else {
+                String::new()
+            }
+        );
+        Ok(())
+    })
+}

--- a/nitro_repo/tests/authorization.rs
+++ b/nitro_repo/tests/authorization.rs
@@ -1,0 +1,314 @@
+//! Authorization tests. (#502)
+//!
+//! Three separate information leaks were found by reading code during this work: the repository
+//! list returned every private repository to anonymous callers, all three project routes took an
+//! `auth` argument and never used it, and `get_config` hardcoded `Visibility::Private`. None of
+//! them had a test. These are the tests.
+//!
+//! Every case here asserts a *refusal*. A test that only checks the happy path cannot tell the
+//! difference between working authorization and none at all.
+
+mod common;
+
+use axum::http::StatusCode;
+use common::{TestServer, skip_without_database};
+use serde_json::json;
+
+/// Makes a repository private. Creation does not take a visibility, so it is a follow-up.
+async fn make_private(server: &TestServer, session: &str, repository: &str) {
+    let response = server
+        .put_json_as(
+            &format!("/api/repository/{repository}"),
+            json!({ "visibility": "Private" }),
+            session,
+        )
+        .await;
+    assert!(
+        response.status.is_success(),
+        "could not make the repository private: {} {}",
+        response.status,
+        response.text
+    );
+}
+
+/// The list used to return every repository regardless of who was asking, so a private
+/// repository's name, storage and type were readable by anyone who could reach the instance.
+#[tokio::test]
+async fn a_private_repository_is_not_listed_anonymously() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_private_repository_is_not_listed_anonymously"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, "local", "secret", "maven")
+        .await;
+    make_private(&server, &session, &repository).await;
+
+    let response = server.get("/api/repository/list").await;
+    assert!(
+        response.status.is_success(),
+        "the list itself should still answer: {}",
+        response.text
+    );
+    assert!(
+        !response.text.contains("secret"),
+        "a private repository must not appear in the anonymous list: {}",
+        response.text
+    );
+
+    // The owner still sees it, or the filter is simply broken rather than correct.
+    let response = server.get_as("/api/repository/list", &session).await;
+    assert!(
+        response.text.contains("secret"),
+        "an admin should still see their own private repository: {}",
+        response.text
+    );
+}
+
+/// All three project routes took an `auth` argument and never read it, so every project and version
+/// in a private repository was readable by anyone who could guess an id.
+#[tokio::test]
+async fn projects_in_a_private_repository_are_not_readable_anonymously() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "projects_in_a_private_repository_are_not_readable_anonymously"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, "local", "secret", "maven")
+        .await;
+
+    // Deployed while the repository is still public, so the project exists before it is locked.
+    let project = nitro_repo::seed::config::MavenProject {
+        repository: "local/secret".to_owned(),
+        group_id: "dev.kingtux".to_owned(),
+        artifact_id: "private-lib".to_owned(),
+        versions: vec![],
+        description: None,
+        classifiers: vec![],
+        dependencies: vec![],
+    };
+    let pom = nitro_repo::seed::artifacts::pom(&project, "1.0.0");
+    server
+        .put_with_basic(
+            "/repositories/local/secret/dev/kingtux/private-lib/1.0.0/private-lib-1.0.0.pom",
+            pom.into_bytes(),
+            "application/xml",
+        )
+        .await;
+
+    let projects = server
+        .get_as("/api/search?text=private-lib", &session)
+        .await;
+    let projects = projects.json();
+    let project_id = projects["results"][0]["project_id"]
+        .as_str()
+        .expect("the deployed project should be findable while public")
+        .to_owned();
+
+    make_private(&server, &session, &repository).await;
+
+    let response = server.get(&format!("/api/project/{project_id}")).await;
+    assert!(
+        response.status == StatusCode::NOT_FOUND
+            || response.status == StatusCode::UNAUTHORIZED
+            || response.status == StatusCode::FORBIDDEN,
+        "a project in a private repository must not be readable anonymously, got {}: {}",
+        response.status,
+        response.text
+    );
+
+    let response = server
+        .get(&format!("/api/project/{project_id}/versions"))
+        .await;
+    assert!(
+        response.status == StatusCode::NOT_FOUND
+            || response.status == StatusCode::UNAUTHORIZED
+            || response.status == StatusCode::FORBIDDEN,
+        "versions in a private repository must not be readable anonymously, got {}: {}",
+        response.status,
+        response.text
+    );
+}
+
+/// Search filters by visibility after the fact. A private repository's contents leaking through it
+/// would be the same defect in a different route.
+#[tokio::test]
+async fn search_does_not_return_private_repositories_anonymously() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "search_does_not_return_private_repositories_anonymously"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, "local", "secret", "maven")
+        .await;
+
+    let project = nitro_repo::seed::config::MavenProject {
+        repository: "local/secret".to_owned(),
+        group_id: "dev.kingtux".to_owned(),
+        artifact_id: "hidden-lib".to_owned(),
+        versions: vec![],
+        description: None,
+        classifiers: vec![],
+        dependencies: vec![],
+    };
+    let pom = nitro_repo::seed::artifacts::pom(&project, "1.0.0");
+    server
+        .put_with_basic(
+            "/repositories/local/secret/dev/kingtux/hidden-lib/1.0.0/hidden-lib-1.0.0.pom",
+            pom.into_bytes(),
+            "application/xml",
+        )
+        .await;
+
+    make_private(&server, &session, &repository).await;
+
+    let response = server.get("/api/search?text=hidden-lib").await;
+    assert!(response.status.is_success(), "{}", response.text);
+    let results = response.json();
+    assert_eq!(
+        results["results"].as_array().map(Vec::len),
+        Some(0),
+        "search must not surface a private repository's contents: {}",
+        response.text
+    );
+
+    let response = server.get_as("/api/search?text=hidden-lib", &session).await;
+    let results = response.json();
+    assert_eq!(
+        results["results"].as_array().map(Vec::len),
+        Some(1),
+        "the owner should still find it: {}",
+        response.text
+    );
+}
+
+/// Reading a file out of a private repository is the leak that matters most — it is the artifact
+/// itself, not metadata about it.
+#[tokio::test]
+async fn files_in_a_private_repository_are_not_downloadable_anonymously() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "files_in_a_private_repository_are_not_downloadable_anonymously"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, "local", "secret", "maven")
+        .await;
+
+    let project = nitro_repo::seed::config::MavenProject {
+        repository: "local/secret".to_owned(),
+        group_id: "dev.kingtux".to_owned(),
+        artifact_id: "private-lib".to_owned(),
+        versions: vec![],
+        description: None,
+        classifiers: vec![],
+        dependencies: vec![],
+    };
+    let jar = nitro_repo::seed::artifacts::jar(&project, "1.0.0", None).unwrap();
+    let path = "/repositories/local/secret/dev/kingtux/private-lib/1.0.0/private-lib-1.0.0.jar";
+    server
+        .put_with_basic(path, jar, "application/java-archive")
+        .await;
+
+    make_private(&server, &session, &repository).await;
+
+    let response = server.get(path).await;
+    assert!(
+        !response.status.is_success(),
+        "a file in a private repository must not be downloadable anonymously, got {}",
+        response.status
+    );
+}
+
+/// Administration must be refused to callers who are not administrators. Without a check here, the
+/// only thing standing between a signed-in user and creating storages is the frontend hiding a link.
+#[tokio::test]
+async fn administration_is_refused_to_anonymous_callers() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "administration_is_refused_to_anonymous_callers"
+        ));
+        return;
+    };
+    server.install().await;
+
+    let response = server.get("/api/storage/list").await;
+    assert!(
+        response.status == StatusCode::UNAUTHORIZED || response.status == StatusCode::FORBIDDEN,
+        "listing storages anonymously should be refused, got {}: {}",
+        response.status,
+        response.text
+    );
+
+    let response = server
+        .post_json(
+            "/api/storage/new/Local",
+            json!({
+                "name": "sneaky",
+                "config": { "type": "Local", "settings": { "path": "/tmp/sneaky" } },
+            }),
+        )
+        .await;
+    assert!(
+        response.status == StatusCode::UNAUTHORIZED || response.status == StatusCode::FORBIDDEN,
+        "creating a storage anonymously should be refused, got {}: {}",
+        response.status,
+        response.text
+    );
+
+    let response = server.get("/api/user-management/list").await;
+    assert!(
+        response.status == StatusCode::UNAUTHORIZED || response.status == StatusCode::FORBIDDEN,
+        "listing users anonymously should be refused, got {}: {}",
+        response.status,
+        response.text
+    );
+}
+
+/// Installing twice would hand an attacker a second administrator on any reachable instance.
+#[tokio::test]
+async fn the_instance_cannot_be_installed_twice() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "the_instance_cannot_be_installed_twice"
+        ));
+        return;
+    };
+    server.install().await;
+
+    let response = server
+        .post_json(
+            "/api/install",
+            json!({
+                "user": {
+                    "username": "second_admin",
+                    "email": "second@example.com",
+                    "name": "Second Admin",
+                    "password": "TestPassword1",
+                }
+            }),
+        )
+        .await;
+
+    assert!(
+        !response.status.is_success(),
+        "a second install should be refused, got {}: {}",
+        response.status,
+        response.text
+    );
+}

--- a/nitro_repo/tests/common/mod.rs
+++ b/nitro_repo/tests/common/mod.rs
@@ -1,0 +1,456 @@
+//! The integration test harness. (#502)
+//!
+//! Each test gets its own Postgres database and its own storage directory, and drives the *real*
+//! router — the one `web::start` serves, with the real middleware stack — through
+//! `tower::ServiceExt::oneshot`. Nothing binds a port, so tests run in parallel without fighting
+//! over one, and there is no server process to start, wait for, or leak.
+//!
+//! Requires a Postgres reachable at `NITRO_TEST_DATABASE_URL` (or the `DATABASE_URL` in
+//! `nr_tests.env`). Without one, [`TestServer::start`] returns `None` and the test skips, unless
+//! `NITRO_TESTS_REQUIRE_DB=1` is set — CI sets it, so a skip there is a failure.
+
+#![allow(dead_code)]
+
+use std::{
+    path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use axum::{
+    Router,
+    body::Body,
+    extract::DefaultBodyLimit,
+    http::{Request, StatusCode, header},
+};
+use http_body_util::BodyExt;
+use nitro_repo::app::{
+    NitroRepo,
+    config::{Mode, SiteSetting, security::SecuritySettings},
+    web::build_app,
+};
+use nr_core::database::DatabaseConfig;
+use serde_json::{Value, json};
+use sqlx::{Connection, Executor, PgConnection};
+use tower::ServiceExt;
+
+pub static TEST_USERNAME: &str = "test_admin";
+pub static TEST_PASSWORD: &str = "TestPassword1";
+
+/// Names each test's database uniquely, so a parallel run does not share state.
+static DATABASE_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+pub struct TestServer {
+    pub router: Router,
+    pub site: NitroRepo,
+    /// Held so the directory outlives the test; dropping it removes the storage and session files.
+    _directory: tempfile::TempDir,
+    database_url: String,
+    database_name: String,
+}
+
+/// Where the test Postgres lives, minus the database name.
+fn postgres_root() -> Option<String> {
+    if let Ok(url) = std::env::var("NITRO_TEST_DATABASE_URL") {
+        return Some(url);
+    }
+    // Falls back to the same file `TestCore` reads, so one setup serves both.
+    let contents = std::fs::read_to_string(find_upwards("nr_tests.env")?).ok()?;
+    for line in contents.lines() {
+        if let Some(value) = line.strip_prefix("DATABASE_URL=") {
+            return Some(value.trim().to_owned());
+        }
+    }
+    None
+}
+
+fn find_upwards(name: &str) -> Option<PathBuf> {
+    let mut directory = std::env::current_dir().ok()?;
+    loop {
+        let candidate = directory.join(name);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        directory = directory.parent()?.to_path_buf();
+    }
+}
+
+/// Skips, or fails, depending on whether the environment promised a database.
+pub fn skip_without_database(what: &str) -> bool {
+    if std::env::var("NITRO_TESTS_REQUIRE_DB").as_deref() == Ok("1") {
+        panic!(
+            "{what} needs a database and NITRO_TESTS_REQUIRE_DB=1 was set. \
+             Start one with `just services-up --profile postgres`."
+        );
+    }
+    eprintln!(
+        "skipping {what}: no test database. Set NITRO_TEST_DATABASE_URL or run `just services-up`."
+    );
+    true
+}
+
+impl TestServer {
+    /// Builds an instance against a fresh database. `None` when there is no Postgres to use.
+    pub async fn start() -> Option<Self> {
+        let root = postgres_root()?;
+
+        // `postgres://user:pass@host/some_db` → the same, with a unique database name. Each test
+        // gets its own so migrations, seeded rows and unique constraints cannot collide.
+        let (prefix, _) = root.rsplit_once('/')?;
+        let database_name = format!(
+            "nr_it_{}_{}",
+            std::process::id(),
+            DATABASE_COUNTER.fetch_add(1, Ordering::SeqCst)
+        );
+        let admin_url = format!("{prefix}/postgres");
+        let database_url = format!("{prefix}/{database_name}");
+
+        let mut admin = PgConnection::connect(&admin_url).await.ok()?;
+        admin
+            .execute(format!(r#"DROP DATABASE IF EXISTS "{database_name}""#).as_str())
+            .await
+            .ok()?;
+        admin
+            .execute(format!(r#"CREATE DATABASE "{database_name}""#).as_str())
+            .await
+            .ok()?;
+        drop(admin);
+
+        let directory = tempfile::tempdir().ok()?;
+
+        let site = NitroRepo::new(
+            Mode::Debug,
+            SiteSetting {
+                app_url: Some("http://localhost:6742/".to_owned()),
+                name: "Integration tests".to_owned(),
+                description: "Integration tests".to_owned(),
+                is_https: false,
+                #[cfg(feature = "frontend")]
+                frontend_path: None,
+            },
+            SecuritySettings::default(),
+            nitro_repo::app::authentication::session::SessionManagerConfig {
+                database_location: directory.path().join("sessions.redb"),
+                ..Default::default()
+            },
+            nitro_repo::repository::staging::StagingConfig {
+                staging_dir: directory.path().join("staging"),
+                ..Default::default()
+            },
+            // No email service: nothing under test sends one, and configuring a transport would
+            // make these tests depend on a mail server being reachable.
+            None,
+            parse_database_config(&database_url)?,
+            Some(directory.path().join("storage")),
+        )
+        .await
+        .ok()?;
+
+        let router = build_app(site.clone(), false, DefaultBodyLimit::max(64 * 1024 * 1024));
+
+        Some(Self {
+            router,
+            site,
+            _directory: directory,
+            database_url,
+            database_name,
+        })
+    }
+
+    /// Creates the first admin, which is what `POST /api/install` does.
+    pub async fn install(&self) {
+        let response = self
+            .post_json(
+                "/api/install",
+                json!({
+                    "user": {
+                        "username": TEST_USERNAME,
+                        "email": "test@example.com",
+                        "name": "Test Admin",
+                        "password": TEST_PASSWORD,
+                    }
+                }),
+            )
+            .await;
+        assert_eq!(
+            response.status,
+            StatusCode::NO_CONTENT,
+            "install failed: {}",
+            response.text
+        );
+    }
+
+    /// Signs in and returns the session id, which the API accepts as `Authorization: Session <id>`.
+    pub async fn sign_in(&self) -> String {
+        let response = self
+            .post_json(
+                "/api/user/login",
+                json!({ "email_or_username": TEST_USERNAME, "password": TEST_PASSWORD }),
+            )
+            .await;
+        assert_eq!(
+            response.status,
+            StatusCode::OK,
+            "login failed: {}",
+            response.text
+        );
+
+        response.json()["session"]["session_id"]
+            .as_str()
+            .expect("the login response should carry a session id")
+            .to_owned()
+    }
+
+    /// Sends a request through the real router.
+    ///
+    /// A `user-agent` is added when the caller did not set one: the login route records it against
+    /// the session and rejects a request without it, and every real client sends one.
+    pub async fn request(&self, mut request: Request<Body>) -> TestResponse {
+        if !request.headers().contains_key(header::USER_AGENT) {
+            request.headers_mut().insert(
+                header::USER_AGENT,
+                axum::http::HeaderValue::from_static("nitro-repo-integration-tests"),
+            );
+        }
+
+        // In production this extension is added by `into_make_service_with_connect_info`, from the
+        // accepted TCP connection. There is no connection here, and the routes that record a
+        // client address — login, password reset — extract it unconditionally.
+        request
+            .extensions_mut()
+            .insert(axum::extract::ConnectInfo(std::net::SocketAddr::from((
+                [127, 0, 0, 1],
+                47_000,
+            ))));
+
+        let response = self
+            .router
+            .clone()
+            .oneshot(request)
+            .await
+            .expect("the router should not fail to respond");
+
+        let status = response.status();
+        let headers = response.headers().clone();
+        let bytes = response
+            .into_body()
+            .collect()
+            .await
+            .expect("the body should be readable")
+            .to_bytes();
+
+        TestResponse {
+            status,
+            headers,
+            text: String::from_utf8_lossy(&bytes).into_owned(),
+            bytes: bytes.to_vec(),
+        }
+    }
+
+    pub async fn get(&self, path: &str) -> TestResponse {
+        self.request(
+            Request::builder()
+                .uri(path)
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+    }
+
+    pub async fn get_as(&self, path: &str, session: &str) -> TestResponse {
+        self.request(
+            Request::builder()
+                .uri(path)
+                .header(header::AUTHORIZATION, format!("Session {session}"))
+                .body(Body::empty())
+                .expect("valid request"),
+        )
+        .await
+    }
+
+    pub async fn post_json(&self, path: &str, body: Value) -> TestResponse {
+        self.request(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(body.to_string()))
+                .expect("valid request"),
+        )
+        .await
+    }
+
+    pub async fn post_json_as(&self, path: &str, body: Value, session: &str) -> TestResponse {
+        self.request(
+            Request::builder()
+                .method("POST")
+                .uri(path)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, format!("Session {session}"))
+                .body(Body::from(body.to_string()))
+                .expect("valid request"),
+        )
+        .await
+    }
+
+    pub async fn put_json_as(&self, path: &str, body: Value, session: &str) -> TestResponse {
+        self.request(
+            Request::builder()
+                .method("PUT")
+                .uri(path)
+                .header(header::CONTENT_TYPE, "application/json")
+                .header(header::AUTHORIZATION, format!("Session {session}"))
+                .body(Body::from(body.to_string()))
+                .expect("valid request"),
+        )
+        .await
+    }
+
+    /// A `PUT` with basic auth — what `mvn deploy` and `npm publish` actually send.
+    pub async fn put_with_basic(
+        &self,
+        path: &str,
+        body: Vec<u8>,
+        content_type: &str,
+    ) -> TestResponse {
+        use base64::{Engine, engine::general_purpose::STANDARD};
+        let credentials = STANDARD.encode(format!("{TEST_USERNAME}:{TEST_PASSWORD}"));
+
+        self.request(
+            Request::builder()
+                .method("PUT")
+                .uri(path)
+                .header(header::CONTENT_TYPE, content_type)
+                .header(header::AUTHORIZATION, format!("Basic {credentials}"))
+                .body(Body::from(body))
+                .expect("valid request"),
+        )
+        .await
+    }
+
+    /// Creates a storage and a repository, and returns the repository's id.
+    pub async fn create_repository(
+        &self,
+        session: &str,
+        storage_name: &str,
+        repository_name: &str,
+        repository_type: &str,
+    ) -> String {
+        let storages = self.get_as("/api/storage/list", session).await;
+        let existing = storages.json().as_array().and_then(|list| {
+            list.iter()
+                .find(|value| value["name"] == storage_name)
+                .and_then(|value| value["id"].as_str().map(str::to_owned))
+        });
+
+        let storage_id = match existing {
+            Some(id) => id,
+            None => {
+                let response = self
+                    .post_json_as(
+                        "/api/storage/new/Local",
+                        json!({
+                            "name": storage_name,
+                            "config": {
+                                "type": "Local",
+                                "settings": { "path": self._directory.path().join("storage") },
+                            },
+                        }),
+                        session,
+                    )
+                    .await;
+                assert!(
+                    response.status.is_success(),
+                    "creating storage failed: {} {}",
+                    response.status,
+                    response.text
+                );
+                response.json()["id"].as_str().unwrap().to_owned()
+            }
+        };
+
+        let response = self
+            .post_json_as(
+                &format!("/api/repository/new/{repository_type}"),
+                json!({
+                    "name": repository_name,
+                    "storage": storage_id,
+                    "configs": { repository_type: { "type": "Hosted" } },
+                }),
+                session,
+            )
+            .await;
+        assert!(
+            response.status.is_success(),
+            "creating repository failed: {} {}",
+            response.status,
+            response.text
+        );
+
+        response.json()["id"].as_str().unwrap().to_owned()
+    }
+}
+
+impl Drop for TestServer {
+    fn drop(&mut self) {
+        // Dropped databases keep a parallel run from accumulating dozens of them. Best effort: a
+        // failure here should not mask whatever the test was actually asserting.
+        let Some((prefix, _)) = self.database_url.rsplit_once('/') else {
+            return;
+        };
+        let admin_url = format!("{prefix}/postgres");
+        let name = self.database_name.clone();
+
+        let _ = std::thread::spawn(move || {
+            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+            else {
+                return;
+            };
+            runtime.block_on(async move {
+                if let Ok(mut admin) = PgConnection::connect(&admin_url).await {
+                    let _ = admin
+                        .execute(
+                            format!(r#"DROP DATABASE IF EXISTS "{name}" WITH (FORCE)"#).as_str(),
+                        )
+                        .await;
+                }
+            });
+        })
+        .join();
+    }
+}
+
+pub struct TestResponse {
+    pub status: StatusCode,
+    pub headers: axum::http::HeaderMap,
+    pub text: String,
+    pub bytes: Vec<u8>,
+}
+
+impl TestResponse {
+    pub fn json(&self) -> Value {
+        serde_json::from_str(&self.text)
+            .unwrap_or_else(|error| panic!("expected JSON, got `{}` ({error})", self.text))
+    }
+}
+
+fn parse_database_config(url: &str) -> Option<DatabaseConfig> {
+    // `postgres://user:password@host:port/database`
+    let rest = url.strip_prefix("postgres://")?;
+    let (credentials, rest) = rest.split_once('@')?;
+    let (user, password) = credentials.split_once(':')?;
+    let (host_port, database) = rest.split_once('/')?;
+    let (host, port) = match host_port.split_once(':') {
+        Some((host, port)) => (host, port.parse().ok()),
+        None => (host_port, None),
+    };
+
+    Some(DatabaseConfig {
+        user: user.to_owned(),
+        password: password.to_owned(),
+        host: host.to_owned(),
+        port,
+        database: database.to_owned(),
+    })
+}

--- a/nitro_repo/tests/maven.rs
+++ b/nitro_repo/tests/maven.rs
@@ -1,0 +1,306 @@
+//! End-to-end Maven tests. (#502)
+//!
+//! These drive the real router with the requests `mvn deploy` and `mvn dependency:get` send. Every
+//! one of them covers something that was broken and is now not — most of Phase 4 had no test that
+//! executed against a database, which is how the `release_type` column mismatch survived.
+
+mod common;
+
+use axum::http::StatusCode;
+use common::{TestServer, skip_without_database};
+use nitro_repo::seed::{artifacts, config::MavenProject};
+
+fn project(repository: &str) -> MavenProject {
+    MavenProject {
+        repository: repository.to_owned(),
+        group_id: "dev.kingtux".to_owned(),
+        artifact_id: "tms".to_owned(),
+        versions: vec![],
+        description: Some("Integration test artifact".to_owned()),
+        classifiers: vec![],
+        dependencies: vec![],
+    }
+}
+
+/// Deploys one version the way Maven does: the POM, the jar, and a checksum beside each.
+async fn deploy(server: &TestServer, repository: &str, version: &str) {
+    let project = project(repository);
+    let base = format!("/repositories/{repository}/dev/kingtux/tms/{version}/tms-{version}");
+
+    let pom = artifacts::pom(&project, version).into_bytes();
+    let response = server
+        .put_with_basic(&format!("{base}.pom"), pom.clone(), "application/xml")
+        .await;
+    assert!(
+        response.status.is_success(),
+        "deploying the POM failed: {} {}",
+        response.status,
+        response.text
+    );
+
+    let sha1 = artifacts::sha1_hex(&pom).into_bytes();
+    let response = server
+        .put_with_basic(&format!("{base}.pom.sha1"), sha1, "text/plain")
+        .await;
+    assert!(
+        response.status.is_success(),
+        "deploying the POM checksum failed: {} {}",
+        response.status,
+        response.text
+    );
+
+    let jar = artifacts::jar(&project, version, None).expect("builds");
+    let response = server
+        .put_with_basic(
+            &format!("{base}.jar"),
+            jar.clone(),
+            "application/java-archive",
+        )
+        .await;
+    assert!(
+        response.status.is_success(),
+        "deploying the jar failed: {} {}",
+        response.status,
+        response.text
+    );
+
+    let sha1 = artifacts::sha1_hex(&jar).into_bytes();
+    let response = server
+        .put_with_basic(&format!("{base}.jar.sha1"), sha1, "text/plain")
+        .await;
+    assert!(
+        response.status.is_success(),
+        "deploying the jar checksum failed: {} {}",
+        response.status,
+        response.text
+    );
+}
+
+#[tokio::test]
+async fn a_deployed_artifact_can_be_fetched_back() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_deployed_artifact_can_be_fetched_back"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "releases", "maven")
+        .await;
+
+    deploy(&server, "local/releases", "1.0.0").await;
+
+    let response = server
+        .get("/repositories/local/releases/dev/kingtux/tms/1.0.0/tms-1.0.0.jar")
+        .await;
+    assert_eq!(response.status, StatusCode::OK);
+
+    let expected = artifacts::jar(&project("local/releases"), "1.0.0", None).unwrap();
+    assert_eq!(
+        response.bytes, expected,
+        "the bytes served back should be the bytes deployed"
+    );
+}
+
+/// The defect that made this necessary: `release_type` was VARCHAR while the Rust type declared
+/// TEXT, so every read of a version failed and this list was always empty — while the deploy itself
+/// reported success.
+#[tokio::test]
+async fn a_deployed_version_is_registered_in_the_database() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_deployed_version_is_registered_in_the_database"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, "local", "releases", "maven")
+        .await;
+
+    deploy(&server, "local/releases", "1.0.0").await;
+    deploy(&server, "local/releases", "1.1.0").await;
+
+    // Search reads through `project_versions`, which is the table whose `release_type` column could
+    // not be decoded — so this is the assertion the original defect would fail.
+    let response = server.get_as("/api/search?text=tms", &session).await;
+    assert!(
+        response.status.is_success(),
+        "search failed: {} {}",
+        response.status,
+        response.text
+    );
+
+    let results = response.json();
+    let results = results["results"].as_array().expect("results array");
+    assert_eq!(
+        results.len(),
+        2,
+        "both deployed versions should be registered, got: {}",
+        response.text
+    );
+
+    let versions: Vec<&str> = results
+        .iter()
+        .filter_map(|value| value["version"].as_str())
+        .collect();
+    assert!(versions.contains(&"1.0.0"), "{versions:?}");
+    assert!(versions.contains(&"1.1.0"), "{versions:?}");
+
+    for result in results {
+        assert_eq!(result["repository"], "releases", "{result}");
+    }
+    let _ = repository;
+}
+
+/// `maven-metadata.xml` is generated, never stored. Nothing uploads it, so if the generator is
+/// wrong the only symptom is that clients cannot resolve a version range.
+#[tokio::test]
+async fn maven_metadata_is_generated_from_the_deployed_versions() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "maven_metadata_is_generated_from_the_deployed_versions"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "releases", "maven")
+        .await;
+
+    deploy(&server, "local/releases", "1.0.0").await;
+    deploy(&server, "local/releases", "1.1.0").await;
+
+    let response = server
+        .get("/repositories/local/releases/dev/kingtux/tms/maven-metadata.xml")
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "maven-metadata.xml should be generated: {}",
+        response.text
+    );
+
+    let body = &response.text;
+    assert!(body.contains("<groupId>dev.kingtux</groupId>"), "{body}");
+    assert!(body.contains("<artifactId>tms</artifactId>"), "{body}");
+    assert!(body.contains("<version>1.0.0</version>"), "{body}");
+    assert!(body.contains("<version>1.1.0</version>"), "{body}");
+    // `release` is the newest non-snapshot, which is what a client resolving RELEASE reads.
+    assert!(body.contains("<release>1.1.0</release>"), "{body}");
+}
+
+/// A checksum that was never uploaded still has to be served — Maven asks for one after every
+/// download and treats a 404 as a corrupt artifact.
+#[tokio::test]
+async fn checksums_are_served_for_files_that_were_never_uploaded_as_checksums() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "checksums_are_served_for_files_that_were_never_uploaded_as_checksums"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "releases", "maven")
+        .await;
+
+    // Deployed *without* an md5 beside it.
+    let project = project("local/releases");
+    let jar = artifacts::jar(&project, "1.0.0", None).unwrap();
+    server
+        .put_with_basic(
+            "/repositories/local/releases/dev/kingtux/tms/1.0.0/tms-1.0.0.jar",
+            jar.clone(),
+            "application/java-archive",
+        )
+        .await;
+
+    let response = server
+        .get("/repositories/local/releases/dev/kingtux/tms/1.0.0/tms-1.0.0.jar.md5")
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "an md5 should be generated on demand: {}",
+        response.text
+    );
+    assert_eq!(response.text.trim(), artifacts::md5_hex(&jar));
+}
+
+/// An uploaded checksum that does not match the artifact means the upload was corrupted in transit.
+/// Accepting it produces a repository whose contents cannot be validated.
+#[tokio::test]
+async fn a_mismatched_checksum_is_rejected() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("a_mismatched_checksum_is_rejected"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "releases", "maven")
+        .await;
+
+    let project = project("local/releases");
+    let jar = artifacts::jar(&project, "1.0.0", None).unwrap();
+    server
+        .put_with_basic(
+            "/repositories/local/releases/dev/kingtux/tms/1.0.0/tms-1.0.0.jar",
+            jar,
+            "application/java-archive",
+        )
+        .await;
+
+    let response = server
+        .put_with_basic(
+            "/repositories/local/releases/dev/kingtux/tms/1.0.0/tms-1.0.0.jar.sha1",
+            b"0000000000000000000000000000000000000000".to_vec(),
+            "text/plain",
+        )
+        .await;
+
+    assert!(
+        response.status.is_client_error(),
+        "a checksum that does not match should be refused, got {}: {}",
+        response.status,
+        response.text
+    );
+}
+
+/// Anonymous writes are how a repository ends up with artifacts nobody deployed.
+#[tokio::test]
+async fn an_anonymous_deploy_is_refused() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("an_anonymous_deploy_is_refused"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "releases", "maven")
+        .await;
+
+    let project = project("local/releases");
+    let response = server
+        .request(
+            axum::http::Request::builder()
+                .method("PUT")
+                .uri("/repositories/local/releases/dev/kingtux/tms/1.0.0/tms-1.0.0.pom")
+                .header(axum::http::header::CONTENT_TYPE, "application/xml")
+                .body(axum::body::Body::from(artifacts::pom(&project, "1.0.0")))
+                .unwrap(),
+        )
+        .await;
+
+    assert!(
+        response.status == StatusCode::UNAUTHORIZED || response.status == StatusCode::FORBIDDEN,
+        "an unauthenticated deploy should be refused, got {}",
+        response.status
+    );
+}

--- a/nitro_repo/tests/npm.rs
+++ b/nitro_repo/tests/npm.rs
@@ -1,0 +1,306 @@
+//! End-to-end npm tests. (#502)
+//!
+//! These send what `npm publish` and `npm install` send. The scoped-package case is here because it
+//! was completely broken — `@scope/pkg` parsed to a scope of `@scope`, and `Display` re-prepended
+//! the `@`, so publish stored `@@scope/pkg` while every fetch looked up the correct key. Nothing
+//! caught it, because nothing published a scoped package and then asked for it back.
+
+mod common;
+
+use axum::http::{StatusCode, header};
+use base64::{Engine, engine::general_purpose::STANDARD};
+use common::{TestServer, skip_without_database};
+use nitro_repo::seed::artifacts;
+use serde_json::json;
+
+/// The packument `npm publish` sends: one version, and the tarball inline as a base64 attachment.
+async fn publish(
+    server: &TestServer,
+    repository: &str,
+    name: &str,
+    version: &str,
+) -> common::TestResponse {
+    let tarball = artifacts::npm_tarball(name, version, Some("Integration test")).expect("builds");
+    let unscoped = name.rsplit('/').next().unwrap_or(name);
+    let file_name = format!("{unscoped}-{version}.tgz");
+
+    let mut manifest = artifacts::package_json(name, version, Some("Integration test"));
+    let object = manifest.as_object_mut().unwrap();
+    object.insert("_id".to_owned(), json!(format!("{name}@{version}")));
+    object.insert(
+        "dist".to_owned(),
+        json!({
+            "integrity": artifacts::integrity(&tarball),
+            "shasum": artifacts::shasum(&tarball),
+            "tarball": format!("http://localhost:6742/repositories/{repository}/{name}/-/{file_name}"),
+        }),
+    );
+    object.insert("_nodeVersion".to_owned(), json!("20.0.0"));
+    object.insert("_npmVersion".to_owned(), json!("10.0.0"));
+    object.insert("readme".to_owned(), json!("# test"));
+    object.insert("readmeFilename".to_owned(), json!("README.md"));
+
+    let body = json!({
+        "_id": name,
+        "name": name,
+        "versions": { version: manifest },
+        "_attachments": {
+            file_name: {
+                "content_type": "application/octet-stream",
+                "data": STANDARD.encode(&tarball),
+                "length": tarball.len(),
+            }
+        },
+    });
+
+    server
+        .request(
+            axum::http::Request::builder()
+                .method("PUT")
+                .uri(format!("/repositories/{repository}/{name}"))
+                .header(header::CONTENT_TYPE, "application/json")
+                .header("npm-command", "publish")
+                .header(
+                    header::AUTHORIZATION,
+                    format!(
+                        "Basic {}",
+                        STANDARD.encode(format!(
+                            "{}:{}",
+                            common::TEST_USERNAME,
+                            common::TEST_PASSWORD
+                        ))
+                    ),
+                )
+                .body(axum::body::Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+}
+
+/// A scoped package must be storable and then fetchable under the *same* key. It was not.
+#[tokio::test]
+async fn a_scoped_package_round_trips() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("a_scoped_package_round_trips"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+
+    let response = publish(&server, "local/npm", "@nitro/example", "1.0.0").await;
+    assert!(
+        response.status.is_success(),
+        "publishing a scoped package failed: {} {}",
+        response.status,
+        response.text
+    );
+
+    let response = server.get("/repositories/local/npm/@nitro/example").await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "the packument should come back under the same name it was published as: {}",
+        response.text
+    );
+
+    let packument = response.json();
+    assert_eq!(packument["name"], "@nitro/example");
+    assert!(
+        packument["versions"]["1.0.0"].is_object(),
+        "the published version should be in the packument: {}",
+        response.text
+    );
+    assert_eq!(
+        packument["dist-tags"]["latest"], "1.0.0",
+        "publishing should set `latest`: {}",
+        response.text
+    );
+}
+
+/// npm names the tarball by the *unscoped* name, and fetches it from a path under the scoped one.
+#[tokio::test]
+async fn a_published_tarball_can_be_downloaded() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_published_tarball_can_be_downloaded"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+
+    publish(&server, "local/npm", "@nitro/example", "1.0.0").await;
+
+    let response = server
+        .get("/repositories/local/npm/@nitro/example/-/example-1.0.0.tgz")
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "the tarball should be downloadable: {}",
+        response.text
+    );
+
+    let expected =
+        artifacts::npm_tarball("@nitro/example", "1.0.0", Some("Integration test")).unwrap();
+    assert_eq!(response.bytes, expected, "the tarball bytes should match");
+}
+
+/// `lodash.merge` is a real package. `validate_name` used to allow only `[a-z0-9_-]`, so a dotted
+/// name could not be published at all.
+#[tokio::test]
+async fn a_dotted_unscoped_name_is_accepted() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("a_dotted_unscoped_name_is_accepted"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+
+    let response = publish(&server, "local/npm", "nitro.helpers", "0.1.0").await;
+    assert!(
+        response.status.is_success(),
+        "a dotted package name should publish: {} {}",
+        response.status,
+        response.text
+    );
+
+    let response = server.get("/repositories/local/npm/nitro.helpers").await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text);
+}
+
+/// Re-publishing an existing version used to overwrite the tarball while leaving the database row
+/// stale. Immutable published versions are the whole contract of a registry.
+#[tokio::test]
+async fn republishing_an_existing_version_is_refused() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "republishing_an_existing_version_is_refused"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+
+    let first = publish(&server, "local/npm", "@nitro/example", "1.0.0").await;
+    assert!(first.status.is_success(), "{}", first.text);
+
+    let second = publish(&server, "local/npm", "@nitro/example", "1.0.0").await;
+    assert_eq!(
+        second.status,
+        StatusCode::CONFLICT,
+        "re-publishing the same version should conflict, got {}: {}",
+        second.status,
+        second.text
+    );
+}
+
+/// The registry advertises this to `npm ping`, and npm refuses to talk to a registry that 404s it.
+#[tokio::test]
+async fn the_registry_answers_ping() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("the_registry_answers_ping"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+
+    let response = server.get("/repositories/local/npm/-/ping").await;
+    assert!(
+        response.status.is_success(),
+        "ping should succeed, got {}: {}",
+        response.status,
+        response.text
+    );
+}
+
+/// A publish with a tarball that does not match its own `integrity` is a corrupted upload. It was
+/// parsed, stored and never checked.
+#[tokio::test]
+async fn a_tarball_that_does_not_match_its_integrity_is_refused() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_tarball_that_does_not_match_its_integrity_is_refused"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+
+    let tarball = artifacts::npm_tarball("@nitro/example", "1.0.0", Some("x")).unwrap();
+    let mut manifest = artifacts::package_json("@nitro/example", "1.0.0", Some("x"));
+    let object = manifest.as_object_mut().unwrap();
+    object.insert("_id".to_owned(), json!("@nitro/example@1.0.0"));
+    object.insert(
+        "dist".to_owned(),
+        json!({
+            // The integrity of *different* content.
+            "integrity": artifacts::integrity(b"not this tarball"),
+            "shasum": artifacts::shasum(&tarball),
+            "tarball": "http://localhost:6742/repositories/local/npm/@nitro/example/-/example-1.0.0.tgz",
+        }),
+    );
+    object.insert("_nodeVersion".to_owned(), json!("20.0.0"));
+    object.insert("_npmVersion".to_owned(), json!("10.0.0"));
+
+    let body = json!({
+        "_id": "@nitro/example",
+        "name": "@nitro/example",
+        "versions": { "1.0.0": manifest },
+        "_attachments": {
+            "example-1.0.0.tgz": {
+                "content_type": "application/octet-stream",
+                "data": STANDARD.encode(&tarball),
+                "length": tarball.len(),
+            }
+        },
+    });
+
+    let response = server
+        .request(
+            axum::http::Request::builder()
+                .method("PUT")
+                .uri("/repositories/local/npm/@nitro/example")
+                .header(header::CONTENT_TYPE, "application/json")
+                .header("npm-command", "publish")
+                .header(
+                    header::AUTHORIZATION,
+                    format!(
+                        "Basic {}",
+                        STANDARD.encode(format!(
+                            "{}:{}",
+                            common::TEST_USERNAME,
+                            common::TEST_PASSWORD
+                        ))
+                    ),
+                )
+                .body(axum::body::Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await;
+
+    assert!(
+        response.status.is_client_error(),
+        "a tarball that does not match its integrity should be refused, got {}: {}",
+        response.status,
+        response.text
+    );
+}

--- a/seed.example.toml
+++ b/seed.example.toml
@@ -1,0 +1,111 @@
+# Example seed configuration.
+#
+# `nitro_repo seed --config seed.example.toml` deploys this suite into a running
+# instance over the real Maven and npm protocols. Re-running is safe — anything already
+# present is left alone.
+#
+# Regenerate with: nitro_repo seed --config seed.toml --write-example
+
+url = "http://localhost:6742"
+
+[auth]
+username = "admin"
+password = "changeme"
+
+[[storages]]
+name = "local"
+type = "Local"
+
+[storages.settings]
+path = "./storage/local"
+
+[[repositories]]
+storage = "local"
+name = "releases"
+type = "maven"
+visibility = "Public"
+
+[[repositories]]
+storage = "local"
+name = "snapshots"
+type = "maven"
+visibility = "Public"
+
+[[repositories]]
+storage = "local"
+name = "npm"
+type = "npm"
+visibility = "Public"
+
+[[maven]]
+repository = "local/releases"
+group_id = "dev.kingtux"
+artifact_id = "tms"
+versions = [
+    "1.0.0",
+    "1.0.1",
+    "1.1.0",
+    "2.0.0-beta.1",
+]
+description = "A seeded example artifact"
+classifiers = [
+    "sources",
+    "javadoc",
+]
+dependencies = ["org.slf4j:slf4j-api:2.0.13"]
+
+[[maven]]
+repository = "local/releases"
+group_id = "dev.kingtux.tools"
+artifact_id = "nested-example"
+versions = ["0.1.0"]
+description = "A deeper group id, to exercise nested paths"
+classifiers = []
+dependencies = ["dev.kingtux:tms:1.1.0"]
+
+[[maven]]
+repository = "local/snapshots"
+group_id = "dev.kingtux"
+artifact_id = "tms"
+versions = ["1.2.0-SNAPSHOT"]
+description = "Snapshot deploys, for maven-metadata.xml"
+classifiers = [
+    "sources",
+    "javadoc",
+]
+dependencies = []
+
+[[npm]]
+repository = "local/npm"
+name = "@nitro/example"
+versions = [
+    "1.0.0",
+    "1.0.1",
+    "1.1.0",
+]
+description = "A scoped package"
+
+[npm.dist_tags]
+
+[[npm]]
+repository = "local/npm"
+name = "nitro.helpers"
+versions = [
+    "0.1.0",
+    "0.2.0",
+]
+description = "An unscoped package with a dot in its name"
+
+[npm.dist_tags]
+
+[[npm]]
+repository = "local/npm"
+name = "@nitro/prerelease"
+versions = [
+    "1.0.0",
+    "2.0.0-beta.1",
+]
+description = "Prerelease versions, and a non-latest dist-tag"
+
+[npm.dist_tags]
+next = "2.0.0-beta.1"


### PR DESCRIPTION
Phase 8. Closes **#502**, closes **#484**.

There was no `tests/` directory anywhere in this repository and no way to exercise a real request. This adds two things that fix that, and reports the four defects they immediately found.

## The seed command

You asked for this: `nitro_repo seed --config seed.toml` deploys a configured suite of Maven artifacts and npm packages into a running instance.

Deploys go over the **real protocols** — a `PUT` of a jar with its sibling `.sha1`/`.md5`, and an npm packument with a base64 `_attachments` entry — so a seed run doubles as a smoke test of the deploy paths. Idempotent; `--write-example` writes a starting config; `seed.example.toml` is committed.

The artifacts are genuine. Jars are real zips with manifests, npm tarballs are real gzipped tars with the `package/` prefix, and a test parses the generated POM through the exact call the server uses on upload. Snapshots deploy the way `mvn deploy` does — two timestamped builds, `tms-1.2.0-20260801.185040-1.jar` — because the plain `-SNAPSHOT` name is what a local `mvn install` produces and leaves snapshot metadata with nothing to describe.

## The integration harness

`nitro_repo` was a binary with no library target, so nothing outside `main.rs` could reach the router. It has a lib target now, and `main.rs` is only the CLI.

Each test gets its own Postgres database and storage directory and drives the **real router** — the one `web::start` serves, with the real middleware stack — through `oneshot`. Nothing binds a port, so tests run in parallel and there is no server process to start or leak. `build_app` is extracted from `start` deliberately: a test that builds its own router tests its own router.

18 end-to-end tests across Maven, npm and authorization, plus 3 database tests on the `TestCore` harness that has sat unused with one `#[ignore]`d self-test.

## The four bugs

**1. Every read of a Maven version failed.** `project_versions.release_type` was `VARCHAR(255)` while `ReleaseType` declares `#[sqlx(type_name = "TEXT")]`; sqlx checks the column's type OID on decode. Nothing that listed Maven versions could ever have returned any. Invisible because `post_pom_upload` only *logged* its errors until Phase 4 made them returned — deploys answered 201 while their version registration had failed.

**2. Text search and any AQL glob on `project` failed against a real database.** `projects.key` carries a nondeterministic ICU collation, and Postgres refuses LIKE/ILIKE on those. This is my Phase 6 code; all 29 AQL unit tests passed, because they compile SQL without executing it.

**3. `npm install @scope/pkg` could not download its tarball.** `@scope/pkg/-/pkg-1.0.0.tgz` is four path components; the scoped branch checked for five. The packument resolved and the download 404'd. The pre-existing unit test asserted a URL npm never sends — with the scope repeated inside the filename — which is where the five came from.

**4. A private repository kept serving its files.** `MavenHosted::reload` refreshed `active`, the push rules and the project config, and never the cached `visibility`. Making a repository private took effect in the database and in `/api/repository/list` while the running repository carried on handing out artifacts to anyone, until a restart.

That fourth one is the **fourth visibility leak** found during this work, and by far the worst — the others exposed metadata, this exposed the artifacts. It is worth stating plainly why they all survived: every one was in a code path with no test, and the tests that did exist only ever checked the happy path. A suite that never asserts a refusal cannot distinguish working authorization from none at all. Every authorization test here asserts a refusal.

## Housekeeping

README badged "Powered By Actix" — 2.0 moved to Axum. CONTRIBUTING asked for Rust 1.56, a MySQL C++ driver, a MySQL database and Node 16, then told you to copy an `example.env` that is not in the repo and build with a `dev-frontend` feature that does not exist; all of it predates the 2.0 rewrite by several years. Both rewritten. #484 closed with a contributors section.

## Verification

149 tests pass with `STORAGE_TESTS_REQUIRE_ALL=1 NITRO_TESTS_REQUIRE_DB=1`; clippy with `-D warnings` and `cargo +nightly fmt --check` clean.

CI now sets `NITRO_TESTS_REQUIRE_DB=1`, so a skipped integration test there is a failure. Locally they skip with a message when there is no database, so nobody is blocked by a service they are not working on.

The seed was also verified by hand against a live instance built from an empty database: 78 files and 7 package versions deployed, `maven-metadata.xml` with all four versions, snapshot metadata with the right build number and all four classifiers, checksums served for files never uploaded as checksums, and both search paths returning results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)