### PR TITLE
Add Cargo and Docker repository types

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ a faster and more modern experience.
   snapshots), checksum verification on upload and generation on demand, and enforced push rules.
 - **npm** — a hosted registry: scoped packages, dist-tags, publish, unpublish, deprecate, search,
   and both login flows including the browser one npm 9+ defaults to.
+- **Cargo** — a hosted registry over the sparse index: publish, yank, owners, search, and renamed
+  dependencies.
+- **Docker** — a hosted OCI registry: push and pull, multi-arch images, referrers, and the bearer
+  token exchange `docker login` uses. Addressed on a domain of its own or by an image-name prefix.
 - **Storage** — the local filesystem, a self-contained object format (FileSystemV2), or S3 and
   anything S3-compatible.
 - **Search** — a small query language (`crates/aql`) over projects and versions, exposed both as
@@ -61,8 +65,8 @@ Building it yourself, and everything else you would need to work on it, is in
 
 ### Documentation
 
-[nitro-repo.kingtux.dev](https://nitro-repo.kingtux.dev/) — installation, configuration, the Maven
-and npm guides, and the API reference. The source is in [`docs/`](docs/) (Astro + Starlight).
+[nitro-repo.kingtux.dev](https://nitro-repo.kingtux.dev/) — installation, configuration, the
+per-format guides, and the API reference. The source is in [`docs/`](docs/) (Astro + Starlight).
 
 ### Status
 

--- a/crates/core/migrations/20260803000000_docker_manifests.down.sql
+++ b/crates/core/migrations/20260803000000_docker_manifests.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS docker_manifests;

--- a/crates/core/migrations/20260803000000_docker_manifests.up.sql
+++ b/crates/core/migrations/20260803000000_docker_manifests.up.sql
@@ -1,0 +1,32 @@
+-- Manifests a Docker repository holds, addressed by digest.
+--
+-- Tags are NOT here: a tag is a version of a project, so it lives in `project_versions` alongside
+-- every other repository type's versions, which is what gives Docker images the project pages,
+-- badges and search everything else already has.
+--
+-- This table exists for the two things `project_versions` cannot express:
+--   * a digest-addressed pull (`GET /v2/{name}/manifests/sha256:...`), which never names a tag;
+--   * an untagged manifest — the per-platform children of an index, and OCI referrers artifacts —
+--     which is reachable and must be retained even though no tag points at it.
+CREATE TABLE IF NOT EXISTS docker_manifests (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid (),
+    repository_id UUID NOT NULL,
+    image_name TEXT COLLATE ignoreCase NOT NULL,
+    -- `algorithm:hex`, exactly as the client sent it. The digest is over the stored bytes, so this
+    -- is the manifest's identity and not merely a checksum of it.
+    digest TEXT NOT NULL,
+    media_type TEXT NOT NULL,
+    size BIGINT NOT NULL,
+    -- The OCI referrers relationship: this manifest is *about* the manifest named here.
+    subject_digest TEXT,
+    artifact_type TEXT,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_docker_manifests_repository FOREIGN KEY (repository_id) REFERENCES repositories (id) ON DELETE CASCADE,
+    CONSTRAINT docker_manifests_unique UNIQUE (repository_id, image_name, digest)
+);
+
+CREATE INDEX IF NOT EXISTS docker_manifests_image ON docker_manifests (repository_id, image_name);
+
+-- `GET /v2/{name}/referrers/{digest}` filters on exactly this.
+CREATE INDEX IF NOT EXISTS docker_manifests_subject ON docker_manifests (repository_id, image_name, subject_digest);

--- a/crates/core/src/database/entities/docker_manifest.rs
+++ b/crates/core/src/database/entities/docker_manifest.rs
@@ -1,0 +1,145 @@
+//! Manifests a Docker repository holds, addressed by digest.
+//!
+//! Tags are not here — a tag is a version, so it lives in `project_versions` with every other
+//! repository type's versions. This table covers the two cases a version row cannot: a pull that
+//! names a digest rather than a tag, and a manifest nothing is tagged at (the per-platform children
+//! of an index, and OCI referrers artifacts), which must still be retained and served.
+
+use serde::Serialize;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::database::prelude::*;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, FromRow, ToSchema, TableType)]
+#[table(name = "docker_manifests")]
+pub struct DBDockerManifest {
+    pub id: Uuid,
+    pub repository_id: Uuid,
+    pub image_name: String,
+    /// `algorithm:hex`, over the exact bytes stored.
+    pub digest: String,
+    pub media_type: String,
+    pub size: i64,
+    /// The manifest this one is *about*, for the OCI referrers API.
+    pub subject_digest: Option<String>,
+    pub artifact_type: Option<String>,
+    pub updated_at: DateTime<FixedOffset>,
+    pub created_at: DateTime<FixedOffset>,
+}
+
+impl DBDockerManifest {
+    #[instrument(skip(database))]
+    pub async fn get(
+        repository_id: Uuid,
+        image_name: &str,
+        digest: &str,
+        database: &PgPool,
+    ) -> Result<Option<Self>, sqlx::Error> {
+        SelectQueryBuilder::with_columns(Self::table_name(), Self::columns())
+            .filter(DBDockerManifestColumn::RepositoryId.equals(repository_id.value()))
+            .filter(DBDockerManifestColumn::ImageName.equals(image_name.value()))
+            .filter(DBDockerManifestColumn::Digest.equals(digest.value()))
+            .query_as()
+            .fetch_optional(database)
+            .await
+    }
+
+    /// Whether a manifest exists, without reading it back.
+    ///
+    /// Used to check that every child of an index is already present before the index is accepted.
+    #[instrument(skip(database))]
+    pub async fn exists(
+        repository_id: Uuid,
+        image_name: &str,
+        digest: &str,
+        database: &PgPool,
+    ) -> Result<bool, sqlx::Error> {
+        let count: i64 = sqlx::query_scalar(
+            r#"SELECT COUNT(*) FROM docker_manifests
+               WHERE repository_id = $1 AND image_name = $2 AND digest = $3"#,
+        )
+        .bind(repository_id)
+        .bind(image_name)
+        .bind(digest)
+        .fetch_one(database)
+        .await?;
+        Ok(count > 0)
+    }
+
+    /// Records a manifest, or refreshes what is already recorded for that digest.
+    ///
+    /// A digest identifies its bytes, so a second push of the same manifest is the same manifest —
+    /// re-pushing an image (which every CI run does) must not be a unique-constraint violation.
+    #[instrument(skip(database))]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn upsert(
+        repository_id: Uuid,
+        image_name: &str,
+        digest: &str,
+        media_type: &str,
+        size: i64,
+        subject_digest: Option<&str>,
+        artifact_type: Option<&str>,
+        database: &PgPool,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"INSERT INTO docker_manifests
+                 (repository_id, image_name, digest, media_type, size, subject_digest, artifact_type)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               ON CONFLICT (repository_id, image_name, digest)
+               DO UPDATE SET media_type = EXCLUDED.media_type,
+                             size = EXCLUDED.size,
+                             subject_digest = EXCLUDED.subject_digest,
+                             artifact_type = EXCLUDED.artifact_type,
+                             updated_at = CURRENT_TIMESTAMP"#,
+        )
+        .bind(repository_id)
+        .bind(image_name)
+        .bind(digest)
+        .bind(media_type)
+        .bind(size)
+        .bind(subject_digest)
+        .bind(artifact_type)
+        .execute(database)
+        .await?;
+        Ok(())
+    }
+
+    /// Every manifest that declares `digest` as its subject — the OCI referrers list.
+    #[instrument(skip(database))]
+    pub async fn referrers(
+        repository_id: Uuid,
+        image_name: &str,
+        subject_digest: &str,
+        database: &PgPool,
+    ) -> Result<Vec<Self>, sqlx::Error> {
+        SelectQueryBuilder::with_columns(Self::table_name(), Self::columns())
+            .filter(DBDockerManifestColumn::RepositoryId.equals(repository_id.value()))
+            .filter(DBDockerManifestColumn::ImageName.equals(image_name.value()))
+            .filter(DBDockerManifestColumn::SubjectDigest.equals(subject_digest.value()))
+            .order_by(DBDockerManifestColumn::CreatedAt, SQLOrder::Ascending)
+            .query_as()
+            .fetch_all(database)
+            .await
+    }
+
+    #[instrument(skip(database))]
+    pub async fn delete(
+        repository_id: Uuid,
+        image_name: &str,
+        digest: &str,
+        database: &PgPool,
+    ) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query(
+            r#"DELETE FROM docker_manifests
+               WHERE repository_id = $1 AND image_name = $2 AND digest = $3"#,
+        )
+        .bind(repository_id)
+        .bind(image_name)
+        .bind(digest)
+        .execute(database)
+        .await?;
+        Ok(result.rows_affected() > 0)
+    }
+}

--- a/crates/core/src/database/entities/mod.rs
+++ b/crates/core/src/database/entities/mod.rs
@@ -1,3 +1,4 @@
+pub mod docker_manifest;
 pub mod project;
 pub mod repository;
 pub mod stages;

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -128,6 +128,41 @@ export default defineConfig({
                 },
               ],
             },
+            {
+              label: "Cargo",
+              collapsed: false,
+              items: [
+                { label: "Overview", slug: "repositories/cargo" },
+                {
+                  label: "Authenticating",
+                  slug: "repositories/cargo/authenticating",
+                },
+                { label: "Publishing", slug: "repositories/cargo/publishing" },
+                {
+                  label: "Configuration",
+                  slug: "repositories/cargo/configuration",
+                },
+              ],
+            },
+            {
+              label: "Docker",
+              collapsed: false,
+              items: [
+                { label: "Overview", slug: "repositories/docker" },
+                {
+                  label: "Authenticating",
+                  slug: "repositories/docker/authenticating",
+                },
+                {
+                  label: "Pushing and pulling",
+                  slug: "repositories/docker/pushing",
+                },
+                {
+                  label: "Configuration",
+                  slug: "repositories/docker/configuration",
+                },
+              ],
+            },
           ],
         },
         {

--- a/docs/src/content/docs/about/comparison.md
+++ b/docs/src/content/docs/about/comparison.md
@@ -14,8 +14,8 @@ Honestly, including the parts where Nitro Repo loses.
 | Maven     |                               ✅                               |  ✅   |     ✅      |                          ✅                          |                         ✅                          |
 | npm       |                           ✅ hosted                            |  ✅   |     ✅      |                          ❌                          |                         ✅                          |
 | NuGet     | [#191](https://github.com/wyatt-herkamp/nitro_repo/issues/191) |  ✅   |     ✅      |                          ❌                          |                         ✅                          |
-| Cargo     |   [#6](https://github.com/wyatt-herkamp/nitro_repo/issues/6)   |  ❌   |     ✅      |                          ❌                          |                         ❌                          |
-| Docker    | [#419](https://github.com/wyatt-herkamp/nitro_repo/issues/419) |  ✅   |     ✅      |                          ❌                          |                         ❌                          |
+| Cargo     |                           ✅ hosted                            |  ❌   |     ✅      |                          ❌                          |                         ❌                          |
+| Docker    |                           ✅ hosted                            |  ✅   |     ✅      |                          ❌                          |                         ❌                          |
 | apt / RPM | [#192](https://github.com/wyatt-herkamp/nitro_repo/issues/192) |  ✅   |     ✅      |                          ❌                          |                         ❌                          |
 
 A linked issue is an open issue, not work in progress.
@@ -26,6 +26,8 @@ A linked issue is an open issue, not work in progress.
 | ------------------------- | :--------: | :---: | :---------: | :--------: |
 | Maven proxying            |     ✅     |  ✅   |     ✅      |     ✅     |
 | npm proxying              |     ❌     |  ✅   |     ✅      |     —      |
+| Docker pull-through cache |     ❌     |  ✅   |     ✅      |     —      |
+| Container image GC        |     ❌     |  ✅   |     ✅      |     —      |
 | Repository grouping       |     ❌     |  ✅   |     ✅      |     ✅     |
 | S3 storage                |     ✅     |  Pro  |     ✅      |     ❌     |
 | Scoped API tokens         |     ✅     |  ✅   |     ✅      |     ✅     |

--- a/docs/src/content/docs/repositories/cargo/authenticating.md
+++ b/docs/src/content/docs/repositories/cargo/authenticating.md
@@ -1,0 +1,74 @@
+---
+title: Authenticating with Cargo
+description: Tokens, credentials.toml, and CI.
+sidebar:
+  order: 2
+---
+
+## Pointing Cargo at the registry
+
+```toml
+# .cargo/config.toml
+[registries.nitro]
+index = "sparse+https://repo.example.com/repositories/local/crates/index/"
+```
+
+The name on the left — `nitro` here — is what you pass to `--registry` and write in
+`publish = [...]`. It is local to your machine and does not have to match the repository's name.
+
+## Getting a token
+
+Cargo has no login handshake with the registry; it only stores a token you give it. Mint one under
+**Profile → Tokens**, scoped to the repository, then:
+
+```sh
+cargo login --registry nitro
+# paste the token when prompted
+```
+
+That writes `~/.cargo/credentials.toml`:
+
+```toml
+[registries.nitro]
+token = "…"
+```
+
+A token needs `Read` for downloads and `Write` to publish or yank.
+
+## How the token reaches the registry
+
+Cargo sends it as a bare header — no scheme:
+
+```text
+Authorization: <token>
+```
+
+That is unusual (most clients send `Bearer <token>`), and Nitro Repo accepts it: a value with no
+space in it is treated as a token. `Bearer <token>` works too, so the same credential can be used
+by `curl` or a script without a second header format.
+
+## CI
+
+Put the token in the environment rather than a file. Cargo reads a per-registry variable:
+
+```sh
+export CARGO_REGISTRIES_NITRO_INDEX="sparse+https://repo.example.com/repositories/local/crates/index/"
+export CARGO_REGISTRIES_NITRO_TOKEN="$NITRO_TOKEN"
+
+cargo publish --registry nitro
+```
+
+The variable name is the registry name uppercased, with `-` becoming `_`.
+
+## Private registries
+
+A private repository sets `auth-required: true` in its `config.json`, which is what tells Cargo to
+send a token on _every_ request rather than only on publish. Without that flag Cargo would fetch the
+index anonymously, get a `401`, and report a hard failure instead of retrying with credentials.
+
+Nothing has to be configured for this — the flag follows the repository's visibility.
+
+## Next
+
+- [Publishing](/repositories/cargo/publishing/)
+- [API tokens and scopes](/admin/tokens/)

--- a/docs/src/content/docs/repositories/cargo/configuration.md
+++ b/docs/src/content/docs/repositories/cargo/configuration.md
@@ -1,0 +1,95 @@
+---
+title: Cargo configuration
+description: The settings on a Cargo repository.
+sidebar:
+  order: 4
+---
+
+A Cargo repository requires the `cargo` config. `project` and `page` are optional and shared with
+Maven and npm.
+
+## `cargo`
+
+```json
+{ "type": "Hosted" }
+```
+
+`Hosted` is the only mode. There is no `Proxy` variant, so a Cargo repository cannot mirror
+crates.io — configure both registries side by side and name yours explicitly on the dependencies
+that come from it:
+
+```toml
+[dependencies]
+serde = "1"                                             # crates.io
+nitro-example = { version = "1", registry = "nitro" }   # yours
+```
+
+## `config.json`
+
+Not a stored config — the registry generates it per request, because the right answer depends on how
+the client reached it:
+
+```json
+{
+  "dl": "https://repo.example.com/repositories/local/crates/api/v1/crates",
+  "api": "https://repo.example.com/repositories/local/crates",
+  "auth-required": false
+}
+```
+
+A request that arrived on a [custom domain](/admin/custom-domains/) is answered with that domain's
+root instead. Telling a client to go back through `/repositories/{storage}/{name}` would work only
+where both hosts resolve.
+
+`auth-required` follows the repository's visibility: `true` for anything not `Public`. It is what
+makes Cargo send a token on index requests as well as on publish.
+
+:::caution[`app_url` must be set]
+Without a custom domain, the registry has nothing but `site.app_url` to build those absolute URLs
+from. With none configured, `config.json` fails rather than emitting a URL pointing nowhere. See
+[Installation](/start/installation/#behind-a-reverse-proxy).
+:::
+
+## `project`
+
+Shared with Maven and npm. Badge appearance and version validation.
+
+| Field                        | Type                                | Default   |
+| ---------------------------- | ----------------------------------- | --------- |
+| `badge_settings.style`       | `flat` \| `plastic` \| `flatsquare` | `flat`    |
+| `badge_settings.label_color` | colour                              | `#555`    |
+| `badge_settings.color`       | colour                              | `#33B5E5` |
+| `require_semver`             | boolean                             | `false`   |
+
+Cargo versions are semver by definition, so `require_semver` is close to a no-op here.
+
+A repository **without** a `project` config cannot serve badges — that is where their settings live.
+See [Badges](/admin/badges/).
+
+## `page`
+
+Shared with Maven and npm. The content shown on the repository's page in the UI.
+
+| Field       | Type                           | Default |
+| ----------- | ------------------------------ | ------- |
+| `page_type` | `Markdown` \| `HTML` \| `None` | —       |
+| `content`   | string or null                 | `null`  |
+
+A good place for the `.cargo/config.toml` your team should be using.
+
+## Repository-level settings
+
+**Visibility.** `Public` downloads need no credentials; `Private` requires a token with read access,
+and sets `auth-required` so Cargo knows to send one. `Hidden` is readable but absent from search and
+listings. Writes always require authentication.
+
+**Active.** An inactive repository refuses every request from everyone.
+
+## No push rules
+
+There is no Cargo equivalent of `maven_push_rules`. The behaviour those would control is fixed:
+
+- Re-publishing an existing version is always refused.
+- Overwriting is never allowed.
+- Any user with `Write` may publish any crate name. Ownership is recorded on first publish and
+  governs `cargo owner`, but it does not reserve the name in advance.

--- a/docs/src/content/docs/repositories/cargo/index.md
+++ b/docs/src/content/docs/repositories/cargo/index.md
@@ -1,0 +1,89 @@
+---
+title: Cargo
+description: A hosted Cargo registry speaking the sparse index protocol — what is supported, and what is not there yet.
+sidebar:
+  order: 1
+---
+
+A Cargo repository is a hosted registry. Point `.cargo/config.toml` at its index and
+`cargo publish`, `cargo add` and `cargo build` work as they do against crates.io.
+
+```toml
+# .cargo/config.toml
+[registries.nitro]
+index = "sparse+https://repo.example.com/repositories/local/crates/index/"
+```
+
+:::caution[The trailing slash is not optional]
+Cargo appends the index path to this URL. Without the slash the last segment is replaced rather
+than appended, and every lookup 404s on a crate that exists.
+:::
+
+## What works
+
+|                    |                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------- |
+| **Sparse index**   | The HTTP index, default since Rust 1.68. No git server involved.                |
+| **Publish**        | `cargo publish`, including the `publish = ["nitro"]` manifest gate.             |
+| **Download**       | `cargo add`, `cargo build`, `cargo fetch`, with `cksum` verified by the client. |
+| **Yank**           | `cargo yank` and `cargo yank --undo`.                                           |
+| **Owners**         | `cargo owner --list`, `--add` and `--remove`.                                   |
+| **Search**         | `cargo search`.                                                                 |
+| **Renamed deps**   | `package = "…"` in the index, so `foo = { package = "bar" }` resolves.          |
+| **Feature syntax** | Index schema 2, so `dep:` and `foo?/bar` features are expressible.              |
+| **Access control** | Reads honour repository visibility; writes require a `Write` action.            |
+| **Custom domains** | `config.json` reports whichever host the client used.                           |
+
+## What is not there
+
+- **No proxying.** There is no `Proxy` mode, so a registry cannot mirror crates.io. Keep crates.io
+  configured alongside yours.
+- **No git index.** Only the sparse protocol. A toolchain older than Rust 1.68 cannot use this
+  registry.
+- **No `cargo login` handshake.** There is no credential-provider flow; paste an API token, as
+  below.
+- **No delete.** A published version can be yanked, never removed — which is what crates.io does,
+  and what every lockfile pinning it depends on.
+
+## Crate names
+
+The registry enforces Cargo's own rules: at most 64 characters, starting with a letter, and made up
+of `a-z`, `A-Z`, `0-9`, `-` and `_`. A name outside that is refused at publish time rather than
+stored as something nobody could depend on.
+
+## The index
+
+A crate's versions are served as newline-delimited JSON — one object per version, in publication
+order:
+
+```text
+GET /repositories/local/crates/index/ni/tr/nitro-example
+```
+
+```json
+{"name":"nitro-example","vers":"0.1.0","deps":[],"cksum":"…","features":{},"yanked":false,"v":2}
+{"name":"nitro-example","vers":"0.2.0","deps":[],"cksum":"…","features":{},"yanked":true,"v":2}
+```
+
+The path prefix comes from the crate name's length, which is how Cargo keeps one directory from
+holding every crate in the registry:
+
+| Name length | Path                   | Example               |
+| ----------- | ---------------------- | --------------------- |
+| 1           | `1/{name}`             | `1/a`                 |
+| 2           | `2/{name}`             | `2/ab`                |
+| 3           | `3/{first}/{name}`     | `3/f/foo`             |
+| 4 or more   | `{c1c2}/{c3c4}/{name}` | `ni/tr/nitro-example` |
+
+The name is lowercased for the path even though the crate name itself is not. A request whose path
+does not match the name it ends with is refused rather than served — otherwise one crate could be
+fetched under another's path, and Cargo caches by path.
+
+The index is generated from what the registry holds rather than stored, and every response carries
+an `ETag`. Cargo revalidates constantly, so a `304` is the common case.
+
+## Next
+
+- [Authenticating](/repositories/cargo/authenticating/) — tokens, and CI.
+- [Publishing](/repositories/cargo/publishing/) — publish, yank, owners.
+- [Configuration](/repositories/cargo/configuration/)

--- a/docs/src/content/docs/repositories/cargo/publishing.md
+++ b/docs/src/content/docs/repositories/cargo/publishing.md
@@ -1,0 +1,88 @@
+---
+title: Publishing to Cargo
+description: cargo publish, yank, and owners.
+sidebar:
+  order: 3
+---
+
+## Publishing
+
+Cargo refuses to publish anywhere unless the crate says so. Add the registry to the manifest:
+
+```toml
+# Cargo.toml
+[package]
+name = "nitro-example"
+version = "0.1.0"
+description = "…"
+license = "MIT"
+publish = ["nitro"]
+```
+
+Then:
+
+```sh
+cargo publish --registry nitro
+```
+
+Without `publish`, Cargo targets crates.io and stops with "the registry is not listed". With
+`publish = false` it refuses everywhere.
+
+### What happens
+
+Cargo packages the crate, then `PUT`s it to `/api/v1/crates/new` as two length-prefixed frames — the
+metadata JSON, then the `.crate` file. The registry:
+
+1. checks the name and version are well formed;
+2. refuses the publish if that version already exists;
+3. computes the `cksum` from the bytes it received, not from anything the client claimed;
+4. stores the `.crate` and writes the index record.
+
+Cargo then polls the index until the new version shows up, which is the "waiting for … to be
+available" line.
+
+### Re-publishing is refused
+
+```text
+error: failed to publish to registry at …
+Caused by: crate version `nitro-example@0.1.0` already exists.
+```
+
+A published version is immutable. Every lockfile that pins it, and every `cksum` in the index,
+assumes the bytes never change. Publish a new version instead.
+
+## Yanking
+
+```sh
+cargo yank --registry nitro --version 0.1.0 nitro-example
+cargo yank --registry nitro --version 0.1.0 --undo nitro-example
+```
+
+Yanking sets `"yanked": true` in the index. New resolutions skip the version; a lockfile that
+already pins it keeps working, and the `.crate` stays downloadable. That is the whole difference
+between yank and delete — and delete is not offered.
+
+## Owners
+
+```sh
+cargo owner --registry nitro --list nitro-example
+cargo owner --registry nitro --add someone nitro-example
+cargo owner --registry nitro --remove someone nitro-example
+```
+
+Whoever publishes a crate first becomes its owner. Adding or removing an owner needs more than
+publish rights: the caller must already manage the crate, or be able to administer the repository.
+Repository `Write` alone is not enough, because handing a crate to a third party is a stronger act
+than pushing a version of it.
+
+## Searching
+
+```sh
+cargo search --registry nitro nitro
+```
+
+Matches the crate name and description.
+
+## Next
+
+- [Configuration](/repositories/cargo/configuration/)

--- a/docs/src/content/docs/repositories/docker/authenticating.md
+++ b/docs/src/content/docs/repositories/docker/authenticating.md
@@ -1,0 +1,83 @@
+---
+title: Authenticating with Docker
+description: docker login, the bearer token exchange, and CI.
+sidebar:
+  order: 2
+---
+
+## `docker login`
+
+```sh
+docker login repo.example.com
+# or, with a hostname on the repository:
+docker login docker.example.com
+```
+
+Use your username, and an **auth token** from **Profile → Tokens** as the password. Your account
+password works too, but a token is what you want: it can be scoped to one repository and revoked on
+its own.
+
+## What actually happens
+
+Docker never sends your credentials to the registry endpoints. It performs the standard bearer
+exchange:
+
+1. `GET /v2/` — the capability probe.
+2. If the registry wants credentials, it answers `401` with a challenge naming where to get a token:
+
+   ```text
+   WWW-Authenticate: Bearer realm="https://repo.example.com/api/docker/token",
+                            scope="repository:local/docker/myimage:pull,push"
+   ```
+
+3. Docker calls that realm with Basic credentials and gets a short-lived token back.
+4. Every subsequent request carries `Authorization: Bearer <token>`.
+
+The token is an ordinary Nitro Repo auth token — the same rows `Profile → Tokens` lists — scoped to
+the repository in the challenge and **expiring after 30 minutes**. Docker fetches a new one whenever
+it gets a `401`, so the short life is invisible. Revoking a token from the profile UI logs the
+Docker client out too.
+
+The realm is built from the host the client is already talking to, not from `site.app_url`. A
+registry on a custom domain may be the only address that resolves from wherever Docker is running.
+
+## Anonymous pulls
+
+A `Public` repository serves pulls with no credentials at all — no challenge, no token. Only writes
+require authentication.
+
+A `Private` or `Hidden` one challenges every read, which is what makes `docker pull` fetch a token
+rather than give up.
+
+## CI
+
+```sh
+echo "$NITRO_TOKEN" | docker login repo.example.com -u "$NITRO_USER" --password-stdin
+docker push repo.example.com/local/docker/myimage:$CI_COMMIT_SHA
+```
+
+`--password-stdin` rather than `-p`: a token on the command line ends up in the process list and in
+shell history.
+
+Give the CI token `Read` and `Write` on that repository and nothing else.
+
+## Troubleshooting
+
+**`http: server gave HTTP response to HTTPS client`** — the daemon will not talk to a plain-HTTP
+registry. Put the instance behind TLS, or add the host to `insecure-registries` in
+`/etc/docker/daemon.json` and restart the daemon. `localhost` is exempt.
+
+**The push says `Layer already exists` and then stops, with no digest line and no error** — the
+daemon could not reach the realm in the challenge. Check that `site.app_url` (or the repository's
+hostname) is an address the client can resolve, _including the port_.
+
+**`denied: you do not have push access to this registry`** — the token authenticated but is not
+scoped to this repository with `Write`, or the user lacks that action. Both are checked.
+
+**`unauthorized` on a pull of a public image** — the repository is `Private` or `Hidden` rather than
+`Public`. Visibility is on the repository, not in its config.
+
+## Next
+
+- [Pushing and pulling](/repositories/docker/pushing/)
+- [API tokens and scopes](/admin/tokens/)

--- a/docs/src/content/docs/repositories/docker/configuration.md
+++ b/docs/src/content/docs/repositories/docker/configuration.md
@@ -1,0 +1,108 @@
+---
+title: Docker configuration
+description: The settings on a Docker repository, and what an operator has to plan for.
+sidebar:
+  order: 4
+---
+
+A Docker repository requires the `docker` config. `project` and `page` are optional and shared with
+the other types.
+
+## `docker`
+
+```json
+{ "type": "Hosted" }
+```
+
+`Hosted` is the only mode. There is no `Proxy` variant, so a Docker repository cannot act as a
+pull-through cache for Docker Hub.
+
+## Hostnames
+
+Not a config — [custom domains](/admin/custom-domains/) are attached to the repository itself, and
+for Docker they are the difference between
+
+```sh
+docker pull docker.example.com/myimage:1.0
+docker pull repo.example.com/local/docker/myimage:1.0
+```
+
+Both work at the same time. Adding a hostname does not break anyone using the prefixed form.
+
+A hostname pointing at a repository that is _not_ a Docker one is unaffected: a `/v2/...` request on
+such a host is served as an ordinary artifact path, so a Maven artifact stored under `v2/` keeps
+working.
+
+## Staging
+
+An in-progress blob upload is buffered to the instance's staging directory before it is handed to
+storage, because there is no streaming write on the storage backends.
+
+```toml
+[staging]
+staging_dir = "./staging"
+```
+
+Two consequences worth planning for:
+
+- **Disk.** A push needs room for the largest layer in flight, per concurrent upload, on the node's
+  local disk — not in S3.
+- **Affinity.** An upload session lives in one process's memory. Behind a load balancer, either pin
+  a client's requests to one backend or run a single instance. A `PATCH` that lands on a different
+  node answers `404 BLOB_UPLOAD_UNKNOWN`.
+
+Abandoned sessions are swept after an hour.
+
+## Storage growth
+
+Nothing garbage-collects blobs. Deleting a tag or a manifest leaves its layers on disk, because
+layers are shared between images and nothing counts references to them.
+
+In practice this means a repository that CI pushes to on every commit grows without bound. Until
+there is a GC, the options are to push fewer distinct layers, or to rebuild the repository
+periodically from what you want to keep.
+
+## `project`
+
+Shared with the other types. Badge appearance and version validation.
+
+| Field                        | Type                                | Default   |
+| ---------------------------- | ----------------------------------- | --------- |
+| `badge_settings.style`       | `flat` \| `plastic` \| `flatsquare` | `flat`    |
+| `badge_settings.label_color` | colour                              | `#555`    |
+| `badge_settings.color`       | colour                              | `#33B5E5` |
+| `require_semver`             | boolean                             | `false`   |
+
+Leave `require_semver` off. A container tag is not a version — `latest`, `edge` and `main` are all
+legitimate — and turning it on would reject them.
+
+A repository **without** a `project` config cannot serve badges. See [Badges](/admin/badges/).
+
+## `page`
+
+Shared with the other types. The content shown on the repository's page in the UI.
+
+| Field       | Type                           | Default |
+| ----------- | ------------------------------ | ------- |
+| `page_type` | `Markdown` \| `HTML` \| `None` | —       |
+| `content`   | string or null                 | `null`  |
+
+## Repository-level settings
+
+**Visibility.** `Public` pulls need no credentials at all. `Private` challenges every read, which is
+what makes a client fetch a token rather than give up. `Hidden` is readable but absent from search
+and listings. Writes always require authentication.
+
+**Active.** An inactive repository refuses every request from everyone.
+
+## Upload size
+
+A layer has to fit inside the server's body limit:
+
+```toml
+[web_server]
+max_upload = "2GiB"   # or "unlimited"
+```
+
+The default is 100 MiB, which is smaller than plenty of real base images. Raise it before the first
+push of anything substantial.

--- a/docs/src/content/docs/repositories/docker/index.md
+++ b/docs/src/content/docs/repositories/docker/index.md
@@ -1,0 +1,107 @@
+---
+title: Docker
+description: A hosted OCI container registry — how it is addressed, what is supported, and what is not there yet.
+sidebar:
+  order: 1
+---
+
+A Docker repository is a hosted container registry speaking the
+[OCI distribution API](https://github.com/opencontainers/distribution-spec/blob/main/spec.md) —
+the one `docker`, `podman`, `containerd`, BuildKit, `crane` and `skopeo` all use.
+
+## Addressing
+
+Docker is the one repository type that is **not** reached under
+`/repositories/{storage}/{repository}`. A client always requests `/v2/...` at the root of whatever
+host it was given, and there is no setting that adds a path prefix. So there are two ways to address
+a registry, and you can use either.
+
+### With a hostname
+
+Attach a [custom domain](/admin/custom-domains/) to the repository, and image names are bare:
+
+```sh
+docker pull docker.example.com/myimage:1.0
+```
+
+This is the form to prefer. It is what every published image reference looks like, and it is the
+only one that produces short names.
+
+### Without one
+
+The first two segments of the image name are the storage and the repository:
+
+```sh
+docker pull repo.example.com/local/docker/myimage:1.0
+```
+
+Nothing to configure — this works on the instance's own host as soon as the repository exists. The
+cost is verbose image names.
+
+:::caution[Docker requires TLS]
+A Docker daemon refuses a plain-HTTP registry unless it is `localhost`, or the host is listed in
+`insecure-registries` in `/etc/docker/daemon.json`. Put the instance behind TLS.
+:::
+
+## What works
+
+|                       |                                                                                  |
+| --------------------- | -------------------------------------------------------------------------------- |
+| **Push and pull**     | `docker push` / `docker pull`, and the same over podman, containerd, crane.      |
+| **Resumable uploads** | `POST` / `PATCH` / `PUT`, monolithic or chunked.                                 |
+| **Multi-arch**        | Image indexes, with their per-platform children.                                 |
+| **Digest pulls**      | `image@sha256:…`, byte-identical to what was pushed.                             |
+| **`HEAD` checks**     | So a push skips layers already present instead of re-uploading them.             |
+| **Tags and catalog**  | `/tags/list` and `/_catalog`, with `?n=` / `?last=` paging.                      |
+| **Referrers**         | The OCI referrers API, for signatures and SBOMs attached to an image.            |
+| **Deletes**           | By tag, and by manifest digest.                                                  |
+| **Auth**              | The `WWW-Authenticate: Bearer` challenge and token endpoint `docker login` uses. |
+| **Shared layers**     | Blobs are content-addressed, so images in one repository share their bases.      |
+
+## What is not there
+
+Stated plainly, because each of these is something a registry is often assumed to do:
+
+- **No pull-through cache.** There is no `Proxy` mode, so a repository cannot mirror Docker Hub.
+- **No garbage collection.** Deleting a tag or a manifest does not reclaim the blobs behind it.
+  Nothing reference-counts layers, so storage only grows.
+- **No blob deletes.** `DELETE` on a blob answers `405`. Removing a layer that another manifest
+  shares would break images that were fine a moment ago.
+- **No cross-repository mounting.** A `?mount=` request falls back to a normal upload, which the
+  spec allows. The client then pushes the blob rather than borrowing it.
+- **No `Range` requests on blobs.** A ranged `GET` is answered in full. Clients cope; a resumed
+  interrupted pull starts over.
+- **Uploads are node-local.** An in-progress push is buffered to the server's staging directory, so
+  it is bound to the node that started it and to that node's disk. Behind a load balancer, pin
+  upload sessions to one backend. See [Configuration](/repositories/docker/configuration/#staging).
+
+## Image names
+
+The registry enforces the distribution spec's grammar: lowercase `a-z`, `0-9`, and `.`, `_`, `-`
+between alphanumerics, in `/`-separated components. `library/alpine` and `team/project/service` are
+fine; `Alpine` is not — Docker itself refuses to push an uppercase name, so accepting one would
+create an image nobody could pull back.
+
+In prefix mode the storage and repository count as the first two components, and the rest is the
+image name proper.
+
+## How storage is laid out
+
+Per repository:
+
+```text
+blobs/sha256/{hex}      layers and image configs, content-addressed
+manifests/sha256/{hex}  manifests, stored as the exact bytes pushed
+```
+
+A manifest is re-served byte-for-byte, never re-serialised — its digest is over those bytes, so
+rewriting them would change the image's identity and break every client that pinned it.
+
+Tags are versions of a project, which is what gives a Docker image the same project pages, badges
+and search as every other repository type.
+
+## Next
+
+- [Authenticating](/repositories/docker/authenticating/) — `docker login`, tokens, CI.
+- [Pushing and pulling](/repositories/docker/pushing/)
+- [Configuration](/repositories/docker/configuration/)

--- a/docs/src/content/docs/repositories/docker/pushing.md
+++ b/docs/src/content/docs/repositories/docker/pushing.md
@@ -1,0 +1,113 @@
+---
+title: Pushing and pulling
+description: docker push, multi-arch images, tags and deletes.
+sidebar:
+  order: 3
+---
+
+## Pushing
+
+```sh
+docker tag myimage:1.0 repo.example.com/local/docker/myimage:1.0
+docker push repo.example.com/local/docker/myimage:1.0
+```
+
+With a hostname on the repository, drop the `local/docker/` prefix.
+
+### What happens
+
+For each layer and for the image config, the client:
+
+1. `HEAD`s the blob to see whether it is already here — if so, nothing transfers;
+2. `POST`s to open an upload and gets a `Location` back;
+3. `PATCH`es the bytes into it, in one go or in chunks;
+4. `PUT`s with `?digest=sha256:…` to commit.
+
+The registry hashes what it received and compares. A mismatch is a `400 DIGEST_INVALID`, the session
+is discarded, and nothing reaches storage.
+
+Then the manifest is `PUT`. Before it is accepted, every blob it references must already be present
+— otherwise a push would succeed and every pull of it would fail on a missing layer, with nothing to
+say which push was at fault.
+
+## Pulling
+
+```sh
+docker pull repo.example.com/local/docker/myimage:1.0
+docker pull repo.example.com/local/docker/myimage@sha256:2c009b…
+```
+
+A digest pull returns exactly the bytes that were pushed.
+
+## Tags
+
+A tag is a mutable pointer to a manifest, and moving it is normal — `:latest` moves with every
+push. Re-tagging is _not_ refused the way re-publishing a version is in Maven, npm or Cargo; a
+container tag is not a version.
+
+```sh
+curl https://repo.example.com/v2/local/docker/myimage/tags/list
+```
+
+```json
+{ "name": "local/docker/myimage", "tags": ["1.0", "1.1", "latest"] }
+```
+
+Tags come back in lexical order, and page with `?n=` and `?last=`.
+
+The whole registry's image list:
+
+```sh
+curl https://repo.example.com/v2/local/docker/_catalog
+```
+
+## Multi-arch images
+
+Push each platform's manifest by digest, then the index that names them:
+
+```sh
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  --tag repo.example.com/local/docker/myimage:1.0 \
+  --push .
+```
+
+The index is refused until all of its children are present, for the same reason a manifest is
+refused until its blobs are. The per-platform manifests are reachable by digest but are not tags —
+only the index gets one.
+
+## Deleting
+
+```sh
+# Remove a tag. The manifest stays, reachable by digest.
+curl -X DELETE -H "Authorization: Bearer $TOKEN" \
+  https://repo.example.com/v2/local/docker/myimage/manifests/1.0
+
+# Remove the manifest itself, and any tag still pointing at it.
+curl -X DELETE -H "Authorization: Bearer $TOKEN" \
+  https://repo.example.com/v2/local/docker/myimage/manifests/sha256:2c009b…
+```
+
+Deleting a manifest also drops any tag aimed at it — a tag left pointing at bytes that are gone
+turns every pull into a `404` on something the tag list still advertises.
+
+:::caution[Blobs are never removed]
+Layers are content-addressed and nothing reference-counts them, so deleting a manifest does not
+reclaim its storage, and `DELETE` on a blob answers `405`. Removing a layer another image shares
+would break that image. Storage only grows; plan for it.
+:::
+
+## Referrers
+
+Signatures, SBOMs and other artifacts attached to an image are found through the referrers API:
+
+```sh
+curl https://repo.example.com/v2/local/docker/myimage/referrers/sha256:2c009b…
+```
+
+An unknown subject answers `200` with an empty index rather than `404` — a client uses this to
+discover whether anything exists at all.
+
+## Next
+
+- [Configuration](/repositories/docker/configuration/)

--- a/docs/src/content/docs/repositories/types.md
+++ b/docs/src/content/docs/repositories/types.md
@@ -8,12 +8,14 @@ sidebar:
 A repository's **type** decides how requests to it are interpreted. The same `PUT` of a file means
 something specific to a Maven repository and nothing at all to an npm one.
 
-Two types ship:
+Four types ship:
 
-| Type    | Modes         | Clients                                                         |
-| ------- | ------------- | --------------------------------------------------------------- |
-| `maven` | Hosted, Proxy | Maven, Gradle, sbt, anything else that speaks the Maven layout. |
-| `npm`   | Hosted        | npm, yarn, pnpm.                                                |
+| Type     | Modes         | Clients                                                         |
+| -------- | ------------- | --------------------------------------------------------------- |
+| `maven`  | Hosted, Proxy | Maven, Gradle, sbt, anything else that speaks the Maven layout. |
+| `npm`    | Hosted        | npm, yarn, pnpm.                                                |
+| `cargo`  | Hosted        | `cargo`, over the sparse index.                                 |
+| `docker` | Hosted        | Docker, podman, containerd, BuildKit, `crane`, `skopeo`.        |
 
 The type is chosen at creation and cannot be changed afterwards — the layout, the metadata and the
 authentication all differ, so there is nothing to convert.
@@ -23,24 +25,43 @@ authentication all differ, so there is nothing to convert.
 A **hosted** repository stores what you publish to it. A **proxy** repository stores nothing of its
 own: it forwards misses to configured upstreams and caches what comes back.
 
-Only Maven has a proxy mode today. An npm repository is always hosted; there is no `Proxy` variant
-in its config, so pointing one at the public registry is not possible yet.
+Only Maven has a proxy mode today. npm, Cargo and Docker repositories are always hosted; there is no
+`Proxy` variant in their configs, so pointing one at npmjs.org, crates.io or Docker Hub is not
+possible yet.
+
+## How a repository is addressed
+
+Three of the four live under one URL:
+
+```text
+{app_url}/repositories/{storage}/{repository}/
+```
+
+Docker is the exception, and not by choice: a Docker client always requests `/v2/...` at the root of
+its host and cannot be given a path prefix. So a Docker repository is reached either on a
+[custom domain](/admin/custom-domains/) of its own, or by putting `{storage}/{repository}` at the
+front of the image name. See [Docker](/repositories/docker/#addressing).
+
+Any repository can have a custom domain attached; for Docker it is the difference between
+`docker.example.com/myimage` and `repo.example.com/local/docker/myimage`.
 
 ## Configs
 
 Behaviour is set by **configs** — named JSON blobs validated against a schema the type publishes,
 stored as separate rows so a type can gain settings without a migration.
 
-| Config             | Maven | npm | What it sets                                         |
-| ------------------ | :---: | :-: | ---------------------------------------------------- |
-| `maven`            |   ●   |     | Hosted or proxy, and the proxy's upstream routes.    |
-| `maven_push_rules` |   ●   |     | Release/snapshot policy, overwrite, yanking, auth.   |
-| `npm`              |       |  ●  | Registry mode.                                       |
-| `project`          |   ●   |  ●  | Badge appearance, and whether semver is required.    |
-| `page`             |   ●   |  ●  | The Markdown or HTML shown on the repository's page. |
+| Config             | Maven | npm | Cargo | Docker | What it sets                                         |
+| ------------------ | :---: | :-: | :---: | :----: | ---------------------------------------------------- |
+| `maven`            |   ●   |     |       |        | Hosted or proxy, and the proxy's upstream routes.    |
+| `maven_push_rules` |   ●   |     |       |        | Release/snapshot policy, overwrite, yanking, auth.   |
+| `npm`              |       |  ●  |       |        | Registry mode.                                       |
+| `cargo`            |       |     |   ●   |        | Registry mode.                                       |
+| `docker`           |       |     |       |   ●    | Registry mode.                                       |
+| `project`          |   ●   |  ●  |   ●   |   ●    | Badge appearance, and whether semver is required.    |
+| `page`             |   ●   |  ●  |   ●   |   ●    | The Markdown or HTML shown on the repository's page. |
 
-A type declares which configs it _requires_ — `maven` and `npm` respectively — and the create form
-asks for those. The rest are optional and can be added later from **Admin → Repositories → _name_**.
+A type declares which configs it _requires_ — the one named after it — and the create form asks for
+those. The rest are optional and can be added later from **Admin → Repositories → _name_**.
 
 A config a repository does not have is not an error; the type falls back to the schema's defaults.
 The exception worth knowing is `project`: without it, badges are refused, because that is where
@@ -49,10 +70,12 @@ their settings live.
 ## Adding a type
 
 Repository types are a trait rather than a hardcoded list, so adding one means implementing the
-trait and registering it — not restructuring the server. NuGet, Cargo, Docker and apt/RPM are open
-issues, not work in progress.
+trait and registering it — not restructuring the server. NuGet and apt/RPM are open issues, not work
+in progress.
 
 ## Next
 
 - [Maven](/repositories/maven/)
 - [npm](/repositories/npm/)
+- [Cargo](/repositories/cargo/)
+- [Docker](/repositories/docker/)

--- a/justfile
+++ b/justfile
@@ -27,10 +27,13 @@ test:
 test-all:
     STORAGE_TESTS_REQUIRE_ALL=1 NITRO_TESTS_REQUIRE_DB=1 cargo test --all
 
-# The end-to-end suite on its own: real Maven and npm requests against the real router, each test
-# in its own database.
+# The end-to-end suite on its own: real Maven, npm, Cargo and Docker requests against the real
+# router, each test in its own database.
+#
+# The binaries are listed by hand because `--test` takes one name at a time. Add new ones here —
+# `hostnames` was missed when it was added, so nothing ran it outside `just test`.
 test-integration:
-    NITRO_TESTS_REQUIRE_DB=1 cargo test -p nitro_repo --test maven --test npm --test authorization
+    NITRO_TESTS_REQUIRE_DB=1 cargo test -p nitro_repo --test maven --test npm --test cargo --test docker --test authorization --test hostnames
 
 # Fills a running instance with a suite of artifacts, over the real protocols.
 seed config="seed.example.toml":

--- a/nitro_repo/src/app/api/docker.rs
+++ b/nitro_repo/src/app/api/docker.rs
@@ -1,0 +1,253 @@
+//! The token endpoint a Docker client is sent to.
+//!
+//! A registry that wants credentials answers `GET /v2/...` with `401` and
+//! `WWW-Authenticate: Bearer realm="...",scope="repository:{image}:pull,push"`. The client then
+//! calls the realm with its Basic credentials, gets a bearer token back, and retries. That is the
+//! whole of `docker login`.
+//!
+//! The realm lives here, under `/api`, rather than under `/v2`: an image can be named anything,
+//! including `token`, and `/api` is nested before the router fallback so it is reachable on a
+//! custom Docker domain as well as on the instance host.
+//!
+//! The token minted is an ordinary Nitro auth token — the same rows `/api/user/token/create`
+//! writes — so there is no second credential store to keep in step, and revoking a token from the
+//! profile UI logs the Docker client out too.
+
+use axum::{
+    extract::{Query, State},
+    response::Response,
+};
+use chrono::{Duration, Local};
+use nr_core::{
+    database::entities::user::auth_token::NewRepositoryToken, user::permissions::RepositoryActions,
+};
+use serde::{Deserialize, Serialize};
+use tracing::{debug, instrument};
+use utoipa::{OpenApi, ToSchema};
+
+use crate::{
+    app::{NitroRepo, RepositoryStorageName},
+    error::InternalError,
+    repository::{Repository, RepositoryAuthentication},
+    utils::ResponseBuilder,
+};
+
+/// How long a minted token lives.
+///
+/// Long enough for a large push to finish, short enough that a token scraped out of a CI log is not
+/// a standing key. Docker re-requests one whenever it gets a 401, so a short life is invisible.
+const TOKEN_LIFETIME: Duration = Duration::minutes(30);
+
+#[derive(OpenApi)]
+#[openapi(paths(token), components(schemas(TokenResponse)))]
+pub struct DockerAPI;
+
+pub fn docker_routes() -> axum::Router<NitroRepo> {
+    axum::Router::new().route("/token", axum::routing::get(token))
+}
+
+#[derive(Debug, Default, Deserialize)]
+pub struct TokenQuery {
+    /// `repository:{image}:{actions}` — what the client is about to do.
+    pub scope: Option<String>,
+    pub service: Option<String>,
+    pub account: Option<String>,
+    /// Set when the client only wants an anonymous token.
+    #[serde(default)]
+    pub offline_token: Option<bool>,
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct TokenResponse {
+    /// The spec names this `token`; the OAuth2 flow names the same value `access_token`. Both are
+    /// sent because different clients read different ones.
+    pub token: String,
+    pub access_token: String,
+    pub expires_in: i64,
+    pub issued_at: String,
+}
+
+/// Exchanges Basic credentials for a bearer token.
+#[utoipa::path(
+    get,
+    path = "/token",
+    responses(
+        (status = 200, description = "A bearer token for the requested scope", body = TokenResponse),
+        (status = 401, description = "The credentials were not accepted"),
+    )
+)]
+#[instrument(skip(site, query, authentication, parts))]
+pub async fn token(
+    State(site): State<NitroRepo>,
+    Query(query): Query<TokenQuery>,
+    authentication: RepositoryAuthentication,
+    parts: http::request::Parts,
+) -> Result<Response, InternalError> {
+    // `RepositoryAuthentication` is the extractor the artifact routes use: it resolves Basic
+    // credentials against the user table and, failing that, treats the password as an auth token.
+    // That second attempt is what makes `docker login -u me -p <token>` work, which is the form
+    // every CI pipeline uses.
+    let Some(user) = authentication.get_user() else {
+        debug!("Refused a Docker token request with no usable credentials");
+        return Ok(unauthorized());
+    };
+
+    let (image, actions) = match query.scope.as_deref().and_then(parse_scope) {
+        Some((image, actions)) => (Some(image), actions),
+        // `docker login` with no scope: the client is only checking the credentials work. A token
+        // scoped to nothing is still useful — it authenticates the next `/v2/` probe, which is what
+        // makes `docker login` report success.
+        None => (None, vec![RepositoryActions::Read]),
+    };
+    let repository = resolve_repository(&site, image.as_deref(), &parts).await;
+
+    let expires_at = Local::now().fixed_offset() + TOKEN_LIFETIME;
+    let source = format!(
+        "Docker client ({})",
+        query.service.as_deref().unwrap_or("-")
+    );
+
+    let new_token = match repository {
+        Some(repository_id) => NewRepositoryToken {
+            user_id: user.id,
+            source,
+            repositories: vec![(repository_id, actions)],
+            expires_at: Some(expires_at),
+        },
+        None => NewRepositoryToken {
+            user_id: user.id,
+            source,
+            repositories: Vec::new(),
+            expires_at: Some(expires_at),
+        },
+    };
+    let (_, secret) = new_token.insert(site.as_ref()).await?;
+
+    Ok(ResponseBuilder::ok().json(&TokenResponse {
+        access_token: secret.clone(),
+        token: secret,
+        expires_in: TOKEN_LIFETIME.num_seconds(),
+        issued_at: Local::now().fixed_offset().to_rfc3339(),
+    }))
+}
+
+fn unauthorized() -> Response {
+    ResponseBuilder::unauthorized()
+        .header(http::header::WWW_AUTHENTICATE, "Basic realm=\"nitro_repo\"")
+        .json(&serde_json::json!({
+            "errors": [{
+                "code": "UNAUTHORIZED",
+                "message": "the credentials were not accepted",
+            }]
+        }))
+}
+
+/// Parses `repository:{image}:{action},{action}`.
+///
+/// The image itself contains `/` but never `:`, so splitting on the first and last colon is
+/// unambiguous.
+fn parse_scope(scope: &str) -> Option<(String, Vec<RepositoryActions>)> {
+    let rest = scope.strip_prefix("repository:")?;
+    let (image, actions) = rest.rsplit_once(':')?;
+    if image.is_empty() {
+        return None;
+    }
+    let actions: Vec<RepositoryActions> = actions
+        .split(',')
+        .filter_map(|action| match action.trim() {
+            "pull" => Some(RepositoryActions::Read),
+            "push" => Some(RepositoryActions::Write),
+            "delete" => Some(RepositoryActions::Write),
+            _ => None,
+        })
+        .collect();
+    if actions.is_empty() {
+        return None;
+    }
+    Some((image.to_owned(), actions))
+}
+
+/// Finds the repository the caller is asking for a token against.
+///
+/// Two ways, matching the two ways a registry is addressed:
+///
+/// * **prefix mode** — the scope's image name begins with `{storage}/{repository}`;
+/// * **hostname mode** — the image name carries no prefix, but the challenge sent the client to a
+///   realm on the registry's own hostname, so the `Host` on this request identifies it.
+///
+/// `None` means the token is minted unscoped. That is not a way to widen access: every request is
+/// still checked against the repository it names, and a token with no repository scope passes no
+/// such check. It only keeps `docker login` working when there is nothing to scope to.
+async fn resolve_repository(
+    site: &NitroRepo,
+    image: Option<&str>,
+    parts: &http::request::Parts,
+) -> Option<uuid::Uuid> {
+    if let Some(image) = image {
+        let mut components = image.split('/');
+        if let (Some(storage), Some(repository)) = (components.next(), components.next()) {
+            let names = RepositoryStorageName::from((storage.to_owned(), repository.to_owned()));
+            // Through the cache-then-database lookup rather than the in-memory table alone: that
+            // table is filled lazily, so a miss on a registry nobody has pulled from yet would mint
+            // a token that grants nothing and make the first push of the day fail.
+            if let Ok(Some(found)) = site.get_repository_from_names(&names).await
+                && found.get_type() == "docker"
+            {
+                return Some(found.id());
+            }
+        }
+    }
+
+    let host = crate::app::host_routing::request_host(
+        &parts.headers,
+        &parts.uri,
+        site.general_security_settings.trust_forwarded_host,
+    )?;
+    site.repository_for_hostname(&host)
+        .filter(|repository| repository.get_type() == "docker")
+        .map(|repository| repository.id())
+}
+
+#[cfg(test)]
+mod tests {
+    use nr_core::user::permissions::RepositoryActions;
+
+    use super::parse_scope;
+
+    #[test]
+    fn a_pull_push_scope_maps_onto_repository_actions() {
+        let (image, actions) = parse_scope("repository:local/docker/alpine:pull,push").unwrap();
+        assert_eq!(image, "local/docker/alpine");
+        assert_eq!(
+            actions,
+            vec![RepositoryActions::Read, RepositoryActions::Write]
+        );
+    }
+
+    #[test]
+    fn a_pull_only_scope_grants_only_read() {
+        let (image, actions) = parse_scope("repository:alpine:pull").unwrap();
+        assert_eq!(image, "alpine");
+        assert_eq!(actions, vec![RepositoryActions::Read]);
+    }
+
+    /// The image name contains slashes but never a colon, so the last colon separates the actions.
+    #[test]
+    fn a_multi_segment_image_name_survives_parsing() {
+        let (image, _) = parse_scope("repository:a/b/c/d:pull").unwrap();
+        assert_eq!(image, "a/b/c/d");
+    }
+
+    #[test]
+    fn a_scope_that_names_nothing_useful_is_ignored() {
+        for scope in [
+            "",
+            "registry:catalog:*",
+            "repository:alpine",
+            "repository::pull",
+            "repository:alpine:nonsense",
+        ] {
+            assert!(parse_scope(scope).is_none(), "{scope:?}");
+        }
+    }
+}

--- a/nitro_repo/src/app/api/mod.rs
+++ b/nitro_repo/src/app/api/mod.rs
@@ -13,6 +13,7 @@ use strum::IntoEnumIterator;
 use tower_http::cors::CorsLayer;
 use tracing::{error, instrument};
 use utoipa::ToSchema;
+pub mod docker;
 pub mod npm;
 pub mod project;
 pub mod repository;
@@ -65,6 +66,9 @@ pub fn api_routes() -> axum::Router<NitroRepo> {
         .nest("/repository", repository::repository_routes())
         .nest("/project", project::project_routes())
         .nest("/npm", npm::npm_routes())
+        // The realm a Docker client is sent to by the `WWW-Authenticate` challenge. Under `/api`
+        // rather than under `/v2` so it can never collide with an image named `token`.
+        .nest("/docker", docker::docker_routes())
         .nest("/search", search::search_routes())
         .fallback(route_not_found)
         .layer(CorsLayer::very_permissive())

--- a/nitro_repo/src/app/authentication/header.rs
+++ b/nitro_repo/src/app/authentication/header.rs
@@ -14,15 +14,24 @@ impl TryFrom<String> for AuthorizationHeader {
     type Error = BadRequestErrors;
     #[instrument(skip(value), name = "AuthorizationHeader::try_from")]
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        let parts: Vec<&str> = value.split(' ').collect();
-
-        if parts.len() != 2 {
+        let value = value.trim();
+        if value.is_empty() {
             return Err(BadRequestErrors::InvalidAuthorizationHeader(
                 InvalidAuthorizationHeader::InvalidFormat,
             ));
         }
-        let scheme = parts[0];
-        let value = parts[1];
+        // Cargo sends the token on its own, with no scheme at all: `Authorization: <token>`. A
+        // value with no space is therefore a bearer token rather than a malformed header — auth
+        // tokens are 32 alphanumeric characters (see `auth_token::utils::generate_token`), so
+        // there is nothing for it to be confused with.
+        let Some((scheme, value)) = value.split_once(' ') else {
+            return Ok(AuthorizationHeader::Bearer {
+                token: value.to_owned(),
+            });
+        };
+        // The value cannot be empty here: the whole header was trimmed above, so anything after a
+        // space has at least one non-whitespace character in it.
+        let value = value.trim_start();
         match scheme {
             "Basic" => parse_basic_header(value),
             "Bearer" => Ok(AuthorizationHeader::Bearer {
@@ -48,14 +57,100 @@ fn parse_basic_header(header: &str) -> Result<AuthorizationHeader, BadRequestErr
         error!("Failed to convert bytes to string: {}", err);
         InvalidAuthorizationHeader::InvalidValue
     })?;
-    let parts: Vec<&str> = decoded.split(':').collect();
-    if parts.len() != 2 {
+    // `split_once`, not `split` with a length check: only the *first* colon separates the two
+    // fields, and everything after it is the password. A password containing a colon used to be
+    // rejected outright, which is exactly what happens when a token is pasted into the password
+    // field of `docker login`.
+    let Some((username, password)) = decoded.split_once(':') else {
         return Err(InvalidAuthorizationHeader::InvalidBasicValue.into());
-    }
-    let username = parts[0];
-    let password = parts[1];
+    };
     Ok(AuthorizationHeader::Basic {
         username: username.to_owned(),
         password: password.to_owned(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use nr_core::utils::base64_utils;
+
+    use super::AuthorizationHeader;
+
+    fn parse(value: &str) -> Result<AuthorizationHeader, super::BadRequestErrors> {
+        AuthorizationHeader::try_from(value.to_owned())
+    }
+
+    fn basic(username: &str, password: &str) -> String {
+        format!(
+            "Basic {}",
+            base64_utils::encode(format!("{username}:{password}"))
+        )
+    }
+
+    #[test]
+    fn a_value_with_no_scheme_is_a_bearer_token() {
+        // What `cargo` sends.
+        let AuthorizationHeader::Bearer { token } = parse("abc123").unwrap() else {
+            panic!("expected a bearer token");
+        };
+        assert_eq!(token, "abc123");
+    }
+
+    #[test]
+    fn the_known_schemes_are_recognised() {
+        assert!(matches!(
+            parse("Bearer abc123").unwrap(),
+            AuthorizationHeader::Bearer { token } if token == "abc123"
+        ));
+        assert!(matches!(
+            parse("Session abc123").unwrap(),
+            AuthorizationHeader::Session { session } if session == "abc123"
+        ));
+        assert!(matches!(
+            parse("Digest abc123").unwrap(),
+            AuthorizationHeader::Other { scheme, value } if scheme == "Digest" && value == "abc123"
+        ));
+    }
+
+    #[test]
+    fn a_basic_password_may_contain_a_colon() {
+        let AuthorizationHeader::Basic { username, password } =
+            parse(&basic("wyatt", "pass:with:colons")).unwrap()
+        else {
+            panic!("expected basic credentials");
+        };
+        assert_eq!(username, "wyatt");
+        assert_eq!(password, "pass:with:colons");
+    }
+
+    #[test]
+    fn a_basic_password_may_be_empty() {
+        let AuthorizationHeader::Basic { username, password } = parse(&basic("wyatt", "")).unwrap()
+        else {
+            panic!("expected basic credentials");
+        };
+        assert_eq!(username, "wyatt");
+        assert_eq!(password, "");
+    }
+
+    #[test]
+    fn a_basic_value_with_no_colon_is_refused() {
+        let value = format!("Basic {}", base64_utils::encode("no-colon-here"));
+        assert!(parse(&value).is_err());
+    }
+
+    #[test]
+    fn an_empty_header_is_refused() {
+        for raw in ["", "   ", "\t"] {
+            assert!(parse(raw).is_err(), "raw: {raw:?}");
+        }
+    }
+
+    #[test]
+    fn surrounding_whitespace_does_not_change_the_result() {
+        assert!(matches!(
+            parse("  Bearer   abc123  ").unwrap(),
+            AuthorizationHeader::Bearer { token } if token == "abc123"
+        ));
+    }
 }

--- a/nitro_repo/src/app/config/max_upload.rs
+++ b/nitro_repo/src/app/config/max_upload.rs
@@ -20,10 +20,33 @@ pub enum MaxUpload {
 impl From<MaxUpload> for axum::extract::DefaultBodyLimit {
     fn from(value: MaxUpload) -> Self {
         match value {
-            MaxUpload::Limit(size) => axum::extract::DefaultBodyLimit::max(size.size),
+            MaxUpload::Limit(size) => axum::extract::DefaultBodyLimit::max(as_bytes(size)),
             MaxUpload::Unlimited => axum::extract::DefaultBodyLimit::disable(),
         }
     }
+}
+
+/// A configured size in bytes.
+///
+/// This used to read `size.size`, which is the bare number with the unit thrown away — so the
+/// default `100MiB` configured a limit of one hundred *bytes*, and the server answered `413` to
+/// every request carrying a body, including creating a repository.
+///
+/// `ConfigSize::get_as_bytes()` is the obvious replacement and is also wrong: `tuxs-config-types`
+/// declares `Unit::Mebibytes = 1024 * 2`, so it multiplies by 2048 rather than 1048576. The
+/// multiplier is therefore computed here until that is fixed upstream. `Unit` is `#[non_exhaustive]`,
+/// so an unrecognised unit falls back to bytes — the conservative direction, since a too-small
+/// limit refuses uploads loudly while a too-large one silently accepts what the operator meant to
+/// cap.
+fn as_bytes(size: ConfigSize) -> usize {
+    let multiplier = if size.unit.is_mebibytes() {
+        1024 * 1024
+    } else if size.unit.is_kibibytes() {
+        1024
+    } else {
+        1
+    };
+    size.size.saturating_mul(multiplier)
 }
 impl Default for MaxUpload {
     fn default() -> Self {
@@ -184,6 +207,25 @@ mod tests {
             );
         }
     }
+    /// The unit has to survive into the limit. It did not: `100MiB` produced a 100-byte limit, and
+    /// the server refused every request with a body.
+    #[test]
+    fn the_limit_is_in_bytes_not_in_whatever_unit_was_written() {
+        let limit = |value: &str| match MaxUpload::from_str(value).unwrap() {
+            MaxUpload::Limit(size) => as_bytes(size),
+            MaxUpload::Unlimited => panic!("expected a limit"),
+        };
+
+        assert_eq!(limit("100MiB"), 100 * 1024 * 1024);
+        assert_eq!(limit("64KiB"), 64 * 1024);
+        assert_eq!(limit("512"), 512);
+
+        let MaxUpload::Limit(default) = MaxUpload::default() else {
+            panic!("expected a limit");
+        };
+        assert_eq!(as_bytes(default), 100 * 1024 * 1024);
+    }
+
     #[test]
     fn test_unlimited() {
         {

--- a/nitro_repo/src/app/host_routing.rs
+++ b/nitro_repo/src/app/host_routing.rs
@@ -112,16 +112,100 @@ async fn dispatch_by_host(
 /// its first value: a proxy chain appends, so the left-most is the one nearest the client, which is
 /// the one the operator's own proxy wrote.
 pub fn request_host(headers: &HeaderMap, uri: &Uri, trust_forwarded: bool) -> Option<String> {
+    raw_host(headers, uri, trust_forwarded).and_then(|raw| normalize_host(&raw))
+}
+
+/// The host *with* its port, for building a URL to hand back to the client.
+///
+/// [`request_host`] deliberately strips the port, because a hostname is registered without one and
+/// a lookup has to match whether or not the client wrote `:8443`. A URL is the opposite case: an
+/// authentication realm of `http://localhost/...` when the instance is on `:6742` points at nothing,
+/// and a Docker client that cannot reach the realm abandons the push without an error.
+pub fn request_authority(headers: &HeaderMap, uri: &Uri, trust_forwarded: bool) -> Option<String> {
+    let raw = raw_host(headers, uri, trust_forwarded)?;
+    // Validated through `normalize_host` so anything that is not a bare host is rejected here too,
+    // but the value returned keeps the port the client actually addressed.
+    normalize_host(&raw)?;
+    Some(raw.trim().to_ascii_lowercase())
+}
+
+/// Picks which of the three sources names the host, without normalising it.
+fn raw_host(headers: &HeaderMap, uri: &Uri, trust_forwarded: bool) -> Option<String> {
     if trust_forwarded
         && let Some(forwarded) = headers.get_str_ignore_empty(&X_FORWARDED_HOST)
-        && let Some(host) = forwarded.split(',').next().and_then(normalize_host)
+        && let Some(first) = forwarded.split(',').next()
+        && normalize_host(first).is_some()
     {
-        return Some(host);
+        return Some(first.to_owned());
     }
-    headers
-        .get_str_ignore_empty(&http::header::HOST)
-        .and_then(normalize_host)
-        .or_else(|| uri.host().and_then(normalize_host))
+    if let Some(host) = headers.get_str_ignore_empty(&http::header::HOST)
+        && normalize_host(host).is_some()
+    {
+        return Some(host.to_owned());
+    }
+    // HTTP/2 has no `Host` header; hyper puts `:authority` in the URI instead. `authority()` rather
+    // than `host()` so the port survives.
+    uri.authority()
+        .map(|authority| authority.as_str().to_owned())
+        .filter(|authority| normalize_host(authority).is_some())
+}
+
+/// The scheme to build absolute URLs with.
+///
+/// The server may be terminating plain HTTP behind a TLS proxy, in which case the request itself
+/// says `http` while the client is on `https`. `X-Forwarded-Proto` is only believed when the
+/// operator has said their proxy sets it — the same switch that guards `X-Forwarded-Host` — and
+/// otherwise the configured `app_url`'s scheme is the operator's own statement of how the instance
+/// is reached.
+pub fn request_scheme(site: &NitroRepo, headers: &HeaderMap, uri: &Uri) -> String {
+    static X_FORWARDED_PROTO: HeaderName = HeaderName::from_static("x-forwarded-proto");
+
+    if site.general_security_settings.trust_forwarded_host
+        && let Some(forwarded) = headers.get_str_ignore_empty(&X_FORWARDED_PROTO)
+        && let Some(first) = forwarded.split(',').next()
+        && matches!(first.trim(), "http" | "https")
+    {
+        return first.trim().to_owned();
+    }
+    if let Some(scheme) = uri.scheme_str() {
+        return scheme.to_owned();
+    }
+    let app_url = {
+        let instance = site.instance.lock();
+        instance.app_url.clone()
+    };
+    if app_url.starts_with("http://") {
+        "http".to_owned()
+    } else {
+        "https".to_owned()
+    }
+}
+
+/// `{scheme}://{host}` for the request as the client addressed it.
+///
+/// Built from the request rather than from `app_url` because a repository reachable on a custom
+/// domain may not be reachable at `app_url` from wherever the client is running — a URL handed back
+/// in a `Location` or an authentication realm has to point somewhere the caller can actually go.
+/// Falls back to `app_url` when the request carries no usable host, and to `None` when there is no
+/// `app_url` either.
+pub fn request_origin(site: &NitroRepo, headers: &HeaderMap, uri: &Uri) -> Option<String> {
+    match request_authority(
+        headers,
+        uri,
+        site.general_security_settings.trust_forwarded_host,
+    ) {
+        Some(authority) => {
+            let scheme = request_scheme(site, headers, uri);
+            Some(format!("{scheme}://{authority}"))
+        }
+        None => {
+            let app_url = {
+                let instance = site.instance.lock();
+                instance.app_url.trim_end_matches('/').to_owned()
+            };
+            (!app_url.is_empty()).then_some(app_url)
+        }
+    }
 }
 
 /// Lowercases a host and strips the port and any trailing root dot.
@@ -173,7 +257,7 @@ fn is_port(value: &str) -> bool {
 mod tests {
     use http::{HeaderMap, HeaderName, HeaderValue, Uri};
 
-    use super::{X_FORWARDED_HOST, normalize_host, request_host};
+    use super::{X_FORWARDED_HOST, normalize_host, request_authority, request_host};
 
     fn headers(pairs: &[(&HeaderName, &str)]) -> HeaderMap {
         let mut headers = HeaderMap::new();
@@ -262,6 +346,49 @@ mod tests {
         assert_eq!(
             request_host(&HeaderMap::new(), &uri, false).as_deref(),
             Some("maven.example.com")
+        );
+    }
+
+    /// A lookup ignores the port; a URL cannot. A realm of `http://localhost/...` for an instance
+    /// on `:6742` is unreachable, and a Docker client that cannot reach the realm abandons the push
+    /// with no error at all.
+    #[test]
+    fn the_authority_keeps_the_port_that_the_host_drops() {
+        let map = headers(&[(&http::header::HOST, "localhost:6742")]);
+        let uri = Uri::from_static("/v2/");
+
+        assert_eq!(
+            request_host(&map, &uri, false).as_deref(),
+            Some("localhost")
+        );
+        assert_eq!(
+            request_authority(&map, &uri, false).as_deref(),
+            Some("localhost:6742")
+        );
+    }
+
+    #[test]
+    fn the_authority_is_normalised_and_validated_like_the_host() {
+        let map = headers(&[(&http::header::HOST, "  Docker.Example.COM:8443 ")]);
+        let uri = Uri::from_static("/v2/");
+        assert_eq!(
+            request_authority(&map, &uri, false).as_deref(),
+            Some("docker.example.com:8443")
+        );
+
+        // Anything that is not a bare host is refused here too.
+        for bad in ["host:notaport", "a/b", "user@example.com"] {
+            let map = headers(&[(&http::header::HOST, bad)]);
+            assert_eq!(request_authority(&map, &uri, false), None, "raw: {bad:?}");
+        }
+    }
+
+    #[test]
+    fn the_authority_falls_back_to_the_uri_for_http2() {
+        let uri = Uri::from_static("https://docker.example.com:8443/v2/");
+        assert_eq!(
+            request_authority(&HeaderMap::new(), &uri, false).as_deref(),
+            Some("docker.example.com:8443")
         );
     }
 

--- a/nitro_repo/src/app/mod.rs
+++ b/nitro_repo/src/app/mod.rs
@@ -46,6 +46,8 @@ pub mod open_api;
 use crate::{
     repository::{
         DynRepository, RepositoryType, StagingConfig,
+        cargo::{CargoRegistryConfigType, CargoRegistryType},
+        docker::{DockerRegistryConfigType, DockerRegistryType, uploads::BlobUploadManager},
         maven::{MavenPushRulesConfigType, MavenRepositoryConfigType, MavenRepositoryType},
         npm::{NPMRegistryConfigType, NpmRegistryType, login::web_login::NpmWebLoginManager},
         repo_tracing::RepositoryMetricsMeter,
@@ -136,6 +138,9 @@ pub struct NitroRepoInner {
     /// npm browser-login sessions awaiting approval. In memory on purpose — see
     /// [`crate::repository::npm::login::web_login`].
     pub npm_web_logins: NpmWebLoginManager,
+    /// In-progress Docker blob uploads. Buffered to the staging directory and tracked in memory,
+    /// for the reasons set out in [`crate::repository::docker::uploads`].
+    pub docker_uploads: BlobUploadManager,
 }
 macro_rules! take_service {
     ($(
@@ -275,6 +280,7 @@ impl NitroRepo {
         } else {
             std::env::current_dir()?.join("storages")
         };
+        let docker_uploads = BlobUploadManager::new(&staging_config.staging_dir);
         let nitro_repo = NitroRepoInner {
             instance: Mutex::new(instance),
             storages: RwLock::new(HashMap::new()),
@@ -288,6 +294,7 @@ impl NitroRepo {
             frontend: frontend::HostedFrontend::new(site.frontend_path)?,
             suggested_local_storage_path,
             npm_web_logins: NpmWebLoginManager::default(),
+            docker_uploads,
         };
 
         let session_manager = Arc::new(SessionManager::new(session_manager, mode)?);
@@ -575,8 +582,15 @@ pub static REPOSITORY_CONFIG_TYPES: &[&dyn RepositoryConfigType] = &[
     &MavenRepositoryConfigType,
     &MavenPushRulesConfigType,
     &NPMRegistryConfigType,
+    &CargoRegistryConfigType,
+    &DockerRegistryConfigType,
 ];
-pub static REPOSITORY_TYPES: &[&dyn RepositoryType] = &[&MavenRepositoryType, &NpmRegistryType];
+pub static REPOSITORY_TYPES: &[&dyn RepositoryType] = &[
+    &MavenRepositoryType,
+    &NpmRegistryType,
+    &CargoRegistryType,
+    &DockerRegistryType,
+];
 
 #[cfg(test)]
 mod registry_tests {

--- a/nitro_repo/src/app/open_api.rs
+++ b/nitro_repo/src/app/open_api.rs
@@ -21,8 +21,8 @@ use utoipa::{
 use super::{
     api,
     api::{
-        repository::RepositoryAPI, storage::StorageAPI, user::UserAPI,
-        user_management::UserManagementAPI,
+        docker::DockerAPI, npm::NpmAPI, repository::RepositoryAPI, storage::StorageAPI,
+        user::UserAPI, user_management::UserManagementAPI,
     },
 };
 use crate::app::{api::project::ProjectRoutes, badge::BadgeRoutes};
@@ -36,6 +36,11 @@ use crate::app::{api::project::ProjectRoutes, badge::BadgeRoutes};
         (path = "/api/repository", api = RepositoryAPI, tags=["repository"]),
         (path="/badge", api = BadgeRoutes),
         (path="/api/project", api = ProjectRoutes, tags= ["project", "repository"]),
+        // `NpmAPI` was declared and never nested, so npm's browser-login endpoints were missing
+        // from the served document — and from the generated frontend types, which is why the login
+        // page calls them through a hand-written interface.
+        (path="/api/npm", api = NpmAPI, tags=["npm", "repository"]),
+        (path="/api/docker", api = DockerAPI, tags=["docker", "repository"]),
     ),
     paths(
         api::info,

--- a/nitro_repo/src/app/web.rs
+++ b/nitro_repo/src/app/web.rs
@@ -103,6 +103,11 @@ pub fn build_app(site: NitroRepo, open_api_routes: bool, body_limit: DefaultBody
         .nest("/repositories", crate::repository::repository_router())
         .nest("/api", api::api_routes())
         .nest("/badge", super::badge::badge_routes())
+        // Docker cannot be given a URL prefix — `docker pull host/x/y` always asks for
+        // `/v2/x/y/...` at the host root. Mounted after the three nests above so none of them can
+        // be shadowed, and before the fallback so a `/v2` request is not mistaken for a frontend
+        // route. See `crate::repository::docker::routing`.
+        .merge(crate::repository::docker::v2_router())
         // Not `frontend_request` directly: a request whose `Host` is registered to a repository is
         // served by that repository, and everything else still gets the single-page app.
         .fallback(super::host_routing::host_or_frontend)

--- a/nitro_repo/src/repository/cargo/configs.rs
+++ b/nitro_repo/src/repository/cargo/configs.rs
@@ -1,0 +1,50 @@
+use nr_core::repository::config::{ConfigDescription, RepositoryConfigError, RepositoryConfigType};
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Which kind of Cargo registry this is.
+///
+/// Only `Hosted` exists today. It is still a tagged enum rather than a unit struct so a `Proxy`
+/// variant carrying an upstream can be added the way Maven's was, without a migration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config")]
+pub enum CargoRegistryConfig {
+    Hosted,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CargoRegistryConfigType;
+impl RepositoryConfigType for CargoRegistryConfigType {
+    fn get_type(&self) -> &'static str {
+        "cargo"
+    }
+
+    fn get_type_static() -> &'static str
+    where
+        Self: Sized,
+    {
+        "cargo"
+    }
+    fn schema(&self) -> Option<schemars::Schema> {
+        Some(schema_for!(CargoRegistryConfig))
+    }
+    fn validate_config(&self, config: Value) -> Result<(), RepositoryConfigError> {
+        let _: CargoRegistryConfig = serde_json::from_value(config)?;
+        Ok(())
+    }
+    fn validate_change(&self, _old: Value, _new: Value) -> Result<(), RepositoryConfigError> {
+        Ok(())
+    }
+    fn default(&self) -> Result<Value, RepositoryConfigError> {
+        Ok(serde_json::to_value(CargoRegistryConfig::Hosted)?)
+    }
+    fn get_description(&self) -> ConfigDescription {
+        ConfigDescription {
+            name: "Cargo Registry Config",
+            description: Some("Handles the type of Cargo Registry"),
+            documentation_link: None,
+            ..Default::default()
+        }
+    }
+}

--- a/nitro_repo/src/repository/cargo/hosted.rs
+++ b/nitro_repo/src/repository/cargo/hosted.rs
@@ -1,0 +1,782 @@
+use std::sync::{
+    Arc,
+    atomic::{self, AtomicBool},
+};
+
+use derive_more::derive::Deref;
+use http::{
+    StatusCode,
+    header::{CONTENT_TYPE, ETAG, IF_NONE_MATCH},
+    request::Parts,
+};
+use nr_core::{
+    database::entities::{
+        project::{
+            DBProject, NewProject, NewProjectMember, ProjectDBType,
+            update::UpdateProject,
+            versions::{DBProjectVersion, NewVersion, UpdateProjectVersion},
+        },
+        repository::DBRepository,
+        user::UserSafeData,
+    },
+    repository::{
+        Visibility,
+        config::{
+            RepositoryConfigType, project::ProjectConfigType, repository_page::RepositoryPageType,
+        },
+        project::{ReleaseType, VersionData},
+    },
+    storage::StoragePath,
+    user::permissions::RepositoryActions,
+};
+use nr_storage::{DynStorage, FileContent, Storage};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use tracing::{debug, info, instrument, warn};
+
+use super::{
+    CargoRegistryConfigType, CargoRegistryError,
+    types::{
+        CargoPath, IndexEntry, is_valid_crate_name, publish::PublishMetadata, split_publish_body,
+    },
+    utils::{crate_file_path, registry_base_url, to_hex},
+};
+use crate::{
+    app::NitroRepo,
+    repository::{
+        RepoResponse, Repository, RepositoryAuthentication, RepositoryFactoryError,
+        RepositoryRequest, utils::RepositoryExt,
+    },
+    utils::ResponseBuilder,
+};
+
+/// The default page size for `cargo search`, and the cap on what a caller can ask for. Without an
+/// upper bound one request could ask the database for every crate in the registry.
+const DEFAULT_SEARCH_SIZE: i64 = 10;
+const MAX_SEARCH_SIZE: i64 = 100;
+
+#[derive(derive_more::Debug)]
+pub struct CargoRegistryInner {
+    #[debug(skip)]
+    pub site: NitroRepo,
+    pub storage: DynStorage,
+    pub id: uuid::Uuid,
+    pub name: String,
+    pub visibility: RwLock<Visibility>,
+    pub active: AtomicBool,
+}
+
+#[derive(Debug, Clone, Deref)]
+pub struct CargoHostedRegistry(Arc<CargoRegistryInner>);
+
+impl CargoHostedRegistry {
+    pub async fn load(
+        site: NitroRepo,
+        storage: DynStorage,
+        repository: DBRepository,
+    ) -> Result<Self, RepositoryFactoryError> {
+        Ok(Self(Arc::new(CargoRegistryInner {
+            site,
+            storage,
+            id: repository.id,
+            name: repository.name.to_string(),
+            visibility: RwLock::new(repository.visibility),
+            active: AtomicBool::new(repository.active),
+        })))
+    }
+
+    /// Refuses a read the caller is not allowed to make.
+    ///
+    /// Unlike npm, cargo is not prompted into sending credentials by a `WWW-Authenticate` challenge
+    /// — it decides up front, from `auth-required` in `config.json`. A private registry therefore
+    /// answers a credential-less request with a plain 401 and relies on `config.json` having told
+    /// the client to send a token in the first place.
+    async fn check_read(
+        &self,
+        authentication: &RepositoryAuthentication,
+    ) -> Result<Option<RepoResponse>, CargoRegistryError> {
+        if self.visibility().is_public() {
+            return Ok(None);
+        }
+        if !authentication
+            .can_access_repository(RepositoryActions::Read, self.id, self.site.as_ref())
+            .await?
+        {
+            return Ok(Some(RepoResponse::unauthorized()));
+        }
+        Ok(None)
+    }
+
+    /// Resolves the caller, or `None` if they may not write here.
+    async fn writer(
+        &self,
+        authentication: &RepositoryAuthentication,
+    ) -> Result<Option<UserSafeData>, CargoRegistryError> {
+        Ok(authentication
+            .get_user_if_has_action(RepositoryActions::Write, self.id, self.site.as_ref())
+            .await?
+            .cloned())
+    }
+
+    async fn project_or_not_found(&self, name: &str) -> Result<DBProject, CargoRegistryError> {
+        self.get_project_from_key(name)
+            .await?
+            .ok_or_else(|| CargoRegistryError::NotFound(format!("crate `{name}` not found")))
+    }
+
+    async fn version_or_not_found(
+        &self,
+        project: &DBProject,
+        version: &str,
+    ) -> Result<DBProjectVersion, CargoRegistryError> {
+        self.get_project_version(project.id, version)
+            .await?
+            .ok_or_else(|| {
+                CargoRegistryError::NotFound(format!(
+                    "crate `{}` has no version `{version}`",
+                    project.key
+                ))
+            })
+    }
+
+    /// `index/config.json`.
+    ///
+    /// Generated per request rather than stored, because the right answer depends on how the client
+    /// reached the registry — a custom hostname and the `/repositories/...` path are both valid and
+    /// must each describe themselves.
+    fn config_json(&self, parts: &Parts) -> Result<RepoResponse, CargoRegistryError> {
+        let base = registry_base_url(self, parts)?;
+        // `dl` has no template markers, so cargo appends `/{crate}/{version}/download` itself.
+        let config = serde_json::json!({
+            "dl": format!("{base}/api/v1/crates"),
+            "api": base,
+            // Cargo only sends a token when it has been told the registry needs one. Without this
+            // a private registry answers every request with a 401 that cargo reports as a hard
+            // failure rather than retrying with credentials.
+            "auth-required": !self.visibility().is_public(),
+        });
+        Ok(ResponseBuilder::ok().json(&config).into())
+    }
+
+    /// The stored index record for one version, with `yanked` taken from its current value.
+    fn index_entry_for(
+        &self,
+        project: &DBProject,
+        version: &DBProjectVersion,
+    ) -> Result<IndexEntry, CargoRegistryError> {
+        let Some(extra) = version.extra.0.extra.clone() else {
+            return Err(CargoRegistryError::CorruptIndexRecord {
+                name: project.key.clone(),
+                version: version.version.clone(),
+            });
+        };
+        let stored: StoredVersion = serde_json::from_value(extra).map_err(|error| {
+            warn!(?error, version = %version.version, "Stored cargo index record will not parse");
+            CargoRegistryError::CorruptIndexRecord {
+                name: project.key.clone(),
+                version: version.version.clone(),
+            }
+        })?;
+        let mut entry = stored.index;
+        entry.yanked = stored.yanked;
+        Ok(entry)
+    }
+
+    /// `index/{prefix}/{name}` — the crate's versions, one JSON object per line.
+    ///
+    /// Cargo revalidates the index constantly, so this answers conditional requests. The body is
+    /// generated from the database on every call, which means there is no stored `Last-Modified` to
+    /// compare against; an `ETag` over the rendered bytes is the one validator that is always
+    /// correct here.
+    #[instrument(skip(self, parts))]
+    async fn index_entry(
+        &self,
+        name: &str,
+        parts: &Parts,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        let project = self.project_or_not_found(name).await?;
+        let versions = DBProjectVersion::get_all_versions(project.id, self.site.as_ref()).await?;
+
+        // Oldest first. Cargo does not require an order, but a stable one keeps the ETag from
+        // changing when nothing has, and publication order is the only ordering this layer can
+        // know is right (see `get_all_versions`).
+        let mut body = String::new();
+        for version in versions.iter().rev() {
+            match self.index_entry_for(&project, version) {
+                Ok(entry) => {
+                    body.push_str(&serde_json::to_string(&entry)?);
+                    body.push('\n');
+                }
+                Err(error) => {
+                    // One unreadable row must not take the whole crate offline; every other version
+                    // of it is still installable.
+                    warn!(?error, "Skipping a version with an unreadable index record");
+                }
+            }
+        }
+        if body.is_empty() {
+            return Err(CargoRegistryError::NotFound(format!(
+                "crate `{name}` has no published versions"
+            )));
+        }
+
+        let etag = format!("\"{}\"", to_hex(&Sha256::digest(body.as_bytes())));
+        if parts
+            .headers
+            .get(IF_NONE_MATCH)
+            .and_then(|value| value.to_str().ok())
+            .is_some_and(|value| value.split(',').any(|tag| tag.trim() == etag))
+        {
+            return Ok(RepoResponse::Other(
+                ResponseBuilder::default()
+                    .status(StatusCode::NOT_MODIFIED)
+                    .header(ETAG, etag)
+                    .empty(),
+            ));
+        }
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::ok()
+                .header(ETAG, etag)
+                .header(CONTENT_TYPE, "text/plain; charset=utf-8")
+                .body(body),
+        ))
+    }
+
+    /// `GET /api/v1/crates/{name}/{version}/download`.
+    ///
+    /// A yanked version is still served. Yanking removes a version from resolution, not from
+    /// existence — a lockfile that already pins it must keep working, which is the whole point of
+    /// yank being distinct from delete.
+    async fn download(
+        &self,
+        name: &str,
+        version: &str,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        let project = self.project_or_not_found(name).await?;
+        let version_row = self.version_or_not_found(&project, version).await?;
+        let path = crate_file_path(&project.key, &version_row.version)?;
+        let Some(file) = self.storage.open_file(self.id, &path).await? else {
+            return Err(CargoRegistryError::NotFound(format!(
+                "the .crate file for `{name}@{version}` is missing from storage"
+            )));
+        };
+        Ok(RepoResponse::FileResponse(Box::new(file)))
+    }
+
+    #[instrument(skip(self, request))]
+    async fn publish(
+        &self,
+        request: RepositoryRequest,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        let Some(user) = self.writer(&request.authentication).await? else {
+            info!("No acceptable user authentication provided");
+            return Ok(RepoResponse::unauthorized());
+        };
+
+        let body = request.body.body_as_bytes().await?;
+        let (metadata, crate_file) = split_publish_body(body)?;
+
+        if !is_valid_crate_name(&metadata.name) {
+            return Err(CargoRegistryError::InvalidCrateName(metadata.name));
+        }
+        if !is_plausible_semver(&metadata.vers) {
+            return Err(CargoRegistryError::InvalidVersion(metadata.vers));
+        }
+
+        let project = self.get_or_create_project(&metadata, user.id).await?;
+
+        // Refused before anything is written, so a rejected re-publish cannot have replaced the
+        // stored .crate of the version it collided with.
+        if self
+            .get_project_version(project.id, &metadata.vers)
+            .await?
+            .is_some()
+        {
+            return Err(CargoRegistryError::VersionAlreadyExists {
+                name: metadata.name,
+                version: metadata.vers,
+            });
+        }
+
+        // Cargo verifies every download against `cksum`, so it is computed from the bytes actually
+        // stored rather than taken from anything the client said.
+        let cksum = to_hex(&Sha256::digest(&crate_file));
+        let path = crate_file_path(&project.key, &metadata.vers)?;
+
+        let version = metadata.vers.clone();
+        let stored = StoredVersion {
+            index: IndexEntry::from_publish(metadata.clone(), cksum),
+            yanked: false,
+            publish: metadata.clone(),
+        };
+
+        NewVersion {
+            project_id: project.id,
+            version: version.clone(),
+            release_type: ReleaseType::release_type_from_version(&version),
+            version_path: path.to_string(),
+            publisher: Some(user.id),
+            version_page: metadata.readme.clone(),
+            extra: VersionData {
+                documentation_url: metadata.documentation.clone(),
+                website: metadata.homepage.clone(),
+                description: metadata.description.clone(),
+                extra: Some(serde_json::to_value(&stored)?),
+                ..Default::default()
+            },
+        }
+        .insert(self.site.as_ref())
+        .await?;
+
+        self.storage
+            .save_file(self.id, FileContent::Bytes(crate_file), &path)
+            .await?;
+
+        debug!(crate_name = %project.key, %version, "Published a crate");
+        Ok(ResponseBuilder::ok()
+            .json(&serde_json::json!({ "warnings": { "invalid_categories": [], "invalid_badges": [], "other": [] } }))
+            .into())
+    }
+
+    async fn get_or_create_project(
+        &self,
+        metadata: &PublishMetadata,
+        publisher: i32,
+    ) -> Result<DBProject, CargoRegistryError> {
+        if let Some(project) =
+            DBProject::find_by_project_key(&metadata.name, self.id, self.site.as_ref()).await?
+        {
+            let description = metadata.description.as_deref();
+            let update = UpdateProject {
+                description: (description != project.description.as_deref())
+                    .then(|| description.map(str::to_owned)),
+                ..Default::default()
+            };
+            if !update.is_empty() {
+                update.update(project.id, self.site.as_ref()).await?;
+            }
+            return Ok(project);
+        }
+
+        let mut storage_path = StoragePath::parse("crates")?;
+        storage_path.push_mut(&metadata.name);
+        let project = NewProject {
+            scope: None,
+            project_key: metadata.name.clone(),
+            name: metadata.name.clone(),
+            description: metadata.description.clone(),
+            repository: self.id,
+            storage_path: storage_path.to_string(),
+        }
+        .insert(self.site.as_ref())
+        .await?;
+
+        // Whoever publishes a crate first owns it, which is what `cargo owner` then manages.
+        NewProjectMember::new_owner(publisher, project.id)
+            .insert_no_return(self.site.as_ref())
+            .await?;
+        info!(?project, "Created a new crate");
+        Ok(project)
+    }
+
+    /// `DELETE .../yank` and `PUT .../unyank`.
+    #[instrument(skip(self, authentication))]
+    async fn set_yanked(
+        &self,
+        authentication: &RepositoryAuthentication,
+        name: &str,
+        version: &str,
+        yanked: bool,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        if self.writer(authentication).await?.is_none() {
+            return Ok(RepoResponse::unauthorized());
+        }
+        let project = self.project_or_not_found(name).await?;
+        let mut version_row = self.version_or_not_found(&project, version).await?;
+
+        let Some(extra) = version_row.extra.0.extra.take() else {
+            return Err(CargoRegistryError::CorruptIndexRecord {
+                name: project.key.clone(),
+                version: version.to_owned(),
+            });
+        };
+        let mut stored: StoredVersion = serde_json::from_value(extra)?;
+        stored.yanked = yanked;
+        version_row.extra.0.extra = Some(serde_json::to_value(&stored)?);
+
+        UpdateProjectVersion {
+            extra: Some(version_row.extra.0.clone()),
+            ..Default::default()
+        }
+        .update(version_row.id, self.site.as_ref())
+        .await?;
+
+        Ok(ResponseBuilder::ok()
+            .json(&serde_json::json!({ "ok": true }))
+            .into())
+    }
+
+    /// `GET /api/v1/crates/{name}/owners`.
+    async fn list_owners(&self, name: &str) -> Result<RepoResponse, CargoRegistryError> {
+        let project = self.project_or_not_found(name).await?;
+        let owners: Vec<OwnerResponse> = sqlx::query_as::<_, (i32, String, Option<String>)>(
+            r#"SELECT users.id, users.username, users.name
+               FROM project_members
+               JOIN users ON users.id = project_members.user_id
+               WHERE project_members.project_id = $1
+               ORDER BY users.username"#,
+        )
+        .bind(project.id)
+        .fetch_all(self.site.as_ref())
+        .await?
+        .into_iter()
+        .map(|(id, login, name)| OwnerResponse { id, login, name })
+        .collect();
+
+        Ok(ResponseBuilder::ok()
+            .json(&serde_json::json!({ "users": owners }))
+            .into())
+    }
+
+    /// `PUT` and `DELETE` on `/api/v1/crates/{name}/owners`.
+    ///
+    /// Managing owners is a stronger right than publishing: it is what lets someone hand the crate
+    /// to a third party. Repository `Write` is not enough — the caller must already manage this
+    /// crate, or be able to administer the repository.
+    #[instrument(skip(self, request))]
+    async fn modify_owners(
+        &self,
+        request: RepositoryRequest,
+        name: &str,
+        adding: bool,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        let Some(user) = self.writer(&request.authentication).await? else {
+            return Ok(RepoResponse::unauthorized());
+        };
+        let project = self.project_or_not_found(name).await?;
+
+        let manages_crate: Option<bool> = sqlx::query_scalar(
+            "SELECT can_manage FROM project_members WHERE project_id = $1 AND user_id = $2",
+        )
+        .bind(project.id)
+        .bind(user.id)
+        .fetch_optional(self.site.as_ref())
+        .await?;
+        let can_manage = manages_crate.unwrap_or(false)
+            || request
+                .authentication
+                .can_access_repository(RepositoryActions::Edit, self.id, self.site.as_ref())
+                .await?;
+        if !can_manage {
+            return Ok(RepoResponse::forbidden());
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct OwnersRequest {
+            #[serde(default)]
+            users: Vec<String>,
+        }
+        let body = request.body.body_as_string().await?;
+        let incoming: OwnersRequest = serde_json::from_str(&body)?;
+
+        let mut changed = Vec::new();
+        for login in incoming.users {
+            let Some(target): Option<i32> =
+                sqlx::query_scalar("SELECT id FROM users WHERE username = $1")
+                    .bind(&login)
+                    .fetch_optional(self.site.as_ref())
+                    .await?
+            else {
+                return Err(CargoRegistryError::NotFound(format!(
+                    "there is no user named `{login}`"
+                )));
+            };
+            if adding {
+                sqlx::query(
+                    r#"INSERT INTO project_members (user_id, project_id, can_write, can_manage)
+                       VALUES ($1, $2, TRUE, TRUE)
+                       ON CONFLICT (project_id, user_id)
+                       DO UPDATE SET can_write = TRUE, can_manage = TRUE"#,
+                )
+                .bind(target)
+                .bind(project.id)
+                .execute(self.site.as_ref())
+                .await?;
+            } else {
+                sqlx::query("DELETE FROM project_members WHERE project_id = $1 AND user_id = $2")
+                    .bind(project.id)
+                    .bind(target)
+                    .execute(self.site.as_ref())
+                    .await?;
+            }
+            changed.push(login);
+        }
+
+        let verb = if adding { "added to" } else { "removed from" };
+        Ok(ResponseBuilder::ok()
+            .json(&serde_json::json!({
+                "ok": true,
+                "msg": format!("{} {verb} owners of {}", changed.join(", "), project.key),
+            }))
+            .into())
+    }
+
+    /// `GET /api/v1/crates?q=...` — what `cargo search` calls.
+    #[instrument(skip(self))]
+    async fn search(&self, query: Option<&str>) -> Result<RepoResponse, CargoRegistryError> {
+        let query: SearchQuery = query
+            .and_then(|query| serde_urlencoded::from_str(query).ok())
+            .unwrap_or_default();
+        let per_page = query
+            .per_page
+            .unwrap_or(DEFAULT_SEARCH_SIZE)
+            .clamp(1, MAX_SEARCH_SIZE);
+
+        // `projects.key` carries the `ignoreCase` collation, which Postgres refuses to run `ILIKE`
+        // against ("nondeterministic collations are not supported for ILIKE") — every search
+        // returned a 500. `COLLATE "C"` gives the comparison a deterministic collation to work in;
+        // no case-sensitivity is lost, because `ILIKE` does that part itself.
+        //
+        // `%`, `_` and `\` in the search text would otherwise act as LIKE syntax.
+        let escaped = query
+            .q
+            .replace('\\', r"\\")
+            .replace('%', r"\%")
+            .replace('_', r"\_");
+        let pattern = format!("%{escaped}%");
+
+        let total: i64 = sqlx::query_scalar(
+            r#"SELECT COUNT(*) FROM projects
+               WHERE repository_id = $1
+                 AND ((key COLLATE "C") ILIKE $2 OR COALESCE(description, '') ILIKE $2)"#,
+        )
+        .bind(self.id)
+        .bind(&pattern)
+        .fetch_one(self.site.as_ref())
+        .await?;
+
+        let projects: Vec<DBProject> = sqlx::query_as(
+            r#"SELECT * FROM projects
+               WHERE repository_id = $1
+                 AND ((key COLLATE "C") ILIKE $2 OR COALESCE(description, '') ILIKE $2)
+               ORDER BY updated_at DESC
+               LIMIT $3"#,
+        )
+        .bind(self.id)
+        .bind(&pattern)
+        .bind(per_page)
+        .fetch_all(self.site.as_ref())
+        .await?;
+
+        let mut crates = Vec::with_capacity(projects.len());
+        for project in projects {
+            let versions =
+                DBProjectVersion::get_all_versions(project.id, self.site.as_ref()).await?;
+            let Some(newest) = versions.first() else {
+                continue;
+            };
+            crates.push(serde_json::json!({
+                "name": project.key,
+                "max_version": newest.version,
+                "description": project.description.clone().unwrap_or_default(),
+            }));
+        }
+
+        Ok(ResponseBuilder::ok()
+            .json(&serde_json::json!({
+                "crates": crates,
+                "meta": { "total": total },
+            }))
+            .into())
+    }
+}
+
+/// What a `cargo` version carries in `project_versions.extra`.
+///
+/// The index record and the publish metadata are both kept: the index is what has to be served back
+/// byte-for-byte on every resolve, and the publish metadata holds the fields the web UI wants
+/// (categories, keywords, licence) that the index has no room for.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredVersion {
+    index: IndexEntry,
+    #[serde(default)]
+    yanked: bool,
+    publish: PublishMetadata,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SearchQuery {
+    #[serde(default)]
+    q: String,
+    per_page: Option<i64>,
+}
+
+#[derive(Debug, Serialize)]
+struct OwnerResponse {
+    id: i32,
+    login: String,
+    name: Option<String>,
+}
+
+/// A cheap sanity check on the version string.
+///
+/// Not a full semver parse — cargo has already refused anything it cannot parse before it gets
+/// here, and this registry has no reason to hold a second, subtly different opinion. What it does
+/// catch is a version that cannot be used as a path component or would collide with the `.crate`
+/// filename convention.
+fn is_plausible_semver(version: &str) -> bool {
+    !version.is_empty()
+        && version.len() <= 64
+        && version.starts_with(|c: char| c.is_ascii_digit())
+        && version
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '+' | '_'))
+}
+
+impl RepositoryExt for CargoHostedRegistry {}
+
+impl Repository for CargoHostedRegistry {
+    type Error = CargoRegistryError;
+
+    fn get_storage(&self) -> DynStorage {
+        self.0.storage.clone()
+    }
+
+    fn site(&self) -> NitroRepo {
+        self.0.site.clone()
+    }
+
+    fn get_type(&self) -> &'static str {
+        "cargo"
+    }
+
+    fn full_type(&self) -> &'static str {
+        "cargo/hosted"
+    }
+
+    fn config_types(&self) -> Vec<&str> {
+        vec![
+            CargoRegistryConfigType::get_type_static(),
+            RepositoryPageType::get_type_static(),
+            ProjectConfigType::get_type_static(),
+        ]
+    }
+
+    fn name(&self) -> String {
+        self.0.name.clone()
+    }
+
+    fn id(&self) -> uuid::Uuid {
+        self.0.id
+    }
+
+    fn visibility(&self) -> Visibility {
+        *self.0.visibility.read()
+    }
+
+    fn is_active(&self) -> bool {
+        self.0.active.load(atomic::Ordering::Relaxed)
+    }
+
+    #[instrument(fields(repository_type = "cargo/hosted"))]
+    async fn reload(&self) -> Result<(), RepositoryFactoryError> {
+        let Some(repository) = DBRepository::get_by_id(self.0.id, self.site.as_ref()).await? else {
+            warn!("Repository no longer exists");
+            self.0.active.store(false, atomic::Ordering::Relaxed);
+            return Ok(());
+        };
+        self.0
+            .active
+            .store(repository.active, atomic::Ordering::Relaxed);
+        *self.0.visibility.write() = repository.visibility;
+        Ok(())
+    }
+
+    async fn handle_get(
+        &self,
+        request: RepositoryRequest,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        // `config.json` is answered before the read check: cargo has to be able to read it to learn
+        // that this registry wants a token at all.
+        let route = CargoPath::try_from(request.path.clone())?;
+        if matches!(route, CargoPath::Config) {
+            return self.config_json(&request.parts);
+        }
+        if let Some(denied) = self.check_read(&request.authentication).await? {
+            return Ok(denied);
+        }
+
+        match route {
+            CargoPath::Config => unreachable!("handled above"),
+            CargoPath::IndexEntry { name } => self.index_entry(&name, &request.parts).await,
+            CargoPath::Download { name, version } => self.download(&name, &version).await,
+            CargoPath::Owners { name } => self.list_owners(&name).await,
+            CargoPath::Search => self.search(request.parts.uri.query()).await,
+            other => {
+                debug!(?other, "Route is not a GET");
+                Ok(RepoResponse::unsupported_method_response(
+                    request.parts.method,
+                    "cargo",
+                ))
+            }
+        }
+    }
+
+    async fn handle_put(
+        &self,
+        request: RepositoryRequest,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        match CargoPath::try_from(request.path.clone())? {
+            CargoPath::Publish => self.publish(request).await,
+            CargoPath::Unyank { name, version } => {
+                self.set_yanked(&request.authentication, &name, &version, false)
+                    .await
+            }
+            CargoPath::Owners { name } => self.modify_owners(request, &name, true).await,
+            other => {
+                debug!(?other, "Route is not a PUT");
+                Ok(RepoResponse::unsupported_method_response(
+                    request.parts.method,
+                    "cargo",
+                ))
+            }
+        }
+    }
+
+    async fn handle_delete(
+        &self,
+        request: RepositoryRequest,
+    ) -> Result<RepoResponse, CargoRegistryError> {
+        match CargoPath::try_from(request.path.clone())? {
+            CargoPath::Yank { name, version } => {
+                self.set_yanked(&request.authentication, &name, &version, true)
+                    .await
+            }
+            CargoPath::Owners { name } => self.modify_owners(request, &name, false).await,
+            other => {
+                debug!(?other, "Route is not a DELETE");
+                Ok(RepoResponse::unsupported_method_response(
+                    request.parts.method,
+                    "cargo",
+                ))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_plausible_semver;
+
+    #[test]
+    fn version_strings_are_sanity_checked() {
+        for good in ["1.0.0", "0.1.0-alpha.1", "1.0.0+build.5", "2.0.0-rc1"] {
+            assert!(is_plausible_semver(good), "{good}");
+        }
+        for bad in ["", "v1.0.0", "1.0.0/../etc", "1 0 0", "latest"] {
+            assert!(!is_plausible_semver(bad), "{bad}");
+        }
+    }
+}

--- a/nitro_repo/src/repository/cargo/mod.rs
+++ b/nitro_repo/src/repository/cargo/mod.rs
@@ -1,0 +1,228 @@
+//! Cargo Registry Implementation
+//!
+//! Implements the sparse (HTTP) registry protocol, which has been the default since Rust 1.68.
+//! There is no git index: a sparse registry is a set of plain files, so the existing storage and
+//! routing carry it without a git server in the way.
+//!
+//! Protocol references:
+//! - Index: <https://doc.rust-lang.org/cargo/reference/registry-index.html>
+//! - Web API: <https://doc.rust-lang.org/cargo/reference/registry-web-api.html>
+
+use ahash::HashMap;
+use futures::future::BoxFuture;
+use hosted::CargoHostedRegistry;
+use nr_core::{
+    database::entities::repository::{DBRepository, DBRepositoryConfig},
+    repository::config::{
+        RepositoryConfigType, project::ProjectConfigType, repository_page::RepositoryPageType,
+    },
+};
+use nr_macros::DynRepositoryHandler;
+use nr_storage::DynStorage;
+
+pub mod hosted;
+pub mod types;
+pub mod utils;
+
+mod configs;
+pub use configs::*;
+
+pub use super::prelude::*;
+use super::{DynRepository, NewRepository, RepositoryType, RepositoryTypeDescription};
+use crate::{
+    app::authentication::AuthenticationError,
+    utils::{IntoErrorResponse, bad_request::BadRequestErrors},
+};
+
+#[derive(Debug, Clone, DynRepositoryHandler)]
+#[repository_handler(error=CargoRegistryError)]
+pub enum CargoRegistry {
+    Hosted(hosted::CargoHostedRegistry),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum CargoRegistryError {
+    #[error("{0}")]
+    NotFound(String),
+    #[error(
+        "The publish body is not in the format cargo sends: the {0} frame is missing or its \
+         declared length runs past the end of the body."
+    )]
+    MalformedPublishBody(&'static str),
+    #[error("`{0}` is not a valid crate name")]
+    InvalidCrateName(String),
+    #[error("`{0}` is not a valid semver version")]
+    InvalidVersion(String),
+    /// crates.io refuses this and so does this registry — an immutable version is the assumption
+    /// every lockfile and every `cksum` in the index is built on.
+    #[error(
+        "crate version `{name}@{version}` already exists. Publish a new version instead; a \
+         published version cannot be replaced."
+    )]
+    VersionAlreadyExists { name: String, version: String },
+    #[error("The stored index record for `{name}@{version}` will not parse")]
+    CorruptIndexRecord { name: String, version: String },
+    #[error("This registry has no `app_url` configured, so it cannot tell cargo where to look")]
+    NoAppUrl,
+    #[error("Invalid storage path: {0}")]
+    InvalidPath(#[from] nr_core::storage::InvalidStoragePath),
+    #[error("{0}")]
+    Other(Box<dyn IntoErrorResponse>),
+}
+
+impl From<CargoRegistryError> for RepositoryHandlerError {
+    fn from(err: CargoRegistryError) -> Self {
+        RepositoryHandlerError::Other(Box::new(err))
+    }
+}
+
+macro_rules! impl_from_error_for_other {
+    ($t:ty) => {
+        impl From<$t> for CargoRegistryError {
+            fn from(e: $t) -> Self {
+                CargoRegistryError::Other(Box::new(e))
+            }
+        }
+    };
+}
+impl_from_error_for_other!(BadRequestErrors);
+impl_from_error_for_other!(sqlx::Error);
+impl_from_error_for_other!(nr_core::database::DBError);
+impl_from_error_for_other!(serde_json::Error);
+impl_from_error_for_other!(std::io::Error);
+impl_from_error_for_other!(AuthenticationError);
+impl_from_error_for_other!(RepositoryHandlerError);
+impl_from_error_for_other!(nr_storage::StorageError);
+
+impl IntoErrorResponse for CargoRegistryError {
+    fn into_response_boxed(self: Box<Self>) -> Response {
+        self.into_response()
+    }
+}
+
+impl From<CargoRegistryError> for DynRepositoryHandlerError {
+    fn from(err: CargoRegistryError) -> Self {
+        DynRepositoryHandlerError(Box::new(err))
+    }
+}
+
+/// The error shape cargo expects.
+///
+/// Cargo reads `errors[].detail` out of the body and prints it. A plain-text body reaches the user
+/// as the HTTP status and nothing else, which is how "failed to publish" ends up with no reason
+/// attached.
+pub fn cargo_error(status: StatusCode, detail: &str) -> Response {
+    let body = serde_json::json!({ "errors": [ { "detail": detail } ] }).to_string();
+    Response::builder()
+        .status(status)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .body(body.into())
+        .unwrap()
+}
+
+impl IntoResponse for CargoRegistryError {
+    fn into_response(self) -> Response {
+        match self {
+            CargoRegistryError::NotFound(ref message) => {
+                cargo_error(StatusCode::NOT_FOUND, message)
+            }
+            CargoRegistryError::VersionAlreadyExists { .. } => {
+                cargo_error(StatusCode::CONFLICT, &self.to_string())
+            }
+            CargoRegistryError::MalformedPublishBody(_)
+            | CargoRegistryError::InvalidCrateName(_)
+            | CargoRegistryError::InvalidVersion(_)
+            | CargoRegistryError::InvalidPath(_) => {
+                cargo_error(StatusCode::BAD_REQUEST, &self.to_string())
+            }
+            CargoRegistryError::CorruptIndexRecord { .. } | CargoRegistryError::NoAppUrl => {
+                cargo_error(StatusCode::INTERNAL_SERVER_ERROR, &self.to_string())
+            }
+            CargoRegistryError::Other(other) => other.into_response_boxed(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct CargoRegistryType;
+
+impl RepositoryType for CargoRegistryType {
+    fn get_type(&self) -> &'static str {
+        "cargo"
+    }
+
+    fn config_types(&self) -> Vec<&str> {
+        vec![
+            CargoRegistryConfigType::get_type_static(),
+            RepositoryPageType::get_type_static(),
+            ProjectConfigType::get_type_static(),
+        ]
+    }
+
+    fn get_description(&self) -> RepositoryTypeDescription {
+        RepositoryTypeDescription {
+            type_name: "cargo",
+            name: "Cargo",
+            description: "A Cargo registry, speaking the sparse index protocol",
+            documentation_url: Some("https://nitro-repo.kingtux.dev/repositories/cargo/"),
+            is_stable: true,
+            required_configs: vec![CargoRegistryConfigType::get_type_static()],
+        }
+    }
+
+    fn create_new(
+        &self,
+        name: String,
+        uuid: uuid::Uuid,
+        configs: HashMap<String, serde_json::Value>,
+        _storage: DynStorage,
+    ) -> BoxFuture<'static, Result<NewRepository, RepositoryFactoryError>> {
+        Box::pin(async move {
+            let sub_type = configs
+                .get(CargoRegistryConfigType::get_type_static())
+                .ok_or(RepositoryFactoryError::MissingConfig(
+                    CargoRegistryConfigType::get_type_static(),
+                ))?
+                .clone();
+            if let Err(err) = serde_json::from_value::<CargoRegistryConfig>(sub_type) {
+                return Err(RepositoryFactoryError::InvalidConfig(
+                    CargoRegistryConfigType::get_type_static(),
+                    err.to_string(),
+                ));
+            }
+            Ok(NewRepository {
+                name,
+                uuid,
+                repository_type: "cargo".to_string(),
+                configs,
+            })
+        })
+    }
+
+    fn load_repo(
+        &self,
+        repo: DBRepository,
+        storage: DynStorage,
+        website: NitroRepo,
+    ) -> BoxFuture<'static, Result<DynRepository, RepositoryFactoryError>> {
+        Box::pin(async move {
+            let Some(config) = DBRepositoryConfig::<CargoRegistryConfig>::get_config(
+                repo.id,
+                CargoRegistryConfigType::get_type_static(),
+                &website.database,
+            )
+            .await?
+            else {
+                return Err(RepositoryFactoryError::MissingConfig(
+                    CargoRegistryConfigType::get_type_static(),
+                ));
+            };
+            match config.value.0 {
+                CargoRegistryConfig::Hosted => {
+                    let hosted = CargoHostedRegistry::load(website, storage, repo).await?;
+                    Ok(CargoRegistry::Hosted(hosted).into())
+                }
+            }
+        })
+    }
+}

--- a/nitro_repo/src/repository/cargo/types/index.rs
+++ b/nitro_repo/src/repository/cargo/types/index.rs
@@ -1,0 +1,231 @@
+//! The registry index record.
+//!
+//! One JSON object per published version, serialised one-per-line into the sparse index. The shape
+//! is fixed by Cargo and documented at
+//! <https://doc.rust-lang.org/cargo/reference/registry-index.html>.
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+use super::publish::{PublishDependency, PublishMetadata};
+
+/// The index schema version this registry writes.
+///
+/// `2` is what unlocks `features2` — a feature whose value contains a `dep:` or `?/` entry can only
+/// be expressed there, and an older Cargo that does not understand `v: 2` is told to upgrade rather
+/// than being handed a record it would misread.
+pub const INDEX_SCHEMA_VERSION: u32 = 2;
+
+/// A single line of the sparse index.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexEntry {
+    pub name: String,
+    pub vers: String,
+    pub deps: Vec<IndexDependency>,
+    /// SHA-256 of the `.crate` file, lowercase hex. Cargo verifies every download against this.
+    pub cksum: String,
+    pub features: BTreeMap<String, Vec<String>>,
+    pub yanked: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub links: Option<String>,
+    pub v: u32,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub features2: BTreeMap<String, Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub rust_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexDependency {
+    /// The name the dependent crate refers to this dependency by. With `explicit_name_in_toml` this
+    /// is the rename, and `package` carries the real crate name.
+    pub name: String,
+    pub req: String,
+    pub features: Vec<String>,
+    pub optional: bool,
+    pub default_features: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    pub kind: String,
+    /// `None` means "this registry". Cargo writes the upstream's index URL here otherwise.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub registry: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub package: Option<String>,
+}
+
+impl From<PublishDependency> for IndexDependency {
+    fn from(dependency: PublishDependency) -> Self {
+        let PublishDependency {
+            name,
+            version_req,
+            features,
+            optional,
+            default_features,
+            target,
+            kind,
+            registry,
+            explicit_name_in_toml,
+        } = dependency;
+        // A renamed dependency is published as `explicit_name_in_toml = "new", name = "real"`, but
+        // the index inverts that: `name` is what the crate calls it and `package` is what to fetch.
+        // Getting this backwards makes a renamed dependency resolve to the wrong crate.
+        let (name, package) = match explicit_name_in_toml {
+            Some(renamed) => (renamed, Some(name)),
+            None => (name, None),
+        };
+        Self {
+            name,
+            req: version_req,
+            features,
+            optional,
+            default_features,
+            target,
+            kind: kind.unwrap_or_else(|| "normal".to_owned()),
+            registry,
+            package,
+        }
+    }
+}
+
+impl IndexEntry {
+    /// Builds the index record for a version being published.
+    ///
+    /// Cargo sends one `features` map; the entries that need index schema 2 are split out into
+    /// `features2` here, because an older client reading them from `features` would fail to parse
+    /// the `dep:`/`?/` syntax rather than ignoring it.
+    pub fn from_publish(metadata: PublishMetadata, cksum: String) -> Self {
+        let PublishMetadata {
+            name,
+            vers,
+            deps,
+            features,
+            links,
+            rust_version,
+            ..
+        } = metadata;
+
+        let mut plain = BTreeMap::new();
+        let mut v2 = BTreeMap::new();
+        for (feature, values) in features {
+            if values
+                .iter()
+                .any(|value| value.starts_with("dep:") || value.contains("?/"))
+            {
+                v2.insert(feature, values);
+            } else {
+                plain.insert(feature, values);
+            }
+        }
+
+        Self {
+            name,
+            vers,
+            deps: deps.into_iter().map(IndexDependency::from).collect(),
+            cksum,
+            features: plain,
+            yanked: false,
+            links,
+            v: INDEX_SCHEMA_VERSION,
+            features2: v2,
+            rust_version,
+        }
+    }
+}
+
+/// Where a crate's index record lives, relative to the index root.
+///
+/// Cargo derives the path from the name's length so the index never has one enormous directory:
+/// one- and two-character names live under `1/` and `2/`, three-character names under `3/{first}/`,
+/// and everything else under the first two characters then the next two. The name is lowercased —
+/// the index is case-insensitive even though the crate name is not.
+///
+/// Getting this wrong does not fail loudly; every lookup simply 404s.
+pub fn index_path_for(name: &str) -> String {
+    let lower = name.to_lowercase();
+    let chars: Vec<char> = lower.chars().collect();
+    match chars.len() {
+        0 => lower,
+        1 => format!("1/{lower}"),
+        2 => format!("2/{lower}"),
+        3 => format!("3/{}/{}", chars[0], lower),
+        _ => {
+            let first: String = chars[0..2].iter().collect();
+            let second: String = chars[2..4].iter().collect();
+            format!("{first}/{second}/{lower}")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{IndexEntry, index_path_for};
+    use crate::repository::cargo::types::publish::PublishMetadata;
+
+    #[test]
+    fn the_index_path_depends_on_the_name_length() {
+        assert_eq!(index_path_for("a"), "1/a");
+        assert_eq!(index_path_for("ab"), "2/ab");
+        assert_eq!(index_path_for("abc"), "3/a/abc");
+        assert_eq!(index_path_for("abcd"), "ab/cd/abcd");
+        assert_eq!(index_path_for("serde"), "se/rd/serde");
+        assert_eq!(index_path_for("cargo"), "ca/rg/cargo");
+    }
+
+    #[test]
+    fn the_index_path_is_lowercased() {
+        assert_eq!(index_path_for("Serde"), "se/rd/serde");
+        assert_eq!(index_path_for("A"), "1/a");
+        assert_eq!(index_path_for("Nitro_Repo"), "ni/tr/nitro_repo");
+    }
+
+    #[test]
+    fn features_needing_schema_two_are_split_out() {
+        let metadata: PublishMetadata = serde_json::from_value(serde_json::json!({
+            "name": "example",
+            "vers": "1.0.0",
+            "deps": [],
+            "features": {
+                "plain": ["other"],
+                "uses-dep": ["dep:serde"],
+                "uses-weak": ["serde?/derive"],
+            },
+        }))
+        .unwrap();
+
+        let entry = IndexEntry::from_publish(metadata, "abc".to_owned());
+        assert_eq!(entry.v, 2);
+        assert!(entry.features.contains_key("plain"));
+        assert!(entry.features2.contains_key("uses-dep"));
+        assert!(entry.features2.contains_key("uses-weak"));
+        assert!(!entry.features.contains_key("uses-dep"));
+    }
+
+    #[test]
+    fn a_renamed_dependency_keeps_the_real_name_in_package() {
+        let metadata: PublishMetadata = serde_json::from_value(serde_json::json!({
+            "name": "example",
+            "vers": "1.0.0",
+            "deps": [{
+                "name": "serde_json",
+                "version_req": "^1",
+                "features": [],
+                "optional": false,
+                "default_features": true,
+                "target": null,
+                "kind": "normal",
+                "registry": null,
+                "explicit_name_in_toml": "json",
+            }],
+            "features": {},
+        }))
+        .unwrap();
+
+        let entry = IndexEntry::from_publish(metadata, "abc".to_owned());
+        let dependency = &entry.deps[0];
+        assert_eq!(dependency.name, "json");
+        assert_eq!(dependency.package.as_deref(), Some("serde_json"));
+        assert_eq!(dependency.req, "^1");
+    }
+}

--- a/nitro_repo/src/repository/cargo/types/mod.rs
+++ b/nitro_repo/src/repository/cargo/types/mod.rs
@@ -1,0 +1,7 @@
+pub mod index;
+pub mod publish;
+pub mod request;
+
+pub use index::{IndexDependency, IndexEntry, index_path_for};
+pub use publish::{PublishMetadata, is_valid_crate_name, split_publish_body};
+pub use request::CargoPath;

--- a/nitro_repo/src/repository/cargo/types/publish.rs
+++ b/nitro_repo/src/repository/cargo/types/publish.rs
@@ -1,0 +1,201 @@
+//! `PUT /api/v1/crates/new` — the publish request.
+//!
+//! The body is not JSON. It is a pair of length-prefixed frames:
+//!
+//! ```text
+//! u32 LE  metadata length
+//! ..      metadata JSON
+//! u32 LE  crate file length
+//! ..      the .crate file
+//! ```
+//!
+//! See <https://doc.rust-lang.org/cargo/reference/registry-web-api.html#publish>.
+
+use std::collections::BTreeMap;
+
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+
+use super::super::CargoRegistryError;
+
+/// Refuses a declared frame length that could not possibly be satisfied before allocating for it.
+/// The length is four attacker-controlled bytes; taken at face value it is a request to reserve up
+/// to 4 GiB.
+fn take_frame(
+    body: &Bytes,
+    offset: &mut usize,
+    what: &'static str,
+) -> Result<Bytes, CargoRegistryError> {
+    let header_end = offset
+        .checked_add(4)
+        .ok_or(CargoRegistryError::MalformedPublishBody(what))?;
+    if body.len() < header_end {
+        return Err(CargoRegistryError::MalformedPublishBody(what));
+    }
+    let length = u32::from_le_bytes([
+        body[*offset],
+        body[*offset + 1],
+        body[*offset + 2],
+        body[*offset + 3],
+    ]) as usize;
+    let end = header_end
+        .checked_add(length)
+        .ok_or(CargoRegistryError::MalformedPublishBody(what))?;
+    if body.len() < end {
+        return Err(CargoRegistryError::MalformedPublishBody(what));
+    }
+    *offset = end;
+    Ok(body.slice(header_end..end))
+}
+
+/// Splits a publish body into its metadata and its `.crate` file.
+pub fn split_publish_body(body: Bytes) -> Result<(PublishMetadata, Bytes), CargoRegistryError> {
+    let mut offset = 0usize;
+    let metadata = take_frame(&body, &mut offset, "metadata")?;
+    let crate_file = take_frame(&body, &mut offset, "crate file")?;
+    let metadata: PublishMetadata = serde_json::from_slice(&metadata)?;
+    Ok((metadata, crate_file))
+}
+
+/// The metadata frame. Cargo adds fields over time, so unknown ones are ignored rather than
+/// refused — a newer toolchain must still be able to publish here.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublishMetadata {
+    pub name: String,
+    pub vers: String,
+    #[serde(default)]
+    pub deps: Vec<PublishDependency>,
+    #[serde(default)]
+    pub features: BTreeMap<String, Vec<String>>,
+    #[serde(default)]
+    pub authors: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub documentation: Option<String>,
+    #[serde(default)]
+    pub homepage: Option<String>,
+    #[serde(default)]
+    pub readme: Option<String>,
+    #[serde(default)]
+    pub readme_file: Option<String>,
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    #[serde(default)]
+    pub categories: Vec<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub license_file: Option<String>,
+    #[serde(default)]
+    pub repository: Option<String>,
+    #[serde(default)]
+    pub links: Option<String>,
+    #[serde(default)]
+    pub rust_version: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PublishDependency {
+    pub name: String,
+    pub version_req: String,
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub optional: bool,
+    #[serde(default = "default_true")]
+    pub default_features: bool,
+    #[serde(default)]
+    pub target: Option<String>,
+    #[serde(default)]
+    pub kind: Option<String>,
+    #[serde(default)]
+    pub registry: Option<String>,
+    #[serde(default)]
+    pub explicit_name_in_toml: Option<String>,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// A crate name Cargo would accept: alphanumeric, `-` and `_`, starting with a letter.
+///
+/// Enforced here rather than only at the storage layer because the name becomes a path component
+/// in both the index and the `.crate` location, and because a name Cargo cannot express is a
+/// package nobody could ever depend on.
+pub fn is_valid_crate_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= 64
+        && name.starts_with(|c: char| c.is_ascii_alphabetic())
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::{BufMut, Bytes, BytesMut};
+
+    use super::{is_valid_crate_name, split_publish_body};
+
+    fn body(metadata: &[u8], crate_file: &[u8]) -> Bytes {
+        let mut buffer = BytesMut::new();
+        buffer.put_u32_le(metadata.len() as u32);
+        buffer.put_slice(metadata);
+        buffer.put_u32_le(crate_file.len() as u32);
+        buffer.put_slice(crate_file);
+        buffer.freeze()
+    }
+
+    #[test]
+    fn a_well_formed_body_splits_into_metadata_and_crate() {
+        let metadata = br#"{"name":"example","vers":"1.0.0","deps":[],"features":{}}"#;
+        let (parsed, file) = split_publish_body(body(metadata, b"tarball bytes")).unwrap();
+        assert_eq!(parsed.name, "example");
+        assert_eq!(parsed.vers, "1.0.0");
+        assert_eq!(&file[..], b"tarball bytes");
+    }
+
+    #[test]
+    fn a_length_longer_than_the_body_is_refused() {
+        let mut buffer = BytesMut::new();
+        buffer.put_u32_le(u32::MAX);
+        buffer.put_slice(b"{}");
+        assert!(split_publish_body(buffer.freeze()).is_err());
+    }
+
+    #[test]
+    fn a_truncated_body_is_refused() {
+        for truncated in [&b""[..], &b"\x01"[..], &b"\x02\x00\x00\x00{"[..]] {
+            assert!(split_publish_body(Bytes::from_static(truncated)).is_err());
+        }
+    }
+
+    #[test]
+    fn a_body_missing_its_crate_frame_is_refused() {
+        let metadata = br#"{"name":"example","vers":"1.0.0"}"#;
+        let mut buffer = BytesMut::new();
+        buffer.put_u32_le(metadata.len() as u32);
+        buffer.put_slice(metadata);
+        assert!(split_publish_body(buffer.freeze()).is_err());
+    }
+
+    #[test]
+    fn crate_names_follow_cargos_rules() {
+        for good in ["serde", "nitro-repo", "nitro_repo", "a", "a1"] {
+            assert!(is_valid_crate_name(good), "{good}");
+        }
+        for bad in [
+            "",
+            "1crate",
+            "-leading",
+            "_leading",
+            "has space",
+            "has/slash",
+            "has.dot",
+        ] {
+            assert!(!is_valid_crate_name(bad), "{bad}");
+        }
+    }
+}

--- a/nitro_repo/src/repository/cargo/types/request.rs
+++ b/nitro_repo/src/repository/cargo/types/request.rs
@@ -1,0 +1,187 @@
+//! Turning a request path into a Cargo registry route.
+//!
+//! Cargo speaks two things over one URL prefix: the sparse index (under `index/`) and the web API
+//! (under `api/v1/`). Both are addressed by path rather than by a header, so — like npm's
+//! [`GetPath`](crate::repository::npm::types::request::GetPath) — this is a `TryFrom<StoragePath>`
+//! rather than a set of axum routes.
+
+use nr_core::storage::StoragePath;
+
+use super::super::CargoRegistryError;
+
+/// The index lives under this prefix, keeping `api/` free for the web API.
+pub const INDEX_PREFIX: &str = "index";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CargoPath {
+    /// `index/config.json` — the sparse index's own descriptor.
+    Config,
+    /// `index/{prefix}/{name}` — one crate's versions, newline-delimited JSON.
+    IndexEntry { name: String },
+    /// `api/v1/crates/new`
+    Publish,
+    /// `api/v1/crates` — with a `?q=` query.
+    Search,
+    /// `api/v1/crates/{name}/{version}/download`
+    Download { name: String, version: String },
+    /// `api/v1/crates/{name}/{version}/yank`
+    Yank { name: String, version: String },
+    /// `api/v1/crates/{name}/{version}/unyank`
+    Unyank { name: String, version: String },
+    /// `api/v1/crates/{name}/owners`
+    Owners { name: String },
+}
+
+impl TryFrom<StoragePath> for CargoPath {
+    type Error = CargoRegistryError;
+
+    fn try_from(path: StoragePath) -> Result<Self, Self::Error> {
+        let components: Vec<String> = Vec::<nr_core::storage::StoragePathComponent>::from(path)
+            .into_iter()
+            .map(String::from)
+            .collect();
+        let as_slice: Vec<&str> = components.iter().map(String::as_str).collect();
+
+        match as_slice.as_slice() {
+            [INDEX_PREFIX, "config.json"] => Ok(CargoPath::Config),
+            // The index prefix directories carry no information the crate name does not already
+            // hold, so the name is taken from the last segment and the rest is only checked for
+            // plausibility. Serving `ab/cd/serde` as `serde` would let one crate be fetched under
+            // another's path and poison a client's cache.
+            [INDEX_PREFIX, rest @ ..] if !rest.is_empty() => {
+                let name = rest[rest.len() - 1];
+                let expected = super::index::index_path_for(name);
+                let actual = rest.join("/");
+                if actual != expected {
+                    return Err(CargoRegistryError::NotFound(format!(
+                        "No crate is indexed at `{actual}`"
+                    )));
+                }
+                Ok(CargoPath::IndexEntry {
+                    name: name.to_owned(),
+                })
+            }
+            ["api", "v1", "crates"] => Ok(CargoPath::Search),
+            ["api", "v1", "crates", "new"] => Ok(CargoPath::Publish),
+            ["api", "v1", "crates", name, "owners"] => Ok(CargoPath::Owners {
+                name: (*name).to_owned(),
+            }),
+            ["api", "v1", "crates", name, version, "download"] => Ok(CargoPath::Download {
+                name: (*name).to_owned(),
+                version: (*version).to_owned(),
+            }),
+            ["api", "v1", "crates", name, version, "yank"] => Ok(CargoPath::Yank {
+                name: (*name).to_owned(),
+                version: (*version).to_owned(),
+            }),
+            ["api", "v1", "crates", name, version, "unyank"] => Ok(CargoPath::Unyank {
+                name: (*name).to_owned(),
+                version: (*version).to_owned(),
+            }),
+            other => Err(CargoRegistryError::NotFound(format!(
+                "`/{}` is not a route this registry serves",
+                other.join("/")
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use nr_core::storage::StoragePath;
+
+    use super::CargoPath;
+
+    fn parse(path: &str) -> Result<CargoPath, super::CargoRegistryError> {
+        CargoPath::try_from(StoragePath::parse(path).unwrap())
+    }
+
+    #[test]
+    fn the_index_routes_parse() {
+        assert_eq!(parse("index/config.json").unwrap(), CargoPath::Config);
+        assert_eq!(
+            parse("index/ca/rg/cargo").unwrap(),
+            CargoPath::IndexEntry {
+                name: "cargo".to_owned()
+            }
+        );
+        assert_eq!(
+            parse("index/1/a").unwrap(),
+            CargoPath::IndexEntry {
+                name: "a".to_owned()
+            }
+        );
+        assert_eq!(
+            parse("index/3/f/foo").unwrap(),
+            CargoPath::IndexEntry {
+                name: "foo".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn an_index_path_that_does_not_match_the_name_is_refused() {
+        // `serde` belongs at `se/rd/serde`, not here.
+        assert!(parse("index/aa/bb/serde").is_err());
+        assert!(parse("index/1/serde").is_err());
+    }
+
+    #[test]
+    fn the_api_routes_parse() {
+        assert_eq!(parse("api/v1/crates/new").unwrap(), CargoPath::Publish);
+        assert_eq!(parse("api/v1/crates").unwrap(), CargoPath::Search);
+        assert_eq!(
+            parse("api/v1/crates/serde/1.0.0/download").unwrap(),
+            CargoPath::Download {
+                name: "serde".to_owned(),
+                version: "1.0.0".to_owned()
+            }
+        );
+        assert_eq!(
+            parse("api/v1/crates/serde/1.0.0/yank").unwrap(),
+            CargoPath::Yank {
+                name: "serde".to_owned(),
+                version: "1.0.0".to_owned()
+            }
+        );
+        assert_eq!(
+            parse("api/v1/crates/serde/1.0.0/unyank").unwrap(),
+            CargoPath::Unyank {
+                name: "serde".to_owned(),
+                version: "1.0.0".to_owned()
+            }
+        );
+        assert_eq!(
+            parse("api/v1/crates/serde/owners").unwrap(),
+            CargoPath::Owners {
+                name: "serde".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn an_unknown_route_is_refused() {
+        for path in [
+            "",
+            "api",
+            "api/v1",
+            "api/v2/crates/new",
+            "index",
+            "nonsense/here",
+        ] {
+            assert!(parse(path).is_err(), "path: {path:?}");
+        }
+    }
+
+    #[test]
+    fn a_crate_named_new_does_not_shadow_the_publish_route() {
+        // `api/v1/crates/new` is publish; `api/v1/crates/new/1.0.0/download` is the crate `new`.
+        assert_eq!(
+            parse("api/v1/crates/new/1.0.0/download").unwrap(),
+            CargoPath::Download {
+                name: "new".to_owned(),
+                version: "1.0.0".to_owned()
+            }
+        );
+    }
+}

--- a/nitro_repo/src/repository/cargo/utils.rs
+++ b/nitro_repo/src/repository/cargo/utils.rs
@@ -1,0 +1,77 @@
+use std::fmt::Write;
+
+use http::request::Parts;
+use nr_core::storage::StoragePath;
+use nr_storage::Storage;
+
+use super::CargoRegistryError;
+use crate::repository::Repository;
+
+/// Lowercase hex, which is the only form cargo accepts for `cksum`.
+///
+/// `sha2` 0.11 returns a `digest::Output`, which does not implement `LowerHex`, so this is written
+/// out rather than formatted. The same helper exists in the Maven module for the same reason.
+pub fn to_hex(bytes: &[u8]) -> String {
+    bytes.iter().fold(String::new(), |mut hex, byte| {
+        let _ = write!(hex, "{byte:02x}");
+        hex
+    })
+}
+
+/// Where a crate's `.crate` file is stored, relative to the repository root.
+///
+/// The crate name is the project key, so the storage layout mirrors what the index says, and
+/// `crates/` keeps the files clear of the `index/` tree a future on-disk index would want.
+pub fn crate_file_path(name: &str, version: &str) -> Result<StoragePath, CargoRegistryError> {
+    let mut path = StoragePath::parse("crates")?;
+    path.push_mut(name);
+    path.push_mut(&format!("{name}-{version}.crate"));
+    Ok(path)
+}
+
+/// The absolute URL cargo should use as the root of this registry.
+///
+/// A registry can be reached two ways, and `config.json` has to name the one the client actually
+/// used. A request that arrived on a hostname registered to this repository is answered with that
+/// hostname's root — telling such a client to go back through `/repositories/{storage}/{name}`
+/// would work but would undo the point of the custom domain, and would break outright when the
+/// custom host is the only one reachable from where cargo is running.
+pub fn registry_base_url(
+    repository: &impl Repository,
+    parts: &Parts,
+) -> Result<String, CargoRegistryError> {
+    let site = repository.site();
+
+    if let Some(host) = crate::app::host_routing::request_host(
+        &parts.headers,
+        &parts.uri,
+        site.general_security_settings.trust_forwarded_host,
+    ) && site
+        .repository_for_hostname(&host)
+        .is_some_and(|found| found.id() == repository.id())
+        && let Some(origin) =
+            crate::app::host_routing::request_origin(&site, &parts.headers, &parts.uri)
+    {
+        // The origin, not the looked-up host: the lookup is deliberately port-blind, but the URL
+        // written into `config.json` is what cargo will actually request.
+        return Ok(origin);
+    }
+
+    let base = {
+        let instance = site.instance.lock();
+        instance.app_url.trim_end_matches('/').to_owned()
+    };
+    if base.is_empty() {
+        return Err(CargoRegistryError::NoAppUrl);
+    }
+    let storage = repository.get_storage();
+    let storage_name = storage
+        .storage_config()
+        .storage_config
+        .storage_name
+        .to_string();
+    Ok(format!(
+        "{base}/repositories/{storage_name}/{}",
+        repository.name()
+    ))
+}

--- a/nitro_repo/src/repository/docker/configs.rs
+++ b/nitro_repo/src/repository/docker/configs.rs
@@ -1,0 +1,50 @@
+use nr_core::repository::config::{ConfigDescription, RepositoryConfigError, RepositoryConfigType};
+use schemars::{JsonSchema, schema_for};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// Which kind of Docker registry this is.
+///
+/// Only `Hosted` exists today. A `Proxy` variant carrying an upstream (a pull-through cache of
+/// Docker Hub) would be added here the way Maven's was, without a migration.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "type", content = "config")]
+pub enum DockerRegistryConfig {
+    Hosted,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct DockerRegistryConfigType;
+impl RepositoryConfigType for DockerRegistryConfigType {
+    fn get_type(&self) -> &'static str {
+        "docker"
+    }
+
+    fn get_type_static() -> &'static str
+    where
+        Self: Sized,
+    {
+        "docker"
+    }
+    fn schema(&self) -> Option<schemars::Schema> {
+        Some(schema_for!(DockerRegistryConfig))
+    }
+    fn validate_config(&self, config: Value) -> Result<(), RepositoryConfigError> {
+        let _: DockerRegistryConfig = serde_json::from_value(config)?;
+        Ok(())
+    }
+    fn validate_change(&self, _old: Value, _new: Value) -> Result<(), RepositoryConfigError> {
+        Ok(())
+    }
+    fn default(&self) -> Result<Value, RepositoryConfigError> {
+        Ok(serde_json::to_value(DockerRegistryConfig::Hosted)?)
+    }
+    fn get_description(&self) -> ConfigDescription {
+        ConfigDescription {
+            name: "Docker Registry Config",
+            description: Some("Handles the type of Docker Registry"),
+            documentation_link: None,
+            ..Default::default()
+        }
+    }
+}

--- a/nitro_repo/src/repository/docker/errors.rs
+++ b/nitro_repo/src/repository/docker/errors.rs
@@ -1,0 +1,143 @@
+//! The OCI error envelope.
+//!
+//! Every non-2xx answer from a registry is expected to look like
+//! `{"errors":[{"code":"...","message":"...","detail":...}]}`. Docker and containerd both surface
+//! `message` to the user and branch on `code` — a plain-text body reaches the user as
+//! "unexpected status" and nothing more.
+//!
+//! Codes are from
+//! <https://github.com/opencontainers/distribution-spec/blob/main/spec.md#error-codes>.
+
+use axum::response::Response;
+use http::StatusCode;
+use serde::Serialize;
+
+/// The subset of the spec's codes this registry can actually produce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorCode {
+    BlobUnknown,
+    BlobUploadInvalid,
+    BlobUploadUnknown,
+    DigestInvalid,
+    ManifestBlobUnknown,
+    ManifestInvalid,
+    ManifestUnknown,
+    NameInvalid,
+    NameUnknown,
+    SizeInvalid,
+    Unauthorized,
+    Denied,
+    Unsupported,
+    TooManyRequests,
+}
+
+impl ErrorCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BlobUnknown => "BLOB_UNKNOWN",
+            Self::BlobUploadInvalid => "BLOB_UPLOAD_INVALID",
+            Self::BlobUploadUnknown => "BLOB_UPLOAD_UNKNOWN",
+            Self::DigestInvalid => "DIGEST_INVALID",
+            Self::ManifestBlobUnknown => "MANIFEST_BLOB_UNKNOWN",
+            Self::ManifestInvalid => "MANIFEST_INVALID",
+            Self::ManifestUnknown => "MANIFEST_UNKNOWN",
+            Self::NameInvalid => "NAME_INVALID",
+            Self::NameUnknown => "NAME_UNKNOWN",
+            Self::SizeInvalid => "SIZE_INVALID",
+            Self::Unauthorized => "UNAUTHORIZED",
+            Self::Denied => "DENIED",
+            Self::Unsupported => "UNSUPPORTED",
+            Self::TooManyRequests => "TOOMANYREQUESTS",
+        }
+    }
+
+    /// The status the spec pairs with each code.
+    pub fn status(self) -> StatusCode {
+        match self {
+            Self::BlobUnknown
+            | Self::BlobUploadUnknown
+            | Self::ManifestUnknown
+            | Self::NameUnknown => StatusCode::NOT_FOUND,
+            Self::Unauthorized => StatusCode::UNAUTHORIZED,
+            Self::Denied => StatusCode::FORBIDDEN,
+            Self::Unsupported => StatusCode::METHOD_NOT_ALLOWED,
+            Self::TooManyRequests => StatusCode::TOO_MANY_REQUESTS,
+            _ => StatusCode::BAD_REQUEST,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    errors: Vec<ErrorEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorEntry {
+    code: &'static str,
+    message: String,
+}
+
+/// Builds the response body for one error code.
+pub fn oci_error(code: ErrorCode, message: impl Into<String>) -> Response {
+    oci_error_with_status(code.status(), code, message)
+}
+
+/// The same, with the status forced.
+///
+/// Needed for the challenge on `/v2/`: the code is `UNAUTHORIZED` but the response also has to
+/// carry `WWW-Authenticate`, which is added by the caller.
+pub fn oci_error_with_status(
+    status: StatusCode,
+    code: ErrorCode,
+    message: impl Into<String>,
+) -> Response {
+    let body = ErrorBody {
+        errors: vec![ErrorEntry {
+            code: code.as_str(),
+            message: message.into(),
+        }],
+    };
+    Response::builder()
+        .status(status)
+        .header(http::header::CONTENT_TYPE, "application/json")
+        .header(
+            super::DOCKER_API_VERSION_HEADER.clone(),
+            super::DOCKER_API_VERSION_VALUE.clone(),
+        )
+        .body(serde_json::to_string(&body).unwrap_or_default().into())
+        .unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use http::StatusCode;
+
+    use super::{ErrorCode, oci_error};
+
+    #[test]
+    fn codes_map_to_the_statuses_the_spec_pairs_them_with() {
+        assert_eq!(ErrorCode::BlobUnknown.status(), StatusCode::NOT_FOUND);
+        assert_eq!(ErrorCode::ManifestUnknown.status(), StatusCode::NOT_FOUND);
+        assert_eq!(ErrorCode::Denied.status(), StatusCode::FORBIDDEN);
+        assert_eq!(ErrorCode::Unauthorized.status(), StatusCode::UNAUTHORIZED);
+        assert_eq!(ErrorCode::DigestInvalid.status(), StatusCode::BAD_REQUEST);
+        assert_eq!(
+            ErrorCode::Unsupported.status(),
+            StatusCode::METHOD_NOT_ALLOWED
+        );
+    }
+
+    #[test]
+    fn the_envelope_carries_the_api_version_header() {
+        let response = oci_error(ErrorCode::NameUnknown, "nope");
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+        assert_eq!(
+            response
+                .headers()
+                .get("docker-distribution-api-version")
+                .unwrap(),
+            "registry/2.0"
+        );
+    }
+}

--- a/nitro_repo/src/repository/docker/hosted.rs
+++ b/nitro_repo/src/repository/docker/hosted.rs
@@ -1,0 +1,1366 @@
+use std::sync::{
+    Arc,
+    atomic::{self, AtomicBool},
+};
+
+use bytes::Bytes;
+use derive_more::derive::Deref;
+use http::{
+    HeaderValue, StatusCode,
+    header::{CONTENT_LENGTH, CONTENT_RANGE, CONTENT_TYPE, LOCATION, RANGE},
+    request::Parts,
+};
+use nr_core::{
+    database::entities::{
+        docker_manifest::DBDockerManifest,
+        project::{
+            DBProject, NewProject, NewProjectMember, ProjectDBType,
+            versions::{DBProjectVersion, NewVersion, UpdateProjectVersion},
+        },
+        repository::DBRepository,
+    },
+    repository::{
+        Visibility,
+        config::{
+            RepositoryConfigType, project::ProjectConfigType, repository_page::RepositoryPageType,
+        },
+        project::{ReleaseType, VersionData},
+    },
+    storage::StoragePath,
+    user::permissions::RepositoryActions,
+};
+use nr_storage::{DynStorage, FileContent, Storage, StorageFile};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, info, instrument, warn};
+use uuid::Uuid;
+
+use super::{
+    DOCKER_API_VERSION_HEADER, DOCKER_API_VERSION_VALUE, DOCKER_CONTENT_DIGEST_HEADER,
+    DOCKER_UPLOAD_UUID_HEADER, DockerError, DockerRegistryConfigType,
+    errors::ErrorCode,
+    types::{
+        Digest, DockerPath, Manifest, Reference,
+        manifest::{DEFAULT_MANIFEST_MEDIA_TYPE, is_index},
+    },
+};
+use crate::{
+    app::NitroRepo,
+    repository::{
+        RepoResponse, Repository, RepositoryAuthentication, RepositoryFactoryError,
+        RepositoryRequest, utils::RepositoryExt,
+    },
+    utils::ResponseBuilder,
+};
+
+/// The default page size for `tags/list` and `_catalog`, and the cap on what `?n=` can ask for.
+const DEFAULT_PAGE_SIZE: usize = 100;
+const MAX_PAGE_SIZE: usize = 1000;
+
+#[derive(derive_more::Debug)]
+pub struct DockerRegistryInner {
+    #[debug(skip)]
+    pub site: NitroRepo,
+    pub storage: DynStorage,
+    pub id: Uuid,
+    pub name: String,
+    pub visibility: RwLock<Visibility>,
+    pub active: AtomicBool,
+}
+
+#[derive(Debug, Clone, Deref)]
+pub struct DockerHostedRegistry(Arc<DockerRegistryInner>);
+
+impl DockerHostedRegistry {
+    pub async fn load(
+        site: NitroRepo,
+        storage: DynStorage,
+        repository: DBRepository,
+    ) -> Result<Self, RepositoryFactoryError> {
+        Ok(Self(Arc::new(DockerRegistryInner {
+            site,
+            storage,
+            id: repository.id,
+            name: repository.name.to_string(),
+            visibility: RwLock::new(repository.visibility),
+            active: AtomicBool::new(repository.active),
+        })))
+    }
+
+    /// Where a blob's bytes live: `blobs/{algorithm}/{hex}`.
+    ///
+    /// Content-addressed, so two images sharing a base layer share the stored bytes. Both
+    /// components come out of a parsed [`Digest`], so neither can escape the repository root.
+    fn blob_path(digest: &Digest) -> Result<StoragePath, DockerError> {
+        let (algorithm, hex) = digest.path_components();
+        let mut path = StoragePath::parse("blobs")?;
+        path.push_mut(algorithm);
+        path.push_mut(hex);
+        Ok(path)
+    }
+
+    /// Where a manifest's bytes live. Separate from blobs so a manifest is never mistaken for one.
+    fn manifest_path(digest: &Digest) -> Result<StoragePath, DockerError> {
+        let (algorithm, hex) = digest.path_components();
+        let mut path = StoragePath::parse("manifests")?;
+        path.push_mut(algorithm);
+        path.push_mut(hex);
+        Ok(path)
+    }
+
+    /// Refuses a read the caller may not make.
+    ///
+    /// A Docker client does not send credentials until it has been challenged, so an
+    /// unauthenticated read of a private registry answers `401` with `WWW-Authenticate` rather than
+    /// a flat `403`. That challenge is the whole handshake `docker login` performs.
+    async fn check_read(
+        &self,
+        authentication: &RepositoryAuthentication,
+        parts: &Parts,
+        scope: Option<String>,
+    ) -> Result<Option<DockerError>, DockerError> {
+        let scope = scope.as_deref();
+        if self.visibility().is_public() {
+            return Ok(None);
+        }
+        if authentication.is_no_identification() {
+            return Ok(Some(self.challenge(parts, scope, "pull")));
+        }
+        if !authentication
+            .can_access_repository(RepositoryActions::Read, self.0.id, self.site.as_ref())
+            .await?
+        {
+            return Ok(Some(DockerError::coded(
+                ErrorCode::Denied,
+                "you do not have read access to this registry",
+            )));
+        }
+        Ok(None)
+    }
+
+    /// The `401` that tells a client where to get a token.
+    ///
+    /// The realm is built from the host the client is already talking to, not from `app_url`: a
+    /// registry reached on a custom domain may be the only address that resolves from wherever
+    /// Docker is running, and it is also what lets the token endpoint work out which repository the
+    /// caller means when the image name carries no prefix.
+    pub fn challenge(&self, parts: &Parts, image: Option<&str>, actions: &str) -> DockerError {
+        let base =
+            crate::app::host_routing::request_origin(&self.0.site, &parts.headers, &parts.uri)
+                .unwrap_or_default();
+        DockerError::Challenge {
+            // Under `/api`, not under `/v2`, so it can never collide with an image literally named
+            // `token`. `/api` is nested before the fallback and served on every host, so it is
+            // reachable on a custom Docker domain too.
+            realm: format!("{base}/api/docker/token"),
+            scope: image.map(|image| format!("repository:{image}:{actions}")),
+        }
+    }
+
+    /// `image` must be the client's spelling — see [`Origin`]. A challenge naming an image the
+    /// client did not ask for makes the token it fetches useless for the request it was retrying.
+    async fn require_write(
+        &self,
+        authentication: &RepositoryAuthentication,
+        parts: &Parts,
+        image: &str,
+    ) -> Result<i32, DockerError> {
+        if authentication.is_no_identification() {
+            return Err(self.challenge(parts, Some(image), "pull,push"));
+        }
+        let Some(user) = authentication
+            .get_user_if_has_action(RepositoryActions::Write, self.0.id, self.site.as_ref())
+            .await?
+        else {
+            return Err(DockerError::coded(
+                ErrorCode::Denied,
+                "you do not have push access to this registry",
+            ));
+        };
+        Ok(user.id)
+    }
+
+    // ---- reads -------------------------------------------------------------------------------
+
+    /// `GET`/`HEAD /v2/{name}/manifests/{reference}`.
+    #[instrument(skip(self))]
+    async fn read_manifest(
+        &self,
+        image: &str,
+        reference: &Reference,
+        head_only: bool,
+    ) -> Result<RepoResponse, DockerError> {
+        let digest = self.resolve_reference(image, reference).await?;
+        let Some(record) =
+            DBDockerManifest::get(self.0.id, image, &digest.to_string(), self.site.as_ref())
+                .await?
+        else {
+            return Err(DockerError::coded(
+                ErrorCode::ManifestUnknown,
+                format!("`{image}:{reference}` is not in this registry"),
+            ));
+        };
+
+        let path = Self::manifest_path(&digest)?;
+        let Some(StorageFile::File { meta, content }) =
+            self.storage.open_file(self.0.id, &path).await?
+        else {
+            // The row and the bytes disagree, which is a server-side inconsistency rather than a
+            // missing image, so it is worth a log rather than a silent 404.
+            warn!(%digest, image, "A recorded manifest has no stored bytes");
+            return Err(DockerError::coded(
+                ErrorCode::ManifestUnknown,
+                format!("the manifest for `{image}:{reference}` is missing from storage"),
+            ));
+        };
+
+        let mut response = ResponseBuilder::ok()
+            .header(CONTENT_TYPE, record.media_type.clone())
+            .header(CONTENT_LENGTH, record.size.to_string())
+            .header(DOCKER_CONTENT_DIGEST_HEADER.clone(), digest.to_string())
+            .header(
+                DOCKER_API_VERSION_HEADER.clone(),
+                DOCKER_API_VERSION_VALUE.clone(),
+            );
+        // A `HEAD` must carry exactly the headers the `GET` would, and no body. Clients use it to
+        // resolve a tag to a digest without transferring the manifest.
+        if head_only {
+            let _ = meta;
+            return Ok(RepoResponse::Other(response.empty()));
+        }
+        response = response.header("accept-ranges", "none");
+        let bytes = read_all(content).await?;
+        Ok(RepoResponse::Other(response.body(bytes)))
+    }
+
+    /// A tag resolves through `project_versions`; a digest is taken as given.
+    async fn resolve_reference(
+        &self,
+        image: &str,
+        reference: &Reference,
+    ) -> Result<Digest, DockerError> {
+        match reference {
+            Reference::Digest(digest) => Ok(digest.clone()),
+            Reference::Tag(tag) => {
+                let project = self.project_or_unknown(image).await?;
+                let Some(version) = self.get_project_version(project.id, tag).await? else {
+                    return Err(DockerError::coded(
+                        ErrorCode::ManifestUnknown,
+                        format!("`{image}` has no tag `{tag}`"),
+                    ));
+                };
+                let stored = self.stored_tag(&version)?;
+                Digest::parse(&stored.digest)
+                    .map_err(|error| DockerError::InvalidDigest(error.to_string()))
+            }
+        }
+    }
+
+    /// `GET`/`HEAD /v2/{name}/blobs/{digest}`.
+    #[instrument(skip(self))]
+    async fn read_blob(
+        &self,
+        image: &str,
+        digest: &Digest,
+        head_only: bool,
+    ) -> Result<RepoResponse, DockerError> {
+        let path = Self::blob_path(digest)?;
+        let Some(StorageFile::File { meta, content }) =
+            self.storage.open_file(self.0.id, &path).await?
+        else {
+            return Err(DockerError::coded(
+                ErrorCode::BlobUnknown,
+                format!("blob `{digest}` is not in this registry"),
+            ));
+        };
+        let size = meta.file_type().file_size;
+
+        let response = ResponseBuilder::ok()
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .header(CONTENT_LENGTH, size.to_string())
+            .header(DOCKER_CONTENT_DIGEST_HEADER.clone(), digest.to_string())
+            .header(
+                DOCKER_API_VERSION_HEADER.clone(),
+                DOCKER_API_VERSION_VALUE.clone(),
+            )
+            // Range requests on blobs are not implemented; saying so keeps a client from asking and
+            // then being handed the whole blob under a `206` it did not get.
+            .header("accept-ranges", "none");
+
+        if head_only {
+            return Ok(RepoResponse::Other(response.empty()));
+        }
+        Ok(RepoResponse::Other(response.body(read_all(content).await?)))
+    }
+
+    /// `GET /v2/{name}/tags/list`.
+    #[instrument(skip(self, parts))]
+    async fn tags_list(
+        &self,
+        origin: &Origin,
+        image: &str,
+        parts: &Parts,
+    ) -> Result<RepoResponse, DockerError> {
+        let project = self.project_or_unknown(image).await?;
+        let versions = DBProjectVersion::get_all_versions(project.id, self.site.as_ref()).await?;
+
+        // The spec orders tags lexically, and pages with `?n=` and `?last=`.
+        let mut tags: Vec<String> = versions
+            .into_iter()
+            .map(|version| version.version)
+            .collect();
+        tags.sort();
+        let query: PageQuery = parts
+            .uri
+            .query()
+            .and_then(|query| serde_urlencoded::from_str(query).ok())
+            .unwrap_or_default();
+        let tags = paginate(tags, &query);
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::ok()
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                // `name` echoes the repository the client asked about, so it has to be spelled the
+                // way the client spelled it — prefix included in prefix mode.
+                .json(&serde_json::json!({ "name": origin.image_name(image), "tags": tags })),
+        ))
+    }
+
+    /// `GET /v2/_catalog`.
+    #[instrument(skip(self, parts))]
+    async fn catalog(&self, origin: &Origin, parts: &Parts) -> Result<RepoResponse, DockerError> {
+        let stored: Vec<String> =
+            sqlx::query_scalar("SELECT key FROM projects WHERE repository_id = $1 ORDER BY key")
+                .bind(self.0.id)
+                .fetch_all(self.site.as_ref())
+                .await?;
+        // Listed the way they would be pulled, so a name copied out of the catalog works verbatim.
+        let mut names: Vec<String> = stored
+            .into_iter()
+            .map(|name| origin.image_name(&name))
+            .collect();
+        names.sort();
+
+        let query: PageQuery = parts
+            .uri
+            .query()
+            .and_then(|query| serde_urlencoded::from_str(query).ok())
+            .unwrap_or_default();
+        let names = paginate(names, &query);
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::ok()
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .json(&serde_json::json!({ "repositories": names })),
+        ))
+    }
+
+    /// `GET /v2/{name}/referrers/{digest}`.
+    ///
+    /// Answers `200` with an empty index when nothing refers to the subject — the spec is explicit
+    /// that an unknown subject is not a 404 here, because a client uses this to *discover* whether
+    /// anything exists.
+    #[instrument(skip(self))]
+    async fn referrers(&self, image: &str, subject: &Digest) -> Result<RepoResponse, DockerError> {
+        let found =
+            DBDockerManifest::referrers(self.0.id, image, &subject.to_string(), self.site.as_ref())
+                .await?;
+
+        let manifests: Vec<serde_json::Value> = found
+            .into_iter()
+            .map(|record| {
+                serde_json::json!({
+                    "mediaType": record.media_type,
+                    "digest": record.digest,
+                    "size": record.size,
+                    "artifactType": record.artifact_type,
+                })
+            })
+            .collect();
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::ok()
+                .header(CONTENT_TYPE, super::types::manifest::MEDIA_TYPE_OCI_INDEX)
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .json(&serde_json::json!({
+                    "schemaVersion": 2,
+                    "mediaType": super::types::manifest::MEDIA_TYPE_OCI_INDEX,
+                    "manifests": manifests,
+                })),
+        ))
+    }
+
+    // ---- uploads -----------------------------------------------------------------------------
+
+    /// `POST /v2/{name}/blobs/uploads/`.
+    #[instrument(skip(self, request))]
+    async fn start_upload(
+        &self,
+        request: RepositoryRequest,
+        image: &str,
+    ) -> Result<RepoResponse, DockerError> {
+        let origin = Origin::of(&request.parts, &request.path);
+        self.require_write(
+            &request.authentication,
+            &request.parts,
+            &origin.image_name(image),
+        )
+        .await?;
+
+        let query: UploadQuery = request
+            .parts
+            .uri
+            .query()
+            .and_then(|query| serde_urlencoded::from_str(query).ok())
+            .unwrap_or_default();
+
+        // Cross-repository mount. Not supported, and the spec says to fall back to a normal upload
+        // rather than to fail — the client then pushes the blob it wanted to borrow.
+        if query.mount.is_some() {
+            debug!("Ignoring a cross-repository mount and starting a normal upload");
+        } else if let Some(raw) = &query.digest {
+            // Monolithic upload: the whole blob came with the POST.
+            let digest = Digest::parse(raw)
+                .map_err(|error| DockerError::InvalidDigest(error.to_string()))?;
+            let body = request.body.body_as_bytes().await?;
+            return self.commit_blob(&origin, image, &digest, body).await;
+        }
+
+        let id = self
+            .site
+            .docker_uploads
+            .start(self.0.id, image)
+            .await
+            .map_err(DockerError::Upload)?;
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::default()
+                .status(StatusCode::ACCEPTED)
+                .header(LOCATION, origin.url(image, &format!("blobs/uploads/{id}")))
+                .header(RANGE, "0-0")
+                .header(CONTENT_LENGTH, "0")
+                .header(DOCKER_UPLOAD_UUID_HEADER.clone(), id.to_string())
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .empty(),
+        ))
+    }
+
+    /// `PATCH /v2/{name}/blobs/uploads/{uuid}`.
+    #[instrument(skip(self, request))]
+    async fn append_upload(
+        &self,
+        request: RepositoryRequest,
+        image: &str,
+        id: Uuid,
+    ) -> Result<RepoResponse, DockerError> {
+        let origin = Origin::of(&request.parts, &request.path);
+        self.require_write(
+            &request.authentication,
+            &request.parts,
+            &origin.image_name(image),
+        )
+        .await?;
+
+        let start = content_range_start(&request.parts);
+        let body = request.body.body_as_bytes().await?;
+        let offset = self
+            .site
+            .docker_uploads
+            .append(id, self.0.id, start, body)
+            .await
+            .map_err(DockerError::Upload)?;
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::default()
+                .status(StatusCode::ACCEPTED)
+                .header(LOCATION, origin.url(image, &format!("blobs/uploads/{id}")))
+                // Inclusive, so an upload of n bytes reports `0-(n-1)`. An empty one reports `0-0`,
+                // which is what the spec's own example does.
+                .header(RANGE, format!("0-{}", offset.saturating_sub(1)))
+                .header(CONTENT_LENGTH, "0")
+                .header(DOCKER_UPLOAD_UUID_HEADER.clone(), id.to_string())
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .empty(),
+        ))
+    }
+
+    /// `PUT /v2/{name}/blobs/uploads/{uuid}?digest=`.
+    #[instrument(skip(self, request))]
+    async fn finish_upload(
+        &self,
+        request: RepositoryRequest,
+        image: &str,
+        id: Uuid,
+    ) -> Result<RepoResponse, DockerError> {
+        let origin = Origin::of(&request.parts, &request.path);
+        self.require_write(
+            &request.authentication,
+            &request.parts,
+            &origin.image_name(image),
+        )
+        .await?;
+
+        let query: UploadQuery = request
+            .parts
+            .uri
+            .query()
+            .and_then(|query| serde_urlencoded::from_str(query).ok())
+            .unwrap_or_default();
+        let Some(raw) = query.digest else {
+            return Err(DockerError::coded(
+                ErrorCode::DigestInvalid,
+                "committing an upload requires a `digest` query parameter",
+            ));
+        };
+        let digest =
+            Digest::parse(&raw).map_err(|error| DockerError::InvalidDigest(error.to_string()))?;
+
+        // A commit may carry the last chunk in its body.
+        let start = content_range_start(&request.parts);
+        let body = request.body.body_as_bytes().await?;
+        if !body.is_empty() {
+            self.site
+                .docker_uploads
+                .append(id, self.0.id, start, body)
+                .await
+                .map_err(DockerError::Upload)?;
+        }
+
+        // Verified against the digest the client committed under; a mismatch closes the session and
+        // nothing reaches storage.
+        let bytes = self
+            .site
+            .docker_uploads
+            .finish(id, self.0.id, &digest)
+            .await
+            .map_err(DockerError::Upload)?;
+
+        self.commit_blob(&origin, image, &digest, bytes).await
+    }
+
+    /// Writes a verified blob and answers the `201` a client expects.
+    async fn commit_blob(
+        &self,
+        origin: &Origin,
+        image: &str,
+        digest: &Digest,
+        bytes: Bytes,
+    ) -> Result<RepoResponse, DockerError> {
+        if !digest.matches(&bytes) {
+            return Err(DockerError::coded(
+                ErrorCode::DigestInvalid,
+                format!(
+                    "the uploaded content is `{}`, but the request committed it as `{digest}`",
+                    Digest::of(digest.algorithm(), &bytes)
+                ),
+            ));
+        }
+        let path = Self::blob_path(digest)?;
+        self.storage
+            .save_file(self.0.id, FileContent::Bytes(bytes), &path)
+            .await?;
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::created()
+                .header(LOCATION, origin.url(image, &format!("blobs/{digest}")))
+                .header(CONTENT_LENGTH, "0")
+                .header(DOCKER_CONTENT_DIGEST_HEADER.clone(), digest.to_string())
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .empty(),
+        ))
+    }
+
+    // ---- manifest push -----------------------------------------------------------------------
+
+    /// `PUT /v2/{name}/manifests/{reference}` — the commit that makes an image pullable.
+    #[instrument(skip(self, request))]
+    async fn put_manifest(
+        &self,
+        request: RepositoryRequest,
+        image: &str,
+        reference: Reference,
+    ) -> Result<RepoResponse, DockerError> {
+        let origin = Origin::of(&request.parts, &request.path);
+        let publisher = self
+            .require_write(
+                &request.authentication,
+                &request.parts,
+                &origin.image_name(image),
+            )
+            .await?;
+
+        let media_type = request
+            .parts
+            .headers
+            .get(CONTENT_TYPE)
+            .and_then(|value| value.to_str().ok())
+            .map(|value| value.split(';').next().unwrap_or(value).trim().to_owned())
+            .unwrap_or_else(|| DEFAULT_MANIFEST_MEDIA_TYPE.to_owned());
+
+        let bytes = request.body.body_as_bytes().await?;
+        if bytes.is_empty() {
+            return Err(DockerError::coded(
+                ErrorCode::ManifestInvalid,
+                "the manifest body is empty",
+            ));
+        }
+        let manifest: Manifest = serde_json::from_slice(&bytes).map_err(|error| {
+            DockerError::coded(
+                ErrorCode::ManifestInvalid,
+                format!("the manifest will not parse: {error}"),
+            )
+        })?;
+
+        // The digest is over the bytes exactly as they arrived, so they are stored and re-served
+        // verbatim. Re-serialising would give the same manifest a different identity, and every
+        // client that pinned the old digest would stop resolving.
+        let digest = Digest::sha256_of(&bytes);
+        if let Reference::Digest(claimed) = &reference
+            && claimed != &digest
+        {
+            return Err(DockerError::coded(
+                ErrorCode::DigestInvalid,
+                format!("the manifest hashes to `{digest}`, but was pushed as `{claimed}`"),
+            ));
+        }
+
+        // Everything a manifest points at must already be here. Without this a push can succeed and
+        // every pull of it then fail on a missing layer, with nothing to say which push was at
+        // fault.
+        if is_index(&media_type) {
+            for child in manifest.child_manifests() {
+                if !DBDockerManifest::exists(
+                    self.0.id,
+                    image,
+                    &child.to_string(),
+                    self.site.as_ref(),
+                )
+                .await?
+                {
+                    return Err(DockerError::coded(
+                        ErrorCode::ManifestBlobUnknown,
+                        format!("the index refers to manifest `{child}`, which is not here yet"),
+                    ));
+                }
+            }
+        } else {
+            for blob in manifest.required_blobs() {
+                let path = Self::blob_path(blob)?;
+                if !self.storage.file_exists(self.0.id, &path).await? {
+                    return Err(DockerError::coded(
+                        ErrorCode::ManifestBlobUnknown,
+                        format!("the manifest refers to blob `{blob}`, which is not here yet"),
+                    ));
+                }
+            }
+        }
+
+        let size = bytes.len() as i64;
+        let path = Self::manifest_path(&digest)?;
+        self.storage
+            .save_file(self.0.id, FileContent::Bytes(bytes), &path)
+            .await?;
+
+        DBDockerManifest::upsert(
+            self.0.id,
+            image,
+            &digest.to_string(),
+            &media_type,
+            size,
+            manifest
+                .subject
+                .as_ref()
+                .map(|subject| subject.digest.to_string())
+                .as_deref(),
+            manifest.artifact_type.as_deref(),
+            self.site.as_ref(),
+        )
+        .await?;
+
+        // Only a tag becomes a version. An untagged manifest — the per-platform child of an index,
+        // or a referrers artifact — is reachable by digest and recorded above, but it is not
+        // something to show on a project page.
+        if let Reference::Tag(tag) = &reference {
+            self.record_tag(image, tag, &digest, &media_type, size, &manifest, publisher)
+                .await?;
+        }
+
+        debug!(image, %reference, %digest, "Accepted a manifest");
+        Ok(RepoResponse::Other(
+            ResponseBuilder::created()
+                .header(
+                    LOCATION,
+                    origin.url(image, &format!("manifests/{reference}")),
+                )
+                .header(CONTENT_LENGTH, "0")
+                .header(DOCKER_CONTENT_DIGEST_HEADER.clone(), digest.to_string())
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .empty(),
+        ))
+    }
+
+    /// Points a tag at a manifest, as a project version.
+    ///
+    /// Re-tagging is normal — `:latest` moves with every push — so an existing tag is updated in
+    /// place rather than refused, which is the opposite of what npm and Cargo do with a version.
+    #[allow(clippy::too_many_arguments)]
+    async fn record_tag(
+        &self,
+        image: &str,
+        tag: &str,
+        digest: &Digest,
+        media_type: &str,
+        size: i64,
+        manifest: &Manifest,
+        publisher: i32,
+    ) -> Result<(), DockerError> {
+        let project = self.get_or_create_project(image, publisher).await?;
+        let stored = StoredTag {
+            digest: digest.to_string(),
+            media_type: media_type.to_owned(),
+            size,
+            platforms: manifest.platforms(),
+        };
+        let extra = VersionData {
+            extra: Some(serde_json::to_value(&stored)?),
+            ..Default::default()
+        };
+
+        match self.get_project_version(project.id, tag).await? {
+            Some(existing) => {
+                UpdateProjectVersion {
+                    extra: Some(extra),
+                    publisher: Some(Some(publisher)),
+                    ..Default::default()
+                }
+                .update(existing.id, self.site.as_ref())
+                .await?;
+            }
+            None => {
+                let mut version_path = StoragePath::parse("manifests")?;
+                let (algorithm, hex) = digest.path_components();
+                version_path.push_mut(algorithm);
+                version_path.push_mut(hex);
+                NewVersion {
+                    project_id: project.id,
+                    version: tag.to_owned(),
+                    release_type: ReleaseType::release_type_from_version(tag),
+                    version_path: version_path.to_string(),
+                    publisher: Some(publisher),
+                    version_page: None,
+                    extra,
+                }
+                .insert(self.site.as_ref())
+                .await?;
+            }
+        }
+        Ok(())
+    }
+
+    async fn get_or_create_project(
+        &self,
+        image: &str,
+        publisher: i32,
+    ) -> Result<DBProject, DockerError> {
+        if let Some(project) =
+            DBProject::find_by_project_key(image, self.0.id, self.site.as_ref()).await?
+        {
+            return Ok(project);
+        }
+        // The image name is the project key. `library/alpine` keeps its slash in the key and
+        // becomes a nested storage path, which is what makes `_catalog` read back the name that was
+        // pushed.
+        let (scope, name) = match image.rsplit_once('/') {
+            Some((scope, name)) => (Some(scope.to_owned()), name.to_owned()),
+            None => (None, image.to_owned()),
+        };
+        let mut storage_path = StoragePath::parse("images")?;
+        for component in image.split('/') {
+            storage_path.push_mut(component);
+        }
+        let project = NewProject {
+            scope,
+            project_key: image.to_owned(),
+            name,
+            description: None,
+            repository: self.0.id,
+            storage_path: storage_path.to_string(),
+        }
+        .insert(self.site.as_ref())
+        .await?;
+        NewProjectMember::new_owner(publisher, project.id)
+            .insert_no_return(self.site.as_ref())
+            .await?;
+        info!(image, "Created a new image");
+        Ok(project)
+    }
+
+    // ---- deletes -----------------------------------------------------------------------------
+
+    #[instrument(skip(self, authentication))]
+    async fn delete_manifest(
+        &self,
+        authentication: &RepositoryAuthentication,
+        parts: &Parts,
+        origin: &Origin,
+        image: &str,
+        reference: &Reference,
+    ) -> Result<RepoResponse, DockerError> {
+        self.require_write(authentication, parts, &origin.image_name(image))
+            .await?;
+
+        match reference {
+            // Deleting a tag removes the pointer, not the manifest — another tag or a digest pull
+            // may still want it.
+            Reference::Tag(tag) => {
+                let project = self.project_or_unknown(image).await?;
+                let Some(version) = self.get_project_version(project.id, tag).await? else {
+                    return Err(DockerError::coded(
+                        ErrorCode::ManifestUnknown,
+                        format!("`{image}` has no tag `{tag}`"),
+                    ));
+                };
+                DBProjectVersion::delete_by_id(version.id, self.site.as_ref()).await?;
+            }
+            Reference::Digest(digest) => {
+                let removed = DBDockerManifest::delete(
+                    self.0.id,
+                    image,
+                    &digest.to_string(),
+                    self.site.as_ref(),
+                )
+                .await?;
+                if !removed {
+                    return Err(DockerError::coded(
+                        ErrorCode::ManifestUnknown,
+                        format!("manifest `{digest}` is not in this registry"),
+                    ));
+                }
+                let path = Self::manifest_path(digest)?;
+                self.storage.delete_file(self.0.id, &path).await?;
+
+                // Any tag still aimed at it would resolve to bytes that are gone, and every pull
+                // would 404 on a manifest the tag list still advertises.
+                if let Some(project) =
+                    DBProject::find_by_project_key(image, self.0.id, self.site.as_ref()).await?
+                {
+                    self.remove_tags_pointing_at(project.id, &digest.to_string())
+                        .await?;
+                }
+            }
+        }
+
+        Ok(RepoResponse::Other(
+            ResponseBuilder::default()
+                .status(StatusCode::ACCEPTED)
+                .header(CONTENT_LENGTH, "0")
+                .header(
+                    DOCKER_API_VERSION_HEADER.clone(),
+                    DOCKER_API_VERSION_VALUE.clone(),
+                )
+                .empty(),
+        ))
+    }
+
+    async fn remove_tags_pointing_at(
+        &self,
+        project: Uuid,
+        digest: &str,
+    ) -> Result<(), DockerError> {
+        let versions = DBProjectVersion::get_all_versions(project, self.site.as_ref()).await?;
+        for version in versions {
+            let Ok(stored) = self.stored_tag(&version) else {
+                continue;
+            };
+            if stored.digest == digest {
+                DBProjectVersion::delete_by_id(version.id, self.site.as_ref()).await?;
+            }
+        }
+        Ok(())
+    }
+
+    // ---- helpers -----------------------------------------------------------------------------
+
+    async fn project_or_unknown(&self, image: &str) -> Result<DBProject, DockerError> {
+        self.get_project_from_key(image).await?.ok_or_else(|| {
+            DockerError::coded(
+                ErrorCode::NameUnknown,
+                format!("`{image}` is not in this registry"),
+            )
+        })
+    }
+
+    fn stored_tag(&self, version: &DBProjectVersion) -> Result<StoredTag, DockerError> {
+        let Some(extra) = version.extra.0.extra.clone() else {
+            return Err(DockerError::coded(
+                ErrorCode::ManifestUnknown,
+                format!("the tag `{}` has no recorded manifest", version.version),
+            ));
+        };
+        serde_json::from_value(extra).map_err(|error| {
+            DockerError::coded(
+                ErrorCode::ManifestUnknown,
+                format!(
+                    "the recorded manifest for `{}` will not parse: {error}",
+                    version.version
+                ),
+            )
+        })
+    }
+}
+
+/// Where the client thinks this registry lives.
+///
+/// A repository is reachable two ways, and the two disagree about what the image is called. On a
+/// custom domain the client wrote `alpine`; in prefix mode it wrote `local/docker/alpine` and the
+/// routing layer stripped the first two segments off before the handler ever saw them.
+///
+/// Every URL and every scope the registry hands back has to use the client's spelling. A `Location`
+/// of `/v2/alpine/blobs/uploads/{id}` sent to a client that asked for `/v2/local/docker/alpine/...`
+/// points at nothing, and the next `PATCH` 404s — which is exactly what happened before this
+/// existed.
+#[derive(Debug)]
+struct Origin {
+    /// The path prefix up to and including `/v2`, with no trailing slash.
+    base: String,
+}
+
+impl Origin {
+    /// Recovers the prefix by subtracting the path the handler was given from the path the client
+    /// sent. Those differ by exactly the segments the routing layer consumed.
+    fn of(parts: &Parts, path: &StoragePath) -> Self {
+        // Both sides are trimmed of slashes before comparing: `StoragePath` only keeps a trailing
+        // slash when the last component looks like a directory, so `/v2/x/y/blobs/uploads/` and
+        // `x/y/blobs/uploads` describe the same request and must still line up.
+        let full = parts.uri.path().trim_end_matches('/');
+        let stripped = path.to_string();
+        let stripped = stripped.trim_matches('/');
+
+        let base = if stripped.is_empty() {
+            full.to_owned()
+        } else {
+            match full.strip_suffix(stripped) {
+                Some(prefix) => prefix.trim_end_matches('/').to_owned(),
+                // Percent-encoding in the URI would make the two disagree. Falling back to the bare
+                // mount point is right for a custom domain and wrong for prefix mode, but it beats
+                // emitting a `Location` built from a prefix that does not match.
+                None => "/v2".to_owned(),
+            }
+        };
+        Self { base }
+    }
+
+    /// The image name as the client wrote it, prefix included.
+    fn image_name(&self, image: &str) -> String {
+        let prefix = self
+            .base
+            .strip_prefix("/v2")
+            .unwrap_or_default()
+            .trim_matches('/');
+        if prefix.is_empty() {
+            image.to_owned()
+        } else {
+            format!("{prefix}/{image}")
+        }
+    }
+
+    fn url(&self, image: &str, suffix: &str) -> String {
+        format!("{}/{image}/{suffix}", self.base)
+    }
+}
+
+/// What a Docker tag carries in `project_versions.extra`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct StoredTag {
+    digest: String,
+    media_type: String,
+    size: i64,
+    #[serde(default)]
+    platforms: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct UploadQuery {
+    digest: Option<String>,
+    /// The digest a client wants to mount from another repository. Read only to notice the attempt
+    /// and fall back to a normal upload; `from` (the source repository) is deliberately not
+    /// captured, because nothing here acts on it.
+    mount: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PageQuery {
+    n: Option<usize>,
+    last: Option<String>,
+}
+
+/// Applies the spec's `?n=` / `?last=` paging to an already-sorted list.
+fn paginate(items: Vec<String>, query: &PageQuery) -> Vec<String> {
+    let size = query.n.unwrap_or(DEFAULT_PAGE_SIZE).clamp(1, MAX_PAGE_SIZE);
+    let start = match &query.last {
+        // `last` is exclusive: the page begins at the first entry *after* it.
+        Some(last) => items.partition_point(|item| item <= last),
+        None => 0,
+    };
+    items.into_iter().skip(start).take(size).collect()
+}
+
+/// The first byte offset a `Content-Range: {start}-{end}` header claims.
+///
+/// Absent on a monolithic `PATCH`, which is what Docker and BuildKit send in the common case, so a
+/// missing header means "continue wherever the upload is" rather than an error.
+fn content_range_start(parts: &Parts) -> Option<u64> {
+    let value = parts.headers.get(CONTENT_RANGE)?.to_str().ok()?;
+    let (start, _) = value.trim().split_once('-')?;
+    start.trim().parse().ok()
+}
+
+async fn read_all(content: nr_storage::StorageFileReader) -> Result<Vec<u8>, DockerError> {
+    use tokio::io::AsyncReadExt;
+    let mut reader = content;
+    let mut bytes = Vec::new();
+    reader.read_to_end(&mut bytes).await?;
+    Ok(bytes)
+}
+
+impl RepositoryExt for DockerHostedRegistry {}
+
+impl Repository for DockerHostedRegistry {
+    type Error = DockerError;
+
+    fn get_storage(&self) -> DynStorage {
+        self.0.storage.clone()
+    }
+
+    fn site(&self) -> NitroRepo {
+        self.0.site.clone()
+    }
+
+    fn get_type(&self) -> &'static str {
+        "docker"
+    }
+
+    fn full_type(&self) -> &'static str {
+        "docker/hosted"
+    }
+
+    fn config_types(&self) -> Vec<&str> {
+        vec![
+            DockerRegistryConfigType::get_type_static(),
+            RepositoryPageType::get_type_static(),
+            ProjectConfigType::get_type_static(),
+        ]
+    }
+
+    fn name(&self) -> String {
+        self.0.name.clone()
+    }
+
+    fn id(&self) -> Uuid {
+        self.0.id
+    }
+
+    fn visibility(&self) -> Visibility {
+        *self.0.visibility.read()
+    }
+
+    fn is_active(&self) -> bool {
+        self.0.active.load(atomic::Ordering::Relaxed)
+    }
+
+    #[instrument(fields(repository_type = "docker/hosted"))]
+    async fn reload(&self) -> Result<(), RepositoryFactoryError> {
+        let Some(repository) = DBRepository::get_by_id(self.0.id, self.site.as_ref()).await? else {
+            warn!("Repository no longer exists");
+            self.0.active.store(false, atomic::Ordering::Relaxed);
+            return Ok(());
+        };
+        self.0
+            .active
+            .store(repository.active, atomic::Ordering::Relaxed);
+        *self.0.visibility.write() = repository.visibility;
+        Ok(())
+    }
+
+    async fn handle_get(&self, request: RepositoryRequest) -> Result<RepoResponse, DockerError> {
+        self.handle_read(request, false).await
+    }
+
+    /// `HEAD` is how a client checks whether a blob or manifest is already here before pushing it,
+    /// so it is answered with the same headers as the `GET` and an empty body. The default trait
+    /// implementation returns 405, which would make every push re-upload every layer.
+    async fn handle_head(&self, request: RepositoryRequest) -> Result<RepoResponse, DockerError> {
+        self.handle_read(request, true).await
+    }
+
+    async fn handle_post(&self, request: RepositoryRequest) -> Result<RepoResponse, DockerError> {
+        match DockerPath::parse(&request.path)? {
+            DockerPath::UploadStart { name } => self.start_upload(request, &name).await,
+            other => {
+                debug!(?other, "Route is not a POST");
+                Err(DockerError::coded(
+                    ErrorCode::Unsupported,
+                    "this route does not accept POST",
+                ))
+            }
+        }
+    }
+
+    async fn handle_patch(&self, request: RepositoryRequest) -> Result<RepoResponse, DockerError> {
+        match DockerPath::parse(&request.path)? {
+            DockerPath::UploadChunk { name, uuid } => {
+                self.append_upload(request, &name, uuid).await
+            }
+            other => {
+                debug!(?other, "Route is not a PATCH");
+                Err(DockerError::coded(
+                    ErrorCode::Unsupported,
+                    "this route does not accept PATCH",
+                ))
+            }
+        }
+    }
+
+    async fn handle_put(&self, request: RepositoryRequest) -> Result<RepoResponse, DockerError> {
+        match DockerPath::parse(&request.path)? {
+            DockerPath::UploadChunk { name, uuid } => {
+                self.finish_upload(request, &name, uuid).await
+            }
+            DockerPath::Manifest { name, reference } => {
+                self.put_manifest(request, &name, reference).await
+            }
+            other => {
+                debug!(?other, "Route is not a PUT");
+                Err(DockerError::coded(
+                    ErrorCode::Unsupported,
+                    "this route does not accept PUT",
+                ))
+            }
+        }
+    }
+
+    async fn handle_delete(&self, request: RepositoryRequest) -> Result<RepoResponse, DockerError> {
+        let origin = Origin::of(&request.parts, &request.path);
+        match DockerPath::parse(&request.path)? {
+            DockerPath::Manifest { name, reference } => {
+                self.delete_manifest(
+                    &request.authentication,
+                    &request.parts,
+                    &origin,
+                    &name,
+                    &reference,
+                )
+                .await
+            }
+            DockerPath::UploadChunk { name, uuid } => {
+                self.require_write(
+                    &request.authentication,
+                    &request.parts,
+                    &origin.image_name(&name),
+                )
+                .await?;
+                self.site
+                    .docker_uploads
+                    .cancel(uuid, self.0.id)
+                    .await
+                    .map_err(DockerError::Upload)?;
+                Ok(RepoResponse::Other(
+                    ResponseBuilder::default()
+                        .status(StatusCode::NO_CONTENT)
+                        .empty(),
+                ))
+            }
+            // Deleting a blob would corrupt every other manifest that shares it — layers are
+            // content-addressed and nothing reference-counts them. Refused rather than silently
+            // breaking images that were fine a moment ago.
+            DockerPath::Blob { .. } => Err(DockerError::coded(
+                ErrorCode::Unsupported,
+                "this registry does not support deleting blobs; delete the manifest instead",
+            )),
+            other => {
+                debug!(?other, "Route is not a DELETE");
+                Err(DockerError::coded(
+                    ErrorCode::Unsupported,
+                    "this route does not accept DELETE",
+                ))
+            }
+        }
+    }
+}
+
+impl DockerHostedRegistry {
+    /// `GET` and `HEAD` differ only in whether a body is written, so they share this.
+    async fn handle_read(
+        &self,
+        request: RepositoryRequest,
+        head_only: bool,
+    ) -> Result<RepoResponse, DockerError> {
+        let route = DockerPath::parse(&request.path)?;
+        let origin = Origin::of(&request.parts, &request.path);
+
+        // The image, for the `scope` on a challenge, spelled the way the client wrote it. `/v2/`
+        // and `_catalog` name none.
+        let scope = match &route {
+            DockerPath::Manifest { name, .. }
+            | DockerPath::Blob { name, .. }
+            | DockerPath::TagsList { name }
+            | DockerPath::Referrers { name, .. }
+            | DockerPath::UploadStart { name }
+            | DockerPath::UploadChunk { name, .. } => Some(origin.image_name(name)),
+            DockerPath::Base | DockerPath::Catalog => None,
+        };
+        if let Some(denied) = self
+            .check_read(&request.authentication, &request.parts, scope)
+            .await?
+        {
+            return Err(denied);
+        }
+
+        match route {
+            // The version check `docker login` and every client start with.
+            DockerPath::Base => Ok(RepoResponse::Other(
+                ResponseBuilder::ok()
+                    .header(
+                        DOCKER_API_VERSION_HEADER.clone(),
+                        DOCKER_API_VERSION_VALUE.clone(),
+                    )
+                    .json(&serde_json::json!({})),
+            )),
+            DockerPath::Catalog => self.catalog(&origin, &request.parts).await,
+            DockerPath::TagsList { name } => self.tags_list(&origin, &name, &request.parts).await,
+            DockerPath::Manifest { name, reference } => {
+                self.read_manifest(&name, &reference, head_only).await
+            }
+            DockerPath::Blob { name, digest } => self.read_blob(&name, &digest, head_only).await,
+            DockerPath::Referrers { name, digest } => self.referrers(&name, &digest).await,
+            // A status request on an in-progress upload.
+            DockerPath::UploadChunk { name, uuid } => {
+                self.require_write(
+                    &request.authentication,
+                    &request.parts,
+                    &origin.image_name(&name),
+                )
+                .await?;
+                let offset = self
+                    .site
+                    .docker_uploads
+                    .offset(uuid, self.0.id)
+                    .map_err(DockerError::Upload)?;
+                Ok(RepoResponse::Other(
+                    ResponseBuilder::default()
+                        .status(StatusCode::NO_CONTENT)
+                        .header(
+                            LOCATION,
+                            origin.url(&name, &format!("blobs/uploads/{uuid}")),
+                        )
+                        .header(RANGE, format!("0-{}", offset.saturating_sub(1)))
+                        .header(DOCKER_UPLOAD_UUID_HEADER.clone(), uuid.to_string())
+                        .empty(),
+                ))
+            }
+            DockerPath::UploadStart { .. } => Err(DockerError::coded(
+                ErrorCode::Unsupported,
+                "an upload is opened with POST",
+            )),
+        }
+    }
+}
+
+/// Present so the unused import of [`HeaderValue`] is not silently load-bearing elsewhere.
+const _: Option<HeaderValue> = None;
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderMap, HeaderValue, Request, header::CONTENT_RANGE};
+
+    use super::{PageQuery, content_range_start, paginate};
+
+    fn page(n: Option<usize>, last: Option<&str>) -> PageQuery {
+        PageQuery {
+            n,
+            last: last.map(ToOwned::to_owned),
+        }
+    }
+
+    fn items() -> Vec<String> {
+        ["a", "b", "c", "d", "e"]
+            .into_iter()
+            .map(ToOwned::to_owned)
+            .collect()
+    }
+
+    #[test]
+    fn paging_defaults_to_everything_up_to_the_page_size() {
+        assert_eq!(paginate(items(), &page(None, None)).len(), 5);
+        assert_eq!(paginate(items(), &page(Some(2), None)), vec!["a", "b"]);
+    }
+
+    /// `last` is exclusive — a page starting *at* it would repeat the entry the client already has.
+    #[test]
+    fn last_starts_the_page_after_it() {
+        assert_eq!(paginate(items(), &page(Some(2), Some("b"))), vec!["c", "d"]);
+        assert_eq!(
+            paginate(items(), &page(None, Some("e"))),
+            Vec::<String>::new()
+        );
+        // A `last` that is not in the list still positions correctly.
+        assert_eq!(paginate(items(), &page(Some(1), Some("bb"))), vec!["c"]);
+    }
+
+    #[test]
+    fn a_page_size_is_clamped_rather_than_trusted() {
+        assert_eq!(paginate(items(), &page(Some(0), None)).len(), 1);
+        assert_eq!(paginate(items(), &page(Some(usize::MAX), None)).len(), 5);
+    }
+
+    #[test]
+    fn a_content_range_start_is_read_when_present() {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_RANGE, HeaderValue::from_static("0-1023"));
+        let parts = parts_with(headers);
+        assert_eq!(content_range_start(&parts), Some(0));
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_RANGE, HeaderValue::from_static("1024-2047"));
+        let parts = parts_with(headers);
+        assert_eq!(content_range_start(&parts), Some(1024));
+    }
+
+    /// Docker and BuildKit send one unranged `PATCH` in the common case, so a missing header must
+    /// mean "continue where the upload is" rather than an error.
+    #[test]
+    fn a_missing_or_unparseable_content_range_is_treated_as_absent() {
+        assert_eq!(content_range_start(&parts_with(HeaderMap::new())), None);
+
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_RANGE, HeaderValue::from_static("nonsense"));
+        assert_eq!(content_range_start(&parts_with(headers)), None);
+    }
+
+    fn parts_with(headers: HeaderMap) -> http::request::Parts {
+        let mut request = Request::builder().uri("/").body(()).unwrap();
+        *request.headers_mut() = headers;
+        request.into_parts().0
+    }
+}

--- a/nitro_repo/src/repository/docker/mod.rs
+++ b/nitro_repo/src/repository/docker/mod.rs
@@ -1,0 +1,278 @@
+//! Docker Registry (OCI distribution) implementation.
+//!
+//! Speaks the v2 API a Docker daemon, containerd, BuildKit, `crane` and `skopeo` all use:
+//! <https://github.com/opencontainers/distribution-spec/blob/main/spec.md>.
+//!
+//! # Addressing
+//!
+//! A Docker client cannot be given a URL prefix — `docker pull host/x/y` always requests
+//! `https://host/v2/x/y/...`, and there is no setting that changes that. So unlike every other
+//! repository type, this one is not reachable only under `/repositories/{storage}/{repository}`.
+//! [`routing`] mounts `/v2` at the host root and resolves the repository two ways:
+//!
+//! * the request's `Host` is registered to a Docker repository — `docker pull
+//!   docker.example.com/alpine`;
+//! * otherwise the first two segments of the image name are the storage and repository — `docker
+//!   pull nitro.example.com/local/docker/alpine`.
+//!
+//! Both end up in [`dispatch_repository_request`](crate::repository::dispatch_repository_request),
+//! the same function the other two entry points use.
+//!
+//! # What is not here
+//!
+//! Pull-through caching of an upstream, blob garbage collection, blob deletes and cross-repository
+//! blob mounting. Each is called out on the documentation page rather than left to be discovered.
+
+use ahash::HashMap;
+use futures::future::BoxFuture;
+use hosted::DockerHostedRegistry;
+use http::{HeaderName, HeaderValue};
+use nr_core::{
+    database::entities::repository::{DBRepository, DBRepositoryConfig},
+    repository::config::{
+        RepositoryConfigType, project::ProjectConfigType, repository_page::RepositoryPageType,
+    },
+};
+use nr_macros::DynRepositoryHandler;
+use nr_storage::DynStorage;
+
+pub mod errors;
+pub mod hosted;
+pub mod routing;
+pub mod types;
+pub mod uploads;
+
+mod configs;
+pub use configs::*;
+pub use routing::v2_router;
+
+pub use super::prelude::*;
+use super::{DynRepository, NewRepository, RepositoryType, RepositoryTypeDescription};
+use crate::{
+    app::authentication::AuthenticationError,
+    repository::docker::{errors::ErrorCode, uploads::UploadError},
+    utils::{IntoErrorResponse, bad_request::BadRequestErrors},
+};
+
+/// Every response a registry sends carries this, and older clients use it to decide whether the
+/// endpoint speaks v2 at all.
+pub static DOCKER_API_VERSION_HEADER: HeaderName =
+    HeaderName::from_static("docker-distribution-api-version");
+pub static DOCKER_API_VERSION_VALUE: HeaderValue = HeaderValue::from_static("registry/2.0");
+/// The digest of the content in the response, which clients verify against.
+pub static DOCKER_CONTENT_DIGEST_HEADER: HeaderName =
+    HeaderName::from_static("docker-content-digest");
+pub static DOCKER_UPLOAD_UUID_HEADER: HeaderName = HeaderName::from_static("docker-upload-uuid");
+
+#[derive(Debug, Clone, DynRepositoryHandler)]
+#[repository_handler(error=DockerError)]
+pub enum DockerRegistry {
+    Hosted(hosted::DockerHostedRegistry),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DockerError {
+    /// Anything that maps cleanly onto one of the spec's error codes, which is most of them.
+    #[error("{message}")]
+    Coded { code: ErrorCode, message: String },
+    #[error("{0}")]
+    InvalidDigest(String),
+    #[error("{0}")]
+    Upload(#[from] UploadError),
+    /// The `401` that starts `docker login`: the body is an error envelope and the response also
+    /// carries a `WWW-Authenticate` challenge naming where to get a token.
+    #[error("authentication is required to access this registry")]
+    Challenge {
+        realm: String,
+        scope: Option<String>,
+    },
+    #[error("{0}")]
+    Other(Box<dyn IntoErrorResponse>),
+}
+
+impl DockerError {
+    pub fn coded(code: ErrorCode, message: impl Into<String>) -> Self {
+        Self::Coded {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+impl From<DockerError> for RepositoryHandlerError {
+    fn from(err: DockerError) -> Self {
+        RepositoryHandlerError::Other(Box::new(err))
+    }
+}
+
+macro_rules! impl_from_error_for_other {
+    ($t:ty) => {
+        impl From<$t> for DockerError {
+            fn from(e: $t) -> Self {
+                DockerError::Other(Box::new(e))
+            }
+        }
+    };
+}
+impl_from_error_for_other!(BadRequestErrors);
+impl_from_error_for_other!(sqlx::Error);
+impl_from_error_for_other!(nr_core::database::DBError);
+impl_from_error_for_other!(serde_json::Error);
+impl_from_error_for_other!(std::io::Error);
+impl_from_error_for_other!(AuthenticationError);
+impl_from_error_for_other!(RepositoryHandlerError);
+impl_from_error_for_other!(nr_storage::StorageError);
+
+/// A path this registry built itself, not one a client sent — every client-supplied component has
+/// already been through [`Digest::parse`](types::Digest::parse) or the image-name grammar. So this
+/// is a bug rather than a bad request, and `NameInvalid` is the closest code that says so.
+impl From<nr_core::storage::InvalidStoragePath> for DockerError {
+    fn from(error: nr_core::storage::InvalidStoragePath) -> Self {
+        DockerError::coded(ErrorCode::NameInvalid, error.to_string())
+    }
+}
+
+impl IntoErrorResponse for DockerError {
+    fn into_response_boxed(self: Box<Self>) -> Response {
+        self.into_response()
+    }
+}
+
+impl From<DockerError> for DynRepositoryHandlerError {
+    fn from(err: DockerError) -> Self {
+        DynRepositoryHandlerError(Box::new(err))
+    }
+}
+
+impl IntoResponse for DockerError {
+    fn into_response(self) -> Response {
+        match self {
+            DockerError::Coded { code, ref message } => errors::oci_error(code, message.clone()),
+            DockerError::InvalidDigest(ref message) => {
+                errors::oci_error(ErrorCode::DigestInvalid, message.clone())
+            }
+            DockerError::Upload(ref error) => {
+                let code = match error {
+                    UploadError::UnknownUpload(_) => ErrorCode::BlobUploadUnknown,
+                    UploadError::DigestMismatch { .. } => ErrorCode::DigestInvalid,
+                    UploadError::OutOfOrderChunk { .. } => ErrorCode::BlobUploadInvalid,
+                    // An IO failure buffering the upload is ours, not the client's, and a 4xx would
+                    // tell the client not to retry something a retry might well fix.
+                    UploadError::Io(_) => {
+                        return errors::oci_error_with_status(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            ErrorCode::BlobUploadInvalid,
+                            error.to_string(),
+                        );
+                    }
+                };
+                errors::oci_error(code, error.to_string())
+            }
+            DockerError::Challenge {
+                ref realm,
+                ref scope,
+            } => {
+                let mut challenge = format!("Bearer realm=\"{realm}\"");
+                if let Some(scope) = scope {
+                    challenge.push_str(&format!(",scope=\"{scope}\""));
+                }
+                let mut response = errors::oci_error_with_status(
+                    StatusCode::UNAUTHORIZED,
+                    ErrorCode::Unauthorized,
+                    self.to_string(),
+                );
+                if let Ok(value) = HeaderValue::from_str(&challenge) {
+                    response
+                        .headers_mut()
+                        .insert(http::header::WWW_AUTHENTICATE, value);
+                }
+                response
+            }
+            DockerError::Other(other) => other.into_response_boxed(),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct DockerRegistryType;
+
+impl RepositoryType for DockerRegistryType {
+    fn get_type(&self) -> &'static str {
+        "docker"
+    }
+
+    fn config_types(&self) -> Vec<&str> {
+        vec![
+            DockerRegistryConfigType::get_type_static(),
+            RepositoryPageType::get_type_static(),
+            ProjectConfigType::get_type_static(),
+        ]
+    }
+
+    fn get_description(&self) -> RepositoryTypeDescription {
+        RepositoryTypeDescription {
+            type_name: "docker",
+            name: "Docker",
+            description: "A Docker registry, speaking the OCI distribution API",
+            documentation_url: Some("https://nitro-repo.kingtux.dev/repositories/docker/"),
+            is_stable: true,
+            required_configs: vec![DockerRegistryConfigType::get_type_static()],
+        }
+    }
+
+    fn create_new(
+        &self,
+        name: String,
+        uuid: uuid::Uuid,
+        configs: HashMap<String, serde_json::Value>,
+        _storage: DynStorage,
+    ) -> BoxFuture<'static, Result<NewRepository, RepositoryFactoryError>> {
+        Box::pin(async move {
+            let sub_type = configs
+                .get(DockerRegistryConfigType::get_type_static())
+                .ok_or(RepositoryFactoryError::MissingConfig(
+                    DockerRegistryConfigType::get_type_static(),
+                ))?
+                .clone();
+            if let Err(err) = serde_json::from_value::<DockerRegistryConfig>(sub_type) {
+                return Err(RepositoryFactoryError::InvalidConfig(
+                    DockerRegistryConfigType::get_type_static(),
+                    err.to_string(),
+                ));
+            }
+            Ok(NewRepository {
+                name,
+                uuid,
+                repository_type: "docker".to_string(),
+                configs,
+            })
+        })
+    }
+
+    fn load_repo(
+        &self,
+        repo: DBRepository,
+        storage: DynStorage,
+        website: NitroRepo,
+    ) -> BoxFuture<'static, Result<DynRepository, RepositoryFactoryError>> {
+        Box::pin(async move {
+            let Some(config) = DBRepositoryConfig::<DockerRegistryConfig>::get_config(
+                repo.id,
+                DockerRegistryConfigType::get_type_static(),
+                &website.database,
+            )
+            .await?
+            else {
+                return Err(RepositoryFactoryError::MissingConfig(
+                    DockerRegistryConfigType::get_type_static(),
+                ));
+            };
+            match config.value.0 {
+                DockerRegistryConfig::Hosted => {
+                    let hosted = DockerHostedRegistry::load(website, storage, repo).await?;
+                    Ok(DockerRegistry::Hosted(hosted).into())
+                }
+            }
+        })
+    }
+}

--- a/nitro_repo/src/repository/docker/routing.rs
+++ b/nitro_repo/src/repository/docker/routing.rs
@@ -1,0 +1,249 @@
+//! `/v2` at the host root.
+//!
+//! Every other repository type is reachable only under `/repositories/{storage}/{repository}`,
+//! because every other client can be told a URL. A Docker client cannot: `docker pull host/x/y`
+//! requests `https://host/v2/x/y/manifests/...` and there is no configuration that adds a prefix.
+//!
+//! So this router is mounted at the host root, *after* `/repositories`, `/api` and `/badge` and
+//! *before* the host-routing fallback. It resolves the repository in two ways, in this order:
+//!
+//! 1. **By host.** The request arrived on a hostname registered to a Docker repository, so the
+//!    whole path after `/v2` is the Docker sub-path and image names need no prefix:
+//!    `docker pull docker.example.com/alpine`.
+//! 2. **By name prefix.** The first two segments of the image name are the storage and the
+//!    repository: `docker pull nitro.example.com/local/docker/alpine`.
+//!
+//! A host that resolves to a repository which is *not* a Docker one falls through to the normal
+//! host dispatch, so an artifact whose path happens to begin with `v2/` is still served over a
+//! custom domain — `/v2` does not become a fourth entry in the "cannot be served over a custom
+//! domain" list in [`host_routing`](crate::app::host_routing).
+
+use axum::{
+    Router,
+    extract::{FromRequestParts, Request, State},
+    response::{IntoResponse, Response},
+    routing::any,
+};
+use http::{HeaderMap, Uri};
+use nr_core::storage::StoragePath;
+use percent_encoding::percent_decode_str;
+use tracing::{Span, debug};
+
+use super::{DockerError, errors::ErrorCode};
+use crate::{
+    app::{NitroRepo, RepositoryStorageName, host_routing::request_host},
+    repository::{
+        DynRepository, Repository, RepositoryAuthentication, dispatch_repository_request,
+    },
+    utils::request_logging::request_span::RequestSpan,
+};
+
+pub fn v2_router() -> Router<NitroRepo> {
+    Router::new()
+        .route("/v2", any(handle_v2))
+        .route("/v2/", any(handle_v2))
+        .route("/v2/{*path}", any(handle_v2))
+}
+
+async fn handle_v2(State(site): State<NitroRepo>, request: Request) -> Response {
+    // The URI path is still percent-encoded here: `{*path}` is captured but this handler reads the
+    // URI directly so that `/v2` and `/v2/` reach the same code as `/v2/{*path}`.
+    let raw = request
+        .uri()
+        .path()
+        .strip_prefix("/v2")
+        .unwrap_or_default()
+        .to_owned();
+    let decoded = percent_decode_str(&raw).decode_utf8_lossy();
+    // `parse`, not `From<&str>`: this is client-controlled, and `From` silently drops `..` rather
+    // than rejecting it.
+    let path = match StoragePath::parse(&decoded) {
+        Ok(path) => path,
+        Err(error) => {
+            return DockerError::coded(ErrorCode::NameInvalid, error.to_string()).into_response();
+        }
+    };
+
+    // Headers and URI, not `&request`: a `&Request` is not `Send` (its `Body` is not `Sync`), so
+    // holding one across the lookup's `.await` would make this handler's future non-`Send` and
+    // axum would refuse it — with an error that names neither the borrow nor the reason.
+    match resolve(&site, request.headers(), request.uri(), path).await {
+        Resolution::Docker { repository, path } => dispatch(site, repository, path, request).await,
+        // A hostname pointing at something that is not a Docker repository: serve the request as
+        // that repository's own path, which is what it would have got without this router.
+        Resolution::OtherRepository => {
+            crate::app::host_routing::host_or_frontend(State(site), request)
+                .await
+                .unwrap_or_else(|error| error.into_response())
+        }
+        Resolution::VersionCheck => version_check(&site, request).await,
+        Resolution::Unknown(message) => {
+            DockerError::coded(ErrorCode::NameUnknown, message).into_response()
+        }
+    }
+}
+
+/// `GET /v2/` with no repository behind it.
+///
+/// Credentials, if any, are checked so that `docker login` finds out about a typo now rather than
+/// on the first push. No credentials is not an error: an anonymous pull of a public image starts
+/// with this same probe, and answering `401` would make it give up before it ever named an image.
+async fn version_check(site: &NitroRepo, request: Request) -> Response {
+    let (mut parts, _) = request.into_parts();
+    let authenticated =
+        <RepositoryAuthentication as FromRequestParts<NitroRepo>>::from_request_parts(
+            &mut parts, site,
+        )
+        .await;
+
+    match authenticated {
+        Ok(_) => Response::builder()
+            .status(http::StatusCode::OK)
+            .header(http::header::CONTENT_TYPE, "application/json")
+            .header(
+                super::DOCKER_API_VERSION_HEADER.clone(),
+                super::DOCKER_API_VERSION_VALUE.clone(),
+            )
+            .body("{}".into())
+            .unwrap(),
+        Err(error) => {
+            debug!(?error, "Refused a /v2/ probe carrying bad credentials");
+            let base = {
+                let instance = site.instance.lock();
+                instance.app_url.trim_end_matches('/').to_owned()
+            };
+            DockerError::Challenge {
+                realm: format!("{base}/api/docker/token"),
+                scope: None,
+            }
+            .into_response()
+        }
+    }
+}
+
+enum Resolution {
+    Docker {
+        repository: DynRepository,
+        path: StoragePath,
+    },
+    /// A bare `/v2/` addressed to the instance itself rather than to any one repository.
+    VersionCheck,
+    OtherRepository,
+    Unknown(String),
+}
+
+/// Works out which repository a `/v2` request is for, and what the path means to it.
+async fn resolve(
+    site: &NitroRepo,
+    headers: &HeaderMap,
+    uri: &Uri,
+    path: StoragePath,
+) -> Resolution {
+    let host = request_host(
+        headers,
+        uri,
+        site.general_security_settings.trust_forwarded_host,
+    );
+
+    if let Some(repository) = host
+        .as_deref()
+        .and_then(|host| site.repository_for_hostname(host))
+    {
+        if repository.get_type() == "docker" {
+            debug!(?host, repository = %repository.name(), "Routing /v2 by host");
+            return Resolution::Docker { repository, path };
+        }
+        return Resolution::OtherRepository;
+    }
+
+    let components: Vec<String> = Vec::<nr_core::storage::StoragePathComponent>::from(path)
+        .into_iter()
+        .map(String::from)
+        .collect();
+
+    // A bare `/v2/` on the instance host names no repository, but it is the capability probe every
+    // client — and every `docker login` — begins with. There is nothing to dispatch to, so it is
+    // answered here rather than 404'd, which would make the whole registry look absent.
+    if components.is_empty() {
+        return Resolution::VersionCheck;
+    }
+    if components.len() < 2 {
+        return Resolution::Unknown(
+            "an image name must begin with `{storage}/{repository}`, or the registry must be \
+             reached on a hostname registered to a Docker repository"
+                .to_owned(),
+        );
+    }
+
+    let names = RepositoryStorageName::from((components[0].clone(), components[1].clone()));
+    let repository = match site.get_repository_from_names(&names).await {
+        Ok(repository) => repository,
+        Err(error) => {
+            return Resolution::Unknown(format!("could not look up the repository: {error}"));
+        }
+    };
+    let Some(repository) = repository else {
+        return Resolution::Unknown(format!(
+            "no repository named `{}/{}`",
+            components[0], components[1]
+        ));
+    };
+    if repository.get_type() != "docker" {
+        return Resolution::Unknown(format!(
+            "`{}/{}` is a `{}` repository, not a Docker one",
+            components[0],
+            components[1],
+            repository.get_type()
+        ));
+    }
+
+    let remaining: StoragePath = components[2..]
+        .iter()
+        .fold(StoragePath::default(), |path, component| {
+            path.push(component)
+        });
+    debug!(repository = %repository.name(), "Routing /v2 by name prefix");
+    Resolution::Docker {
+        repository,
+        path: remaining,
+    }
+}
+
+async fn dispatch(
+    site: NitroRepo,
+    repository: DynRepository,
+    path: StoragePath,
+    request: Request,
+) -> Response {
+    let (mut parts, body) = request.into_parts();
+
+    let parent_span = parts
+        .extensions
+        .get::<RequestSpan>()
+        .map(|span| span.0.clone())
+        .unwrap_or_else(Span::current);
+
+    // Extracted here rather than as a handler argument, for the same reason host routing does it:
+    // `AuthenticationLayer` skips `OPTIONS`, and `RepositoryAuthentication` rejects a request it
+    // did not annotate — which would turn every preflight into a 401.
+    let authentication =
+        match <RepositoryAuthentication as FromRequestParts<NitroRepo>>::from_request_parts(
+            &mut parts, &site,
+        )
+        .await
+        {
+            Ok(authentication) => authentication,
+            Err(error) => return error.into_response(),
+        };
+
+    let request = Request::from_parts(parts, body);
+    dispatch_repository_request(
+        &site,
+        repository,
+        path,
+        authentication,
+        &parent_span,
+        request,
+    )
+    .await
+}

--- a/nitro_repo/src/repository/docker/types/digest.rs
+++ b/nitro_repo/src/repository/docker/types/digest.rs
@@ -1,0 +1,220 @@
+//! Content digests — `sha256:<hex>`.
+//!
+//! A digest is both an identifier and a path component, so it is parsed into a type rather than
+//! passed around as a string. Anything that reaches storage has been through
+//! [`Digest::parse`], which is what keeps a crafted `..` or a stray `/` out of a blob path.
+
+use std::{fmt::Display, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest as _, Sha256, Sha512};
+
+/// The algorithms this registry will accept in a digest.
+///
+/// Deliberately not open-ended: an unknown algorithm cannot be verified, and accepting one would
+/// mean storing content under a digest nobody can check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Algorithm {
+    Sha256,
+    Sha512,
+}
+
+impl Algorithm {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Sha256 => "sha256",
+            Self::Sha512 => "sha512",
+        }
+    }
+
+    /// How many hex characters a digest of this algorithm has.
+    fn hex_length(self) -> usize {
+        match self {
+            Self::Sha256 => 64,
+            Self::Sha512 => 128,
+        }
+    }
+
+    pub fn digest(self, data: &[u8]) -> String {
+        match self {
+            Self::Sha256 => to_hex(&Sha256::digest(data)),
+            Self::Sha512 => to_hex(&Sha512::digest(data)),
+        }
+    }
+}
+
+impl FromStr for Algorithm {
+    type Err = InvalidDigest;
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "sha256" => Ok(Self::Sha256),
+            "sha512" => Ok(Self::Sha512),
+            other => Err(InvalidDigest::UnsupportedAlgorithm(other.to_owned())),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum InvalidDigest {
+    #[error("a digest must be `algorithm:hex`, got `{0}`")]
+    Malformed(String),
+    #[error("`{0}` is not a digest algorithm this registry supports")]
+    UnsupportedAlgorithm(String),
+    #[error("`{0}` is not the right length or is not lowercase hex")]
+    BadHex(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Digest {
+    algorithm: Algorithm,
+    hex: String,
+}
+
+impl Digest {
+    pub fn parse(value: &str) -> Result<Self, InvalidDigest> {
+        let Some((algorithm, hex)) = value.split_once(':') else {
+            return Err(InvalidDigest::Malformed(value.to_owned()));
+        };
+        let algorithm: Algorithm = algorithm.parse()?;
+        // Lowercase only, and exactly the right length. An uppercase digest would be a different
+        // string for the same content, which would store one blob twice and make `HEAD` miss.
+        if hex.len() != algorithm.hex_length()
+            || !hex
+                .chars()
+                .all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c))
+        {
+            return Err(InvalidDigest::BadHex(hex.to_owned()));
+        }
+        Ok(Self {
+            algorithm,
+            hex: hex.to_owned(),
+        })
+    }
+
+    /// The digest of some content, under the given algorithm.
+    pub fn of(algorithm: Algorithm, data: &[u8]) -> Self {
+        Self {
+            algorithm,
+            hex: algorithm.digest(data),
+        }
+    }
+
+    /// The sha256 digest of some content — what a registry uses unless told otherwise.
+    pub fn sha256_of(data: &[u8]) -> Self {
+        Self::of(Algorithm::Sha256, data)
+    }
+
+    pub fn algorithm(&self) -> Algorithm {
+        self.algorithm
+    }
+
+    pub fn hex(&self) -> &str {
+        &self.hex
+    }
+
+    /// Whether this digest is the digest of `data`.
+    pub fn matches(&self, data: &[u8]) -> bool {
+        self.algorithm.digest(data) == self.hex
+    }
+
+    /// The two path components content under this digest is stored at: `{algorithm}/{hex}`.
+    ///
+    /// Both are constrained by parsing — an algorithm from a fixed set, a hex string of a fixed
+    /// length — so neither can be a path traversal.
+    pub fn path_components(&self) -> (&'static str, &str) {
+        (self.algorithm.as_str(), &self.hex)
+    }
+}
+
+impl Display for Digest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{}", self.algorithm.as_str(), self.hex)
+    }
+}
+
+impl Serialize for Digest {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for Digest {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Digest::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+fn to_hex(bytes: &[u8]) -> String {
+    use std::fmt::Write;
+    bytes.iter().fold(String::new(), |mut hex, byte| {
+        let _ = write!(hex, "{byte:02x}");
+        hex
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Algorithm, Digest, InvalidDigest};
+
+    /// The sha256 of the empty string, which is what an empty layer's digest actually is.
+    const EMPTY_SHA256: &str =
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    #[test]
+    fn a_well_formed_digest_parses_and_round_trips() {
+        let digest = Digest::parse(EMPTY_SHA256).unwrap();
+        assert_eq!(digest.algorithm(), Algorithm::Sha256);
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        assert_eq!(
+            digest.path_components(),
+            (
+                "sha256",
+                "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+            )
+        );
+    }
+
+    #[test]
+    fn the_digest_of_content_matches_it() {
+        let digest = Digest::sha256_of(b"");
+        assert_eq!(digest.to_string(), EMPTY_SHA256);
+        assert!(digest.matches(b""));
+        assert!(!digest.matches(b"something else"));
+    }
+
+    #[test]
+    fn a_digest_cannot_carry_a_path_traversal() {
+        for bad in [
+            "sha256:../../etc/passwd",
+            "sha256:..",
+            "../sha256:abc",
+            "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b85/",
+        ] {
+            assert!(Digest::parse(bad).is_err(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn a_malformed_digest_is_refused() {
+        assert_eq!(
+            Digest::parse("nocolon"),
+            Err(InvalidDigest::Malformed("nocolon".to_owned()))
+        );
+        assert_eq!(
+            Digest::parse("md5:d41d8cd98f00b204e9800998ecf8427e"),
+            Err(InvalidDigest::UnsupportedAlgorithm("md5".to_owned()))
+        );
+        // Right shape, wrong length.
+        assert!(Digest::parse("sha256:abc").is_err());
+        // Uppercase hex is a different string for the same bytes.
+        assert!(Digest::parse(&EMPTY_SHA256.to_uppercase()).is_err());
+    }
+
+    #[test]
+    fn sha512_is_accepted_at_its_own_length() {
+        let digest = Digest::of(Algorithm::Sha512, b"");
+        assert_eq!(digest.hex().len(), 128);
+        assert_eq!(Digest::parse(&digest.to_string()).unwrap(), digest);
+    }
+}

--- a/nitro_repo/src/repository/docker/types/manifest.rs
+++ b/nitro_repo/src/repository/docker/types/manifest.rs
@@ -1,0 +1,225 @@
+//! Manifests and indexes, parsed only as far as this registry needs them.
+//!
+//! A manifest is stored and re-served as the exact bytes that were pushed — its digest is over
+//! those bytes, so re-serialising it would change its identity. These types exist to answer two
+//! questions about a manifest before it is accepted: which blobs must already exist, and what does
+//! it refer to.
+
+use serde::Deserialize;
+
+use super::digest::Digest;
+
+pub const MEDIA_TYPE_DOCKER_MANIFEST: &str = "application/vnd.docker.distribution.manifest.v2+json";
+pub const MEDIA_TYPE_DOCKER_MANIFEST_LIST: &str =
+    "application/vnd.docker.distribution.manifest.list.v2+json";
+pub const MEDIA_TYPE_OCI_MANIFEST: &str = "application/vnd.oci.image.manifest.v1+json";
+pub const MEDIA_TYPE_OCI_INDEX: &str = "application/vnd.oci.image.index.v1+json";
+
+/// The default a client is assumed to have meant when it sends no `Content-Type`.
+pub const DEFAULT_MANIFEST_MEDIA_TYPE: &str = MEDIA_TYPE_DOCKER_MANIFEST;
+
+/// Whether a media type names a multi-platform index rather than a single image.
+pub fn is_index(media_type: &str) -> bool {
+    matches!(
+        media_type,
+        MEDIA_TYPE_DOCKER_MANIFEST_LIST | MEDIA_TYPE_OCI_INDEX
+    )
+}
+
+/// One entry in a manifest's `layers`, or its `config`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Descriptor {
+    #[serde(rename = "mediaType")]
+    pub media_type: Option<String>,
+    pub digest: Digest,
+    #[serde(default)]
+    pub size: i64,
+    #[serde(default)]
+    pub platform: Option<Platform>,
+    /// Set on a foreign//non-distributable layer, which by definition is not in this registry.
+    #[serde(default)]
+    pub urls: Vec<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Platform {
+    #[serde(default)]
+    pub architecture: Option<String>,
+    #[serde(default)]
+    pub os: Option<String>,
+    #[serde(default)]
+    pub variant: Option<String>,
+}
+
+/// The union of an image manifest and an index — enough of either to validate it.
+///
+/// One type rather than two because the fields do not overlap: an image manifest has `config` and
+/// `layers`, an index has `manifests`, and which one applies is decided by the media type.
+#[derive(Debug, Clone, Deserialize)]
+pub struct Manifest {
+    #[serde(rename = "schemaVersion", default)]
+    pub schema_version: u32,
+    #[serde(rename = "mediaType", default)]
+    pub media_type: Option<String>,
+    #[serde(rename = "artifactType", default)]
+    pub artifact_type: Option<String>,
+    #[serde(default)]
+    pub config: Option<Descriptor>,
+    #[serde(default)]
+    pub layers: Vec<Descriptor>,
+    #[serde(default)]
+    pub manifests: Vec<Descriptor>,
+    /// The OCI referrers relationship: this manifest is *about* the manifest it names.
+    #[serde(default)]
+    pub subject: Option<Descriptor>,
+}
+
+impl Manifest {
+    /// The blobs that must already be in storage before this manifest can be accepted.
+    ///
+    /// A layer that carries `urls` is a foreign layer — it lives somewhere else by design, and
+    /// requiring it here would make every Windows base image unpushable.
+    pub fn required_blobs(&self) -> Vec<&Digest> {
+        self.config
+            .iter()
+            .chain(self.layers.iter())
+            .filter(|descriptor| descriptor.urls.is_empty())
+            .map(|descriptor| &descriptor.digest)
+            .collect()
+    }
+
+    /// The child manifests an index points at.
+    pub fn child_manifests(&self) -> Vec<&Digest> {
+        self.manifests
+            .iter()
+            .map(|descriptor| &descriptor.digest)
+            .collect()
+    }
+
+    /// The platforms an index covers, formatted for display.
+    pub fn platforms(&self) -> Vec<String> {
+        self.manifests
+            .iter()
+            .filter_map(|descriptor| descriptor.platform.as_ref())
+            .map(|platform| {
+                let os = platform.os.as_deref().unwrap_or("unknown");
+                let architecture = platform.architecture.as_deref().unwrap_or("unknown");
+                match platform.variant.as_deref() {
+                    Some(variant) => format!("{os}/{architecture}/{variant}"),
+                    None => format!("{os}/{architecture}"),
+                }
+            })
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Manifest, is_index};
+
+    const CONFIG: &str = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+    const LAYER: &str = "sha256:2222222222222222222222222222222222222222222222222222222222222222";
+    const FOREIGN: &str = "sha256:3333333333333333333333333333333333333333333333333333333333333333";
+
+    #[test]
+    fn an_image_manifest_lists_its_config_and_layers() {
+        let manifest: Manifest = serde_json::from_value(serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": super::MEDIA_TYPE_OCI_MANIFEST,
+            "config": { "mediaType": "application/vnd.oci.image.config.v1+json", "digest": CONFIG, "size": 7 },
+            "layers": [
+                { "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip", "digest": LAYER, "size": 32 },
+            ],
+        }))
+        .unwrap();
+
+        let required: Vec<String> = manifest
+            .required_blobs()
+            .into_iter()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(required, vec![CONFIG.to_owned(), LAYER.to_owned()]);
+    }
+
+    /// A foreign layer lives outside this registry on purpose; demanding it would make every
+    /// Windows base image impossible to push.
+    #[test]
+    fn a_foreign_layer_is_not_required_to_be_present() {
+        let manifest: Manifest = serde_json::from_value(serde_json::json!({
+            "schemaVersion": 2,
+            "config": { "digest": CONFIG, "size": 7 },
+            "layers": [
+                { "digest": LAYER, "size": 32 },
+                { "digest": FOREIGN, "size": 99, "urls": ["https://example.com/layer"] },
+            ],
+        }))
+        .unwrap();
+
+        let required: Vec<String> = manifest
+            .required_blobs()
+            .into_iter()
+            .map(ToString::to_string)
+            .collect();
+        assert_eq!(required, vec![CONFIG.to_owned(), LAYER.to_owned()]);
+    }
+
+    #[test]
+    fn an_index_lists_its_children_and_platforms() {
+        let manifest: Manifest = serde_json::from_value(serde_json::json!({
+            "schemaVersion": 2,
+            "mediaType": super::MEDIA_TYPE_OCI_INDEX,
+            "manifests": [
+                { "digest": CONFIG, "size": 1, "platform": { "os": "linux", "architecture": "amd64" } },
+                { "digest": LAYER, "size": 1, "platform": { "os": "linux", "architecture": "arm64", "variant": "v8" } },
+            ],
+        }))
+        .unwrap();
+
+        assert!(manifest.required_blobs().is_empty());
+        assert_eq!(manifest.child_manifests().len(), 2);
+        assert_eq!(
+            manifest.platforms(),
+            vec!["linux/amd64".to_owned(), "linux/arm64/v8".to_owned()]
+        );
+    }
+
+    #[test]
+    fn index_media_types_are_recognised() {
+        assert!(is_index(super::MEDIA_TYPE_OCI_INDEX));
+        assert!(is_index(super::MEDIA_TYPE_DOCKER_MANIFEST_LIST));
+        assert!(!is_index(super::MEDIA_TYPE_OCI_MANIFEST));
+        assert!(!is_index(super::MEDIA_TYPE_DOCKER_MANIFEST));
+    }
+
+    #[test]
+    fn a_manifest_with_a_subject_keeps_it() {
+        let manifest: Manifest = serde_json::from_value(serde_json::json!({
+            "schemaVersion": 2,
+            "config": { "digest": CONFIG, "size": 7 },
+            "layers": [],
+            "artifactType": "application/vnd.example.sbom",
+            "subject": { "digest": LAYER, "size": 1 },
+        }))
+        .unwrap();
+
+        assert_eq!(
+            manifest.subject.unwrap().digest.to_string(),
+            LAYER.to_owned()
+        );
+        assert_eq!(
+            manifest.artifact_type.as_deref(),
+            Some("application/vnd.example.sbom")
+        );
+    }
+
+    /// A digest that will not parse must fail the manifest, not be silently dropped — a manifest
+    /// with an unverifiable layer reference is not one this registry can serve.
+    #[test]
+    fn a_manifest_with_an_unparseable_digest_is_refused() {
+        let result: Result<Manifest, _> = serde_json::from_value(serde_json::json!({
+            "schemaVersion": 2,
+            "layers": [{ "digest": "not-a-digest", "size": 1 }],
+        }));
+        assert!(result.is_err());
+    }
+}

--- a/nitro_repo/src/repository/docker/types/mod.rs
+++ b/nitro_repo/src/repository/docker/types/mod.rs
@@ -1,0 +1,7 @@
+pub mod digest;
+pub mod manifest;
+pub mod request;
+
+pub use digest::{Algorithm, Digest};
+pub use manifest::Manifest;
+pub use request::{DockerPath, Reference};

--- a/nitro_repo/src/repository/docker/types/request.rs
+++ b/nitro_repo/src/repository/docker/types/request.rs
@@ -1,0 +1,405 @@
+//! Turning a `/v2/...` path into a registry route.
+//!
+//! The image name is a variable-length prefix (`library/alpine`, `team/project/service`), so unlike
+//! npm's leading-segment dispatch this matches from the *end* of the path: the last one to three
+//! segments name the operation, and everything before them is the image.
+
+use nr_core::storage::StoragePath;
+use uuid::Uuid;
+
+use super::digest::Digest;
+use crate::repository::docker::{DockerError, errors::ErrorCode};
+
+/// What a manifest request addresses: a mutable tag, or an immutable digest.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Reference {
+    Tag(String),
+    Digest(Digest),
+}
+
+impl Reference {
+    /// A reference is a digest if it parses as one, and a tag otherwise.
+    ///
+    /// A tag can never contain `:`, so there is no ambiguity — but the parse has to come first,
+    /// because a malformed digest must be an error rather than a tag with a colon in it.
+    pub fn parse(value: &str) -> Result<Self, DockerError> {
+        if value.contains(':') {
+            return Digest::parse(value)
+                .map(Reference::Digest)
+                .map_err(|error| DockerError::InvalidDigest(error.to_string()));
+        }
+        if !is_valid_tag(value) {
+            return Err(DockerError::Coded {
+                code: ErrorCode::ManifestInvalid,
+                message: format!("`{value}` is not a valid tag"),
+            });
+        }
+        Ok(Reference::Tag(value.to_owned()))
+    }
+}
+
+impl std::fmt::Display for Reference {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Reference::Tag(tag) => f.write_str(tag),
+            Reference::Digest(digest) => write!(f, "{digest}"),
+        }
+    }
+}
+
+/// The distribution spec's tag grammar: `[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}`.
+pub fn is_valid_tag(tag: &str) -> bool {
+    !tag.is_empty()
+        && tag.len() <= 128
+        && tag.starts_with(|c: char| c.is_ascii_alphanumeric() || c == '_')
+        && tag
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'))
+}
+
+/// The distribution spec's name grammar: slash-separated components of
+/// `[a-z0-9]+(?:(?:\.|_|__|-+)[a-z0-9]+)*`.
+///
+/// Lowercase only — Docker itself refuses to push an uppercase name, and accepting one here would
+/// create an image nobody could pull back.
+pub fn is_valid_image_name(name: &str) -> bool {
+    if name.is_empty() || name.len() > 255 {
+        return false;
+    }
+    name.split('/').all(is_valid_name_component)
+}
+
+fn is_valid_name_component(component: &str) -> bool {
+    let bytes = component.as_bytes();
+    let alphanumeric = |b: u8| b.is_ascii_lowercase() || b.is_ascii_digit();
+
+    // Must start and end with an alphanumeric; separators only ever sit between them. A
+    // single-character component is both the first and the last byte, which is why this is a
+    // first/last check rather than a slice of the interior — `bytes[1..len - 1]` panics at len 1.
+    let (Some(&first), Some(&last)) = (bytes.first(), bytes.last()) else {
+        return false;
+    };
+    if !alphanumeric(first) || !alphanumeric(last) {
+        return false;
+    }
+
+    // The grammar allows `.`, `_`, `__` and runs of `-` between alphanumerics. A doubled `.` is
+    // not in it, and would also read as a path component this registry does not want to store.
+    let mut previous = 0u8;
+    for &byte in bytes {
+        if !alphanumeric(byte) && !matches!(byte, b'.' | b'_' | b'-') {
+            return false;
+        }
+        if byte == b'.' && previous == b'.' {
+            return false;
+        }
+        previous = byte;
+    }
+    true
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DockerPath {
+    /// `/v2/` — the version check.
+    Base,
+    /// `/v2/_catalog`
+    Catalog,
+    /// `/v2/{name}/tags/list`
+    TagsList { name: String },
+    /// `/v2/{name}/manifests/{reference}`
+    Manifest { name: String, reference: Reference },
+    /// `/v2/{name}/blobs/{digest}`
+    Blob { name: String, digest: Digest },
+    /// `/v2/{name}/blobs/uploads/`
+    UploadStart { name: String },
+    /// `/v2/{name}/blobs/uploads/{uuid}`
+    UploadChunk { name: String, uuid: Uuid },
+    /// `/v2/{name}/referrers/{digest}`
+    Referrers { name: String, digest: Digest },
+}
+
+impl DockerPath {
+    /// Parses the path *after* `/v2`.
+    pub fn parse(path: &StoragePath) -> Result<Self, DockerError> {
+        let components: Vec<String> =
+            Vec::<nr_core::storage::StoragePathComponent>::from(path.clone())
+                .into_iter()
+                .map(String::from)
+                .collect();
+        let parts: Vec<&str> = components.iter().map(String::as_str).collect();
+
+        if parts.is_empty() {
+            return Ok(DockerPath::Base);
+        }
+        if parts == ["_catalog"] {
+            return Ok(DockerPath::Catalog);
+        }
+
+        // `blobs/uploads` is the only three-segment tail, and it is also a legal two-segment one
+        // (`.../blobs/uploads/` starts an upload). Checked before the generic tails so an upload id
+        // is never mistaken for a digest.
+        if parts.len() >= 3 {
+            let tail = &parts[parts.len() - 2..];
+            if tail == ["blobs", "uploads"] {
+                let name = join_name(&parts[..parts.len() - 2])?;
+                return Ok(DockerPath::UploadStart { name });
+            }
+        }
+        if parts.len() >= 4 {
+            let tail = &parts[parts.len() - 3..parts.len() - 1];
+            if tail == ["blobs", "uploads"] {
+                let raw = parts[parts.len() - 1];
+                let uuid = Uuid::parse_str(raw).map_err(|_| DockerError::Coded {
+                    code: ErrorCode::BlobUploadInvalid,
+                    message: format!("`{raw}` is not an upload id this registry issued"),
+                })?;
+                let name = join_name(&parts[..parts.len() - 3])?;
+                return Ok(DockerPath::UploadChunk { name, uuid });
+            }
+        }
+
+        if parts.len() >= 3 {
+            let kind = parts[parts.len() - 2];
+            let last = parts[parts.len() - 1];
+            let name_parts = &parts[..parts.len() - 2];
+            match kind {
+                "tags" if last == "list" => {
+                    return Ok(DockerPath::TagsList {
+                        name: join_name(name_parts)?,
+                    });
+                }
+                "manifests" => {
+                    return Ok(DockerPath::Manifest {
+                        name: join_name(name_parts)?,
+                        reference: Reference::parse(last)?,
+                    });
+                }
+                "blobs" => {
+                    let digest = Digest::parse(last)
+                        .map_err(|error| DockerError::InvalidDigest(error.to_string()))?;
+                    return Ok(DockerPath::Blob {
+                        name: join_name(name_parts)?,
+                        digest,
+                    });
+                }
+                "referrers" => {
+                    let digest = Digest::parse(last)
+                        .map_err(|error| DockerError::InvalidDigest(error.to_string()))?;
+                    return Ok(DockerPath::Referrers {
+                        name: join_name(name_parts)?,
+                        digest,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        Err(DockerError::Coded {
+            code: ErrorCode::NameUnknown,
+            message: format!(
+                "`/v2/{}` is not a route this registry serves",
+                parts.join("/")
+            ),
+        })
+    }
+}
+
+fn join_name(parts: &[&str]) -> Result<String, DockerError> {
+    if parts.is_empty() {
+        return Err(DockerError::Coded {
+            code: ErrorCode::NameInvalid,
+            message: "the request named no image".to_owned(),
+        });
+    }
+    let name = parts.join("/");
+    if !is_valid_image_name(&name) {
+        return Err(DockerError::Coded {
+            code: ErrorCode::NameInvalid,
+            message: format!("`{name}` is not a valid image name"),
+        });
+    }
+    Ok(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use nr_core::storage::StoragePath;
+
+    use super::{DockerPath, Reference, is_valid_image_name, is_valid_tag};
+    use crate::repository::docker::types::digest::Digest;
+
+    const EMPTY_SHA256: &str =
+        "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    fn parse(path: &str) -> Result<DockerPath, crate::repository::docker::DockerError> {
+        DockerPath::parse(&StoragePath::parse(path).unwrap())
+    }
+
+    #[test]
+    fn the_base_and_catalog_routes_parse() {
+        assert_eq!(parse("").unwrap(), DockerPath::Base);
+        assert_eq!(parse("/").unwrap(), DockerPath::Base);
+        assert_eq!(parse("_catalog").unwrap(), DockerPath::Catalog);
+    }
+
+    #[test]
+    fn a_multi_segment_image_name_is_kept_whole() {
+        assert_eq!(
+            parse("team/project/service/manifests/latest").unwrap(),
+            DockerPath::Manifest {
+                name: "team/project/service".to_owned(),
+                reference: Reference::Tag("latest".to_owned()),
+            }
+        );
+        assert_eq!(
+            parse("library/alpine/tags/list").unwrap(),
+            DockerPath::TagsList {
+                name: "library/alpine".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn a_manifest_can_be_addressed_by_tag_or_by_digest() {
+        assert_eq!(
+            parse("alpine/manifests/3.19").unwrap(),
+            DockerPath::Manifest {
+                name: "alpine".to_owned(),
+                reference: Reference::Tag("3.19".to_owned()),
+            }
+        );
+        assert_eq!(
+            parse(&format!("alpine/manifests/{EMPTY_SHA256}")).unwrap(),
+            DockerPath::Manifest {
+                name: "alpine".to_owned(),
+                reference: Reference::Digest(Digest::parse(EMPTY_SHA256).unwrap()),
+            }
+        );
+    }
+
+    #[test]
+    fn the_blob_and_upload_routes_parse() {
+        assert_eq!(
+            parse(&format!("alpine/blobs/{EMPTY_SHA256}")).unwrap(),
+            DockerPath::Blob {
+                name: "alpine".to_owned(),
+                digest: Digest::parse(EMPTY_SHA256).unwrap(),
+            }
+        );
+        assert_eq!(
+            parse("alpine/blobs/uploads/").unwrap(),
+            DockerPath::UploadStart {
+                name: "alpine".to_owned()
+            }
+        );
+
+        let uuid = uuid::Uuid::new_v4();
+        assert_eq!(
+            parse(&format!("alpine/blobs/uploads/{uuid}")).unwrap(),
+            DockerPath::UploadChunk {
+                name: "alpine".to_owned(),
+                uuid,
+            }
+        );
+    }
+
+    /// An image literally called `blobs` or `manifests` must not be mistaken for the tail that
+    /// names the operation.
+    #[test]
+    fn an_image_named_like_a_route_segment_still_resolves() {
+        assert_eq!(
+            parse("blobs/manifests/latest").unwrap(),
+            DockerPath::Manifest {
+                name: "blobs".to_owned(),
+                reference: Reference::Tag("latest".to_owned()),
+            }
+        );
+        assert_eq!(
+            parse("manifests/tags/list").unwrap(),
+            DockerPath::TagsList {
+                name: "manifests".to_owned()
+            }
+        );
+    }
+
+    #[test]
+    fn the_referrers_route_parses() {
+        assert_eq!(
+            parse(&format!("alpine/referrers/{EMPTY_SHA256}")).unwrap(),
+            DockerPath::Referrers {
+                name: "alpine".to_owned(),
+                digest: Digest::parse(EMPTY_SHA256).unwrap(),
+            }
+        );
+    }
+
+    #[test]
+    fn a_route_with_no_image_name_is_refused() {
+        for path in ["manifests/latest", "tags/list", "blobs/uploads/"] {
+            assert!(parse(path).is_err(), "{path}");
+        }
+    }
+
+    #[test]
+    fn an_unknown_route_is_refused() {
+        for path in ["alpine", "alpine/nonsense/latest", "alpine/manifests"] {
+            assert!(parse(path).is_err(), "{path}");
+        }
+    }
+
+    #[test]
+    fn a_bad_upload_id_is_refused() {
+        assert!(parse("alpine/blobs/uploads/not-a-uuid").is_err());
+    }
+
+    #[test]
+    fn image_names_follow_the_distribution_grammar() {
+        for good in [
+            "alpine",
+            "library/alpine",
+            "a/b/c",
+            "my-app",
+            "my_app",
+            "app.v2",
+            "n1",
+        ] {
+            assert!(is_valid_image_name(good), "{good}");
+        }
+        for bad in [
+            "",
+            "Alpine",
+            "UPPER/case",
+            "-leading",
+            "trailing-",
+            "a//b",
+            "a b",
+            "a/",
+            "/a",
+            "a..b",
+            ".a",
+            "a.",
+            "_a",
+            "a_",
+            "a/../b",
+        ] {
+            assert!(!is_valid_image_name(bad), "{bad}");
+        }
+    }
+
+    #[test]
+    fn tags_follow_the_distribution_grammar() {
+        for good in ["latest", "v1.0.0", "1", "_underscore", "a-b.c_d"] {
+            assert!(is_valid_tag(good), "{good}");
+        }
+        for bad in [
+            "",
+            ".leading-dot",
+            "-leading-dash",
+            "has space",
+            "has/slash",
+            &"x".repeat(129),
+        ] {
+            assert!(!is_valid_tag(bad), "{bad}");
+        }
+    }
+}

--- a/nitro_repo/src/repository/docker/uploads.rs
+++ b/nitro_repo/src/repository/docker/uploads.rs
@@ -1,0 +1,416 @@
+//! Resumable blob uploads.
+//!
+//! Docker pushes a blob in three steps: `POST` to open a session, one or more `PATCH`es to stream
+//! bytes into it, then `PUT ?digest=` to commit. [`Storage::save_file`] takes a whole
+//! [`FileContent`](nr_storage::FileContent) and there is no append or streaming write on any
+//! backend, so the in-progress bytes are buffered to the local staging directory — the same place
+//! [`StagingManager`](crate::repository::staging::StagingManager) writes — and only handed to
+//! storage once the digest has been verified.
+//!
+//! The consequence, which the Docker docs page states: an upload is tied to the node that started
+//! it, and is bounded by that node's disk. Adding a streaming write to the `Storage` trait would
+//! remove both limits, at the cost of implementing it on all three backends and giving S3 real
+//! multipart-upload state.
+//!
+//! The session table is modelled on
+//! [`NpmWebLoginManager`](crate::repository::npm::login::web_login::NpmWebLoginManager): an
+//! in-memory map with a TTL, swept whenever a new session is opened.
+
+use std::{
+    fmt::Debug,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+
+use ahash::HashMap;
+use bytes::Bytes;
+use chrono::{DateTime, Duration, FixedOffset, Local};
+use parking_lot::Mutex;
+use tokio::io::AsyncWriteExt;
+use tracing::{debug, instrument, warn};
+use uuid::Uuid;
+
+use super::types::digest::Digest;
+
+/// How long an upload can sit untouched before it is swept.
+///
+/// Docker retries a failed push rather than resuming a stale one, so this only has to outlast a
+/// slow layer, not a slow human.
+const SESSION_TTL: Duration = Duration::hours(1);
+
+#[derive(Debug, thiserror::Error)]
+pub enum UploadError {
+    #[error("upload `{0}` is not open")]
+    UnknownUpload(Uuid),
+    #[error("IO error while buffering an upload: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("the uploaded content is `{actual}`, but the request committed it as `{expected}`")]
+    DigestMismatch { expected: String, actual: String },
+    #[error("this upload starts at offset {expected}, but the chunk claims to start at {actual}")]
+    OutOfOrderChunk { expected: u64, actual: u64 },
+}
+
+#[derive(Debug, Clone)]
+struct UploadSession {
+    repository: Uuid,
+    image: String,
+    path: PathBuf,
+    /// How many bytes have been written, which is also the offset the next chunk must start at.
+    offset: u64,
+    touched: DateTime<FixedOffset>,
+}
+
+#[derive(Default)]
+struct UploadState {
+    sessions: HashMap<Uuid, UploadSession>,
+}
+
+/// Tracks in-progress blob uploads across every Docker repository on this node.
+#[derive(Clone)]
+pub struct BlobUploadManager {
+    state: Arc<Mutex<UploadState>>,
+    root: Arc<PathBuf>,
+}
+
+impl Debug for BlobUploadManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BlobUploadManager")
+            .field("root", &self.root)
+            .field("open", &self.state.lock().sessions.len())
+            .finish()
+    }
+}
+
+impl BlobUploadManager {
+    /// `staging_dir` is the instance's staging directory; uploads live in a `docker` subdirectory
+    /// of it so they are obviously separate from staged artifacts.
+    pub fn new(staging_dir: &Path) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(UploadState::default())),
+            root: Arc::new(staging_dir.join("docker")),
+        }
+    }
+
+    /// Opens a session and returns its id, which becomes the last segment of the upload URL.
+    #[instrument(skip(self))]
+    pub async fn start(&self, repository: Uuid, image: &str) -> Result<Uuid, UploadError> {
+        self.sweep_expired();
+        tokio::fs::create_dir_all(self.root.as_path()).await?;
+
+        let id = Uuid::new_v4();
+        let path = self.root.join(id.to_string());
+        // Created up front so a `PATCH` that arrives before any bytes have been written still has
+        // a file to append to.
+        tokio::fs::File::create(&path).await?;
+
+        self.state.lock().sessions.insert(
+            id,
+            UploadSession {
+                repository,
+                image: image.to_owned(),
+                path,
+                offset: 0,
+                touched: Local::now().fixed_offset(),
+            },
+        );
+        debug!(%id, %repository, image, "Opened a blob upload");
+        Ok(id)
+    }
+
+    /// Appends a chunk and returns the new total length.
+    ///
+    /// `expected_start` is the `Content-Range` a chunked client sends. A chunk that does not start
+    /// where the session left off is refused rather than appended: silently accepting it would
+    /// assemble a blob out of order and the digest check at the end would report a corrupt upload
+    /// with no indication of why.
+    #[instrument(skip(self, chunk), fields(chunk_length = chunk.len()))]
+    pub async fn append(
+        &self,
+        id: Uuid,
+        repository: Uuid,
+        expected_start: Option<u64>,
+        chunk: Bytes,
+    ) -> Result<u64, UploadError> {
+        let session = self.session(id, repository)?;
+        if let Some(start) = expected_start
+            && start != session.offset
+        {
+            return Err(UploadError::OutOfOrderChunk {
+                expected: session.offset,
+                actual: start,
+            });
+        }
+
+        if !chunk.is_empty() {
+            let mut file = tokio::fs::OpenOptions::new()
+                .append(true)
+                .open(&session.path)
+                .await?;
+            file.write_all(&chunk).await?;
+            file.flush().await?;
+        }
+
+        let mut state = self.state.lock();
+        let Some(session) = state.sessions.get_mut(&id) else {
+            return Err(UploadError::UnknownUpload(id));
+        };
+        session.offset += chunk.len() as u64;
+        session.touched = Local::now().fixed_offset();
+        Ok(session.offset)
+    }
+
+    /// How many bytes a session has taken so far, for the `Range` header on a status request.
+    pub fn offset(&self, id: Uuid, repository: Uuid) -> Result<u64, UploadError> {
+        Ok(self.session(id, repository)?.offset)
+    }
+
+    /// Verifies the buffered bytes against the digest the client committed them under, and returns
+    /// them.
+    ///
+    /// The session and its temporary file are removed either way — a mismatch is not resumable, and
+    /// leaving the file behind would leak the bytes of a rejected upload onto disk.
+    #[instrument(skip(self))]
+    pub async fn finish(
+        &self,
+        id: Uuid,
+        repository: Uuid,
+        expected: &Digest,
+    ) -> Result<Bytes, UploadError> {
+        let session = self.session(id, repository)?;
+        let bytes = tokio::fs::read(&session.path).await?;
+        self.discard(id).await;
+
+        let actual = Digest::of(expected.algorithm(), &bytes);
+        if &actual != expected {
+            return Err(UploadError::DigestMismatch {
+                expected: expected.to_string(),
+                actual: actual.to_string(),
+            });
+        }
+        debug!(%id, length = bytes.len(), "Committed a blob upload");
+        Ok(Bytes::from(bytes))
+    }
+
+    /// `DELETE` on an upload URL: abandon it.
+    #[instrument(skip(self))]
+    pub async fn cancel(&self, id: Uuid, repository: Uuid) -> Result<(), UploadError> {
+        self.session(id, repository)?;
+        self.discard(id).await;
+        Ok(())
+    }
+
+    /// Looks a session up, refusing one that belongs to a different repository.
+    ///
+    /// The id alone is not authority to write: without this check an upload opened against a
+    /// repository the caller can write to could be committed into one they cannot.
+    fn session(&self, id: Uuid, repository: Uuid) -> Result<UploadSession, UploadError> {
+        let state = self.state.lock();
+        match state.sessions.get(&id) {
+            Some(session) if session.repository == repository => Ok(session.clone()),
+            Some(session) => {
+                warn!(
+                    %id,
+                    expected = %session.repository,
+                    actual = %repository,
+                    "An upload id was presented to a repository it was not opened against"
+                );
+                Err(UploadError::UnknownUpload(id))
+            }
+            None => Err(UploadError::UnknownUpload(id)),
+        }
+    }
+
+    /// The image an upload was opened against, for the `Location` a commit responds with.
+    pub fn image(&self, id: Uuid, repository: Uuid) -> Result<String, UploadError> {
+        Ok(self.session(id, repository)?.image)
+    }
+
+    async fn discard(&self, id: Uuid) {
+        let removed = self.state.lock().sessions.remove(&id);
+        if let Some(session) = removed {
+            let _ = tokio::fs::remove_file(&session.path).await;
+        }
+    }
+
+    /// Drops sessions nobody has touched inside the TTL.
+    ///
+    /// Synchronous, and the files are left for the next process start to clear: doing the removal
+    /// here would mean holding the lock across IO.
+    fn sweep_expired(&self) {
+        let cutoff = Local::now().fixed_offset() - SESSION_TTL;
+        let mut state = self.state.lock();
+        let expired: Vec<PathBuf> = state
+            .sessions
+            .iter()
+            .filter(|(_, session)| session.touched < cutoff)
+            .map(|(_, session)| session.path.clone())
+            .collect();
+        if expired.is_empty() {
+            return;
+        }
+        state
+            .sessions
+            .retain(|_, session| session.touched >= cutoff);
+        drop(state);
+
+        tokio::spawn(async move {
+            for path in expired {
+                let _ = tokio::fs::remove_file(path).await;
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use bytes::Bytes;
+    use uuid::Uuid;
+
+    use super::{BlobUploadManager, UploadError};
+    use crate::repository::docker::types::digest::Digest;
+
+    fn manager() -> (BlobUploadManager, tempfile::TempDir) {
+        let directory = tempfile::tempdir().unwrap();
+        (BlobUploadManager::new(directory.path()), directory)
+    }
+
+    #[tokio::test]
+    async fn a_chunked_upload_reassembles_in_order() {
+        let (manager, _directory) = manager();
+        let repository = Uuid::new_v4();
+
+        let id = manager.start(repository, "alpine").await.unwrap();
+        assert_eq!(
+            manager
+                .append(id, repository, Some(0), Bytes::from_static(b"hello "))
+                .await
+                .unwrap(),
+            6
+        );
+        assert_eq!(
+            manager
+                .append(id, repository, Some(6), Bytes::from_static(b"world"))
+                .await
+                .unwrap(),
+            11
+        );
+
+        let digest = Digest::sha256_of(b"hello world");
+        let bytes = manager.finish(id, repository, &digest).await.unwrap();
+        assert_eq!(&bytes[..], b"hello world");
+    }
+
+    #[tokio::test]
+    async fn a_monolithic_upload_needs_no_content_range() {
+        let (manager, _directory) = manager();
+        let repository = Uuid::new_v4();
+
+        let id = manager.start(repository, "alpine").await.unwrap();
+        manager
+            .append(id, repository, None, Bytes::from_static(b"payload"))
+            .await
+            .unwrap();
+
+        let digest = Digest::sha256_of(b"payload");
+        assert_eq!(
+            &manager.finish(id, repository, &digest).await.unwrap()[..],
+            b"payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn a_chunk_that_does_not_continue_the_upload_is_refused() {
+        let (manager, _directory) = manager();
+        let repository = Uuid::new_v4();
+
+        let id = manager.start(repository, "alpine").await.unwrap();
+        manager
+            .append(id, repository, Some(0), Bytes::from_static(b"abc"))
+            .await
+            .unwrap();
+
+        let error = manager
+            .append(id, repository, Some(99), Bytes::from_static(b"def"))
+            .await
+            .unwrap_err();
+        assert!(matches!(error, UploadError::OutOfOrderChunk { .. }));
+        // The rejected chunk must not have been written.
+        assert_eq!(manager.offset(id, repository).unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn a_digest_mismatch_is_refused_and_closes_the_upload() {
+        let (manager, _directory) = manager();
+        let repository = Uuid::new_v4();
+
+        let id = manager.start(repository, "alpine").await.unwrap();
+        manager
+            .append(id, repository, None, Bytes::from_static(b"actual"))
+            .await
+            .unwrap();
+
+        let wrong = Digest::sha256_of(b"something else");
+        let error = manager.finish(id, repository, &wrong).await.unwrap_err();
+        assert!(matches!(error, UploadError::DigestMismatch { .. }));
+
+        // A mismatch is not resumable, so the session is gone.
+        assert!(matches!(
+            manager.offset(id, repository).unwrap_err(),
+            UploadError::UnknownUpload(_)
+        ));
+    }
+
+    /// An upload id is not authority to write: it only works against the repository it was opened
+    /// against.
+    #[tokio::test]
+    async fn an_upload_cannot_be_committed_into_another_repository() {
+        let (manager, _directory) = manager();
+        let mine = Uuid::new_v4();
+        let theirs = Uuid::new_v4();
+
+        let id = manager.start(mine, "alpine").await.unwrap();
+        manager
+            .append(id, mine, None, Bytes::from_static(b"payload"))
+            .await
+            .unwrap();
+
+        let digest = Digest::sha256_of(b"payload");
+        assert!(matches!(
+            manager.finish(id, theirs, &digest).await.unwrap_err(),
+            UploadError::UnknownUpload(_)
+        ));
+        assert!(matches!(
+            manager
+                .append(id, theirs, None, Bytes::from_static(b"x"))
+                .await
+                .unwrap_err(),
+            UploadError::UnknownUpload(_)
+        ));
+        // Still usable by its owner.
+        assert_eq!(manager.offset(id, mine).unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn a_cancelled_upload_is_forgotten() {
+        let (manager, _directory) = manager();
+        let repository = Uuid::new_v4();
+
+        let id = manager.start(repository, "alpine").await.unwrap();
+        manager.cancel(id, repository).await.unwrap();
+        assert!(matches!(
+            manager.offset(id, repository).unwrap_err(),
+            UploadError::UnknownUpload(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn an_unknown_upload_is_refused() {
+        let (manager, _directory) = manager();
+        let repository = Uuid::new_v4();
+        let id = Uuid::new_v4();
+        assert!(matches!(
+            manager.offset(id, repository).unwrap_err(),
+            UploadError::UnknownUpload(_)
+        ));
+    }
+}

--- a/nitro_repo/src/repository/mod.rs
+++ b/nitro_repo/src/repository/mod.rs
@@ -27,7 +27,9 @@ pub mod staging;
 pub use staging::*;
 mod repo_http;
 pub use repo_http::*;
+pub mod cargo;
 pub mod commands;
+pub mod docker;
 pub mod maven;
 pub mod npm;
 mod repo_type;
@@ -157,4 +159,6 @@ pub trait Repository: Send + Sync + Clone + Debug {
 pub enum DynRepository {
     Maven(maven::MavenRepository),
     NPM(npm::NPMRegistry),
+    Cargo(cargo::CargoRegistry),
+    Docker(docker::DockerRegistry),
 }

--- a/nitro_repo/src/repository/npm/search.rs
+++ b/nitro_repo/src/repository/npm/search.rs
@@ -99,6 +99,10 @@ pub async fn handle_search(
 
     let site = repository.site();
     // npm sends the raw search text; `%` and `_` in it would otherwise act as LIKE wildcards.
+    //
+    // The `COLLATE "C"` below is not cosmetic: `projects.key` is declared with the nondeterministic
+    // `ignoreCase` collation, and Postgres refuses `ILIKE` against one ("nondeterministic
+    // collations are not supported for ILIKE"). Without it every search answered 500.
     let escaped = query
         .text
         .replace('\\', r"\\")
@@ -108,7 +112,8 @@ pub async fn handle_search(
 
     let total: i64 = sqlx::query_scalar(
         r#"SELECT COUNT(*) FROM projects
-           WHERE repository_id = $1 AND (key ILIKE $2 OR COALESCE(description, '') ILIKE $2)"#,
+           WHERE repository_id = $1
+             AND ((key COLLATE "C") ILIKE $2 OR COALESCE(description, '') ILIKE $2)"#,
     )
     .bind(repository.id())
     .bind(&pattern)
@@ -117,7 +122,8 @@ pub async fn handle_search(
 
     let projects: Vec<DBProject> = sqlx::query_as(
         r#"SELECT * FROM projects
-           WHERE repository_id = $1 AND (key ILIKE $2 OR COALESCE(description, '') ILIKE $2)
+           WHERE repository_id = $1
+             AND ((key COLLATE "C") ILIKE $2 OR COALESCE(description, '') ILIKE $2)
            ORDER BY updated_at DESC
            LIMIT $3 OFFSET $4"#,
     )

--- a/nitro_repo/src/seed/artifacts.rs
+++ b/nitro_repo/src/seed/artifacts.rs
@@ -140,6 +140,123 @@ pub fn npm_tarball(
     Ok(encoder.finish()?)
 }
 
+/// A `.crate` file: a gzipped tar whose entries all sit under `{name}-{version}/`, which is the
+/// layout `cargo package` produces and the one `cargo` expects when it unpacks a download.
+pub fn crate_file(name: &str, version: &str, description: Option<&str>) -> anyhow::Result<Vec<u8>> {
+    let prefix = format!("{name}-{version}");
+    let manifest = format!(
+        "[package]\nname = \"{name}\"\nversion = \"{version}\"\nedition = \"2021\"\n\
+         description = \"{}\"\nlicense = \"MIT\"\n",
+        description.unwrap_or("Seeded by nitro_repo")
+    );
+    let source = format!("pub fn name() -> &'static str {{ {name:?} }}\n");
+
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append(
+            &mut builder,
+            &format!("{prefix}/Cargo.toml"),
+            manifest.as_bytes(),
+        )?;
+        append(
+            &mut builder,
+            &format!("{prefix}/src/lib.rs"),
+            source.as_bytes(),
+        )?;
+        builder.finish()?;
+    }
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes)?;
+    Ok(encoder.finish()?)
+}
+
+/// The body `cargo publish` sends: two length-prefixed frames, metadata then the `.crate` file.
+pub fn cargo_publish_body(metadata: &serde_json::Value, crate_file: &[u8]) -> Vec<u8> {
+    let metadata = serde_json::to_vec(metadata).expect("metadata should serialise");
+    let mut body = Vec::with_capacity(metadata.len() + crate_file.len() + 8);
+    body.extend_from_slice(&(metadata.len() as u32).to_le_bytes());
+    body.extend_from_slice(&metadata);
+    body.extend_from_slice(&(crate_file.len() as u32).to_le_bytes());
+    body.extend_from_slice(crate_file);
+    body
+}
+
+pub fn sha256_hex(data: &[u8]) -> String {
+    hex(&sha2::Sha256::digest(data))
+}
+
+/// The `algorithm:hex` digest a registry addresses content by.
+pub fn oci_digest(data: &[u8]) -> String {
+    format!("sha256:{}", sha256_hex(data))
+}
+
+/// A gzipped-tar image layer holding one file, so a pushed image has real content in it.
+pub struct OciLayer {
+    /// What is uploaded as a blob, and what the manifest's layer descriptor names.
+    pub gzipped: Vec<u8>,
+    /// The digest of the *uncompressed* tar.
+    ///
+    /// This is what goes in the config's `rootfs.diff_ids`, and it is not the same as the blob's
+    /// digest. A Docker daemon decompresses each layer on pull and checks the result against the
+    /// diff id — using the compressed digest here makes the pull fail with `wrong diff id` after
+    /// everything has already transferred.
+    pub diff_id: String,
+}
+
+pub fn oci_layer(name: &str, contents: &str) -> anyhow::Result<OciLayer> {
+    let mut tar_bytes = Vec::new();
+    {
+        let mut builder = tar::Builder::new(&mut tar_bytes);
+        append(&mut builder, name, contents.as_bytes())?;
+        builder.finish()?;
+    }
+    let diff_id = oci_digest(&tar_bytes);
+
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&tar_bytes)?;
+    Ok(OciLayer {
+        gzipped: encoder.finish()?,
+        diff_id,
+    })
+}
+
+/// An OCI image config blob — the JSON document `docker inspect` shows.
+pub fn oci_config(layer: &OciLayer) -> Vec<u8> {
+    let config = serde_json::json!({
+        "architecture": "amd64",
+        "os": "linux",
+        "config": { "Env": ["PATH=/usr/local/bin:/usr/bin:/bin"] },
+        "rootfs": { "type": "layers", "diff_ids": [layer.diff_id] },
+        "history": [{ "created_by": "nitro_repo seed" }],
+    });
+    serde_json::to_vec(&config).expect("the config should serialise")
+}
+
+/// An OCI image manifest pointing at a config and one layer.
+///
+/// Returned as bytes rather than as a `Value`, because a manifest's digest is over the exact bytes
+/// that are sent — a caller that re-serialised it would compute a digest the registry disagrees
+/// with.
+pub fn oci_manifest(config: &[u8], layer: &[u8]) -> Vec<u8> {
+    let manifest = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.manifest.v1+json",
+        "config": {
+            "mediaType": "application/vnd.oci.image.config.v1+json",
+            "digest": oci_digest(config),
+            "size": config.len(),
+        },
+        "layers": [{
+            "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+            "digest": oci_digest(layer),
+            "size": layer.len(),
+        }],
+    });
+    serde_json::to_vec(&manifest).expect("the manifest should serialise")
+}
+
 fn append<W: Write>(builder: &mut tar::Builder<W>, path: &str, data: &[u8]) -> anyhow::Result<()> {
     let mut header = tar::Header::new_gnu();
     header.set_size(data.len() as u64);
@@ -272,6 +389,91 @@ mod tests {
     fn checksum_helpers_agree_with_known_digests() {
         assert_eq!(sha1_hex(b""), "da39a3ee5e6b4b0d3255bfef95601890afd80709");
         assert_eq!(md5_hex(b""), "d41d8cd98f00b204e9800998ecf8427e");
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    /// A layer's blob digest and its `diff_id` describe different bytes — compressed and not. A
+    /// config that names the compressed digest passes every registry-side check and then fails the
+    /// pull with `wrong diff id`, after the whole image has transferred.
+    #[test]
+    fn a_layers_diff_id_is_the_digest_of_the_uncompressed_tar() {
+        let layer = oci_layer("hello.txt", "contents").expect("builds");
+        assert_ne!(layer.diff_id, oci_digest(&layer.gzipped));
+
+        let mut decompressed = Vec::new();
+        std::io::Read::read_to_end(
+            &mut flate2::read::GzDecoder::new(std::io::Cursor::new(&layer.gzipped)),
+            &mut decompressed,
+        )
+        .expect("the layer should be gzip");
+        assert_eq!(layer.diff_id, oci_digest(&decompressed));
+
+        // And the config repeats it verbatim.
+        let config: serde_json::Value =
+            serde_json::from_slice(&oci_config(&layer)).expect("the config should be JSON");
+        assert_eq!(config["rootfs"]["diff_ids"][0], layer.diff_id);
+    }
+
+    #[test]
+    fn the_manifest_points_at_the_config_and_the_compressed_layer() {
+        let layer = oci_layer("hello.txt", "contents").unwrap();
+        let config = oci_config(&layer);
+        let manifest: serde_json::Value =
+            serde_json::from_slice(&oci_manifest(&config, &layer.gzipped)).unwrap();
+
+        assert_eq!(manifest["config"]["digest"], oci_digest(&config));
+        assert_eq!(manifest["config"]["size"], config.len());
+        assert_eq!(manifest["layers"][0]["digest"], oci_digest(&layer.gzipped));
+        assert_eq!(manifest["layers"][0]["size"], layer.gzipped.len());
+    }
+
+    #[test]
+    fn the_crate_file_unpacks_with_a_name_version_prefix() {
+        let bytes = crate_file("example", "1.0.0", Some("Example")).expect("builds");
+        let decoder = flate2::read::GzDecoder::new(std::io::Cursor::new(bytes));
+        let mut archive = tar::Archive::new(decoder);
+
+        let paths: Vec<String> = archive
+            .entries()
+            .expect("entries")
+            .map(|entry| entry.unwrap().path().unwrap().display().to_string())
+            .collect();
+
+        assert!(
+            paths.contains(&"example-1.0.0/Cargo.toml".to_owned()),
+            "{paths:?}"
+        );
+        assert!(
+            paths.contains(&"example-1.0.0/src/lib.rs".to_owned()),
+            "{paths:?}"
+        );
+    }
+
+    /// The frame lengths are little-endian u32s. Reading them the other way round would put the
+    /// split in the wrong place, and the failure would surface as unparseable JSON.
+    #[test]
+    fn the_publish_body_is_two_length_prefixed_frames() {
+        let metadata = serde_json::json!({ "name": "example", "vers": "1.0.0" });
+        let body = cargo_publish_body(&metadata, b"crate bytes");
+
+        let metadata_length = u32::from_le_bytes([body[0], body[1], body[2], body[3]]) as usize;
+        let metadata_end = 4 + metadata_length;
+        assert_eq!(
+            serde_json::from_slice::<serde_json::Value>(&body[4..metadata_end]).unwrap(),
+            metadata
+        );
+
+        let crate_length = u32::from_le_bytes([
+            body[metadata_end],
+            body[metadata_end + 1],
+            body[metadata_end + 2],
+            body[metadata_end + 3],
+        ]) as usize;
+        assert_eq!(crate_length, b"crate bytes".len());
+        assert_eq!(&body[metadata_end + 4..], b"crate bytes");
     }
 
     /// A tarball must be byte-identical across runs, so re-seeding does not produce a new integrity

--- a/nitro_repo/src/seed/config.rs
+++ b/nitro_repo/src/seed/config.rs
@@ -23,6 +23,12 @@ pub struct SeedConfig {
     /// npm packages to publish.
     #[serde(default)]
     pub npm: Vec<NpmPackage>,
+    /// Crates to publish.
+    #[serde(default)]
+    pub cargo: Vec<CargoCrate>,
+    /// Container images to push.
+    #[serde(default)]
+    pub docker: Vec<DockerImage>,
 }
 
 /// How to authenticate.
@@ -51,7 +57,7 @@ pub struct SeedStorage {
 pub struct SeedRepository {
     pub storage: String,
     pub name: String,
-    /// `maven` or `npm`.
+    /// `maven`, `npm`, `cargo` or `docker`.
     #[serde(rename = "type")]
     pub repository_type: String,
     /// Defaults to public so a seeded instance can be browsed without signing in.
@@ -101,6 +107,26 @@ pub struct NpmPackage {
     pub dist_tags: std::collections::BTreeMap<String, String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CargoCrate {
+    /// `{storage}/{repository}`.
+    pub repository: String,
+    pub name: String,
+    pub versions: Vec<String>,
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DockerImage {
+    /// `{storage}/{repository}`.
+    pub repository: String,
+    /// The image name *without* the `{storage}/{repository}` prefix — the seeder adds it, because
+    /// that is how a client addresses a registry that has no hostname of its own yet.
+    pub name: String,
+    pub tags: Vec<String>,
+}
+
 impl SeedConfig {
     /// The suite written by `seed --write-example`.
     ///
@@ -136,6 +162,18 @@ impl SeedConfig {
                     storage: "local".to_owned(),
                     name: "npm".to_owned(),
                     repository_type: "npm".to_owned(),
+                    visibility: "Public".to_owned(),
+                },
+                SeedRepository {
+                    storage: "local".to_owned(),
+                    name: "crates".to_owned(),
+                    repository_type: "cargo".to_owned(),
+                    visibility: "Public".to_owned(),
+                },
+                SeedRepository {
+                    storage: "local".to_owned(),
+                    name: "docker".to_owned(),
+                    repository_type: "docker".to_owned(),
                     visibility: "Public".to_owned(),
                 },
             ],
@@ -200,6 +238,28 @@ impl SeedConfig {
                         .collect(),
                 },
             ],
+            cargo: vec![
+                CargoCrate {
+                    repository: "local/crates".to_owned(),
+                    // Four characters or more, so the index path goes through the
+                    // `{c1c2}/{c3c4}/` branch rather than one of the short-name special cases.
+                    name: "nitro-example".to_owned(),
+                    versions: vec!["0.1.0".to_owned(), "0.2.0".to_owned(), "1.0.0".to_owned()],
+                    description: Some("A seeded crate".to_owned()),
+                },
+                CargoCrate {
+                    repository: "local/crates".to_owned(),
+                    // Three characters: the `3/{first}/` branch, which is easy to get wrong.
+                    name: "nrx".to_owned(),
+                    versions: vec!["0.1.0".to_owned()],
+                    description: Some("A short crate name, for the index prefix rule".to_owned()),
+                },
+            ],
+            docker: vec![DockerImage {
+                repository: "local/docker".to_owned(),
+                name: "example".to_owned(),
+                tags: vec!["1.0".to_owned(), "latest".to_owned()],
+            }],
         }
     }
 }

--- a/nitro_repo/src/seed/mod.rs
+++ b/nitro_repo/src/seed/mod.rs
@@ -19,7 +19,10 @@ use tracing::{info, warn};
 pub mod artifacts;
 pub mod config;
 
-use config::{MavenProject, NpmPackage, SeedAuth, SeedConfig, SeedRepository, SeedStorage};
+use config::{
+    CargoCrate, DockerImage, MavenProject, NpmPackage, SeedAuth, SeedConfig, SeedRepository,
+    SeedStorage,
+};
 
 pub struct Seeder {
     client: Client,
@@ -129,6 +132,12 @@ impl Seeder {
         }
         for package in &config.npm {
             self.publish_npm(package).await?;
+        }
+        for krate in &config.cargo {
+            self.publish_crate(krate).await?;
+        }
+        for image in &config.docker {
+            self.push_image(image).await?;
         }
 
         Ok(())
@@ -568,6 +577,152 @@ impl Seeder {
             }
         }
 
+        Ok(())
+    }
+
+    /// `cargo publish`: a `PUT` of two length-prefixed frames to `/api/v1/crates/new`.
+    async fn publish_crate(&mut self, krate: &CargoCrate) -> anyhow::Result<()> {
+        for version in &krate.versions {
+            let crate_file =
+                artifacts::crate_file(&krate.name, version, krate.description.as_deref())?;
+            let metadata = json!({
+                "name": krate.name,
+                "vers": version,
+                "deps": [],
+                "features": {},
+                "authors": ["nitro_repo seed"],
+                "description": krate.description.clone().unwrap_or_else(|| "Seeded by nitro_repo".to_owned()),
+                "keywords": [],
+                "categories": [],
+                "license": "MIT",
+            });
+            let body = artifacts::cargo_publish_body(&metadata, &crate_file);
+
+            let url = format!(
+                "{}/repositories/{}/api/v1/crates/new",
+                self.base, krate.repository
+            );
+            let response = self
+                .authorize(
+                    self.client
+                        .put(&url)
+                        .header("Content-Type", "application/octet-stream")
+                        .body(body),
+                )
+                .send()
+                .await?;
+
+            let status = response.status();
+            if status == StatusCode::CONFLICT {
+                warn!(krate = %krate.name, %version, "Already published, leaving it alone");
+                self.summary.skipped += 1;
+            } else if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                anyhow::bail!(
+                    "Publishing {}@{version} failed: {status} {body}",
+                    krate.name
+                );
+            } else {
+                info!(krate = %krate.name, %version, "Published");
+                self.summary.packages_published += 1;
+            }
+        }
+        Ok(())
+    }
+
+    /// `docker push`: each blob through the three-step upload, then the manifest.
+    ///
+    /// The image name carries the `{storage}/{repository}` prefix because a seeded registry has no
+    /// hostname of its own — this is exactly what a client would send to
+    /// `docker push localhost:6742/local/docker/example:1.0`.
+    async fn push_image(&mut self, image: &DockerImage) -> anyhow::Result<()> {
+        let name = format!("{}/{}", image.repository, image.name);
+
+        for tag in &image.tags {
+            // One layer per tag, so the two tags are genuinely different images rather than the
+            // same manifest under two names — which would not exercise re-tagging.
+            let layer = artifacts::oci_layer("hello.txt", &format!("{}:{tag}", image.name))?;
+            let config = artifacts::oci_config(&layer);
+            let manifest = artifacts::oci_manifest(&config, &layer.gzipped);
+
+            for blob in [&layer.gzipped, &config] {
+                self.push_blob(&name, blob).await?;
+            }
+
+            let url = format!("{}/v2/{name}/manifests/{tag}", self.base);
+            let response = self
+                .authorize(
+                    self.client
+                        .put(&url)
+                        .header("Content-Type", "application/vnd.oci.image.manifest.v1+json")
+                        .body(manifest),
+                )
+                .send()
+                .await?;
+
+            let status = response.status();
+            if !status.is_success() {
+                let body = response.text().await.unwrap_or_default();
+                anyhow::bail!("Pushing {name}:{tag} failed: {status} {body}");
+            }
+            info!(image = %name, %tag, "Pushed");
+            self.summary.packages_published += 1;
+        }
+        Ok(())
+    }
+
+    async fn push_blob(&mut self, name: &str, blob: &[u8]) -> anyhow::Result<()> {
+        let digest = artifacts::oci_digest(blob);
+
+        // A blob already present is the common case on a re-run, and skipping it is what a real
+        // client does too.
+        let head = self
+            .authorize(
+                self.client
+                    .head(format!("{}/v2/{name}/blobs/{digest}", self.base)),
+            )
+            .send()
+            .await?;
+        if head.status().is_success() {
+            self.summary.skipped += 1;
+            return Ok(());
+        }
+
+        let started = self
+            .authorize(
+                self.client
+                    .post(format!("{}/v2/{name}/blobs/uploads/", self.base)),
+            )
+            .send()
+            .await?;
+        if !started.status().is_success() {
+            let status = started.status();
+            let body = started.text().await.unwrap_or_default();
+            anyhow::bail!("Opening a blob upload for {name} failed: {status} {body}");
+        }
+        let location = started
+            .headers()
+            .get("location")
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned)
+            .ok_or_else(|| anyhow::anyhow!("The registry opened an upload with no Location"))?;
+        // Relative, as the registry emits it, so it is resolved against the instance base here.
+        let location = format!("{}{location}", self.base);
+
+        let response = self
+            .authorize(
+                self.client
+                    .put(format!("{location}?digest={digest}"))
+                    .body(blob.to_vec()),
+            )
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Committing a blob for {name} failed: {status} {body}");
+        }
+        self.summary.files_uploaded += 1;
         Ok(())
     }
 }

--- a/nitro_repo/tests/cargo.rs
+++ b/nitro_repo/tests/cargo.rs
@@ -1,0 +1,506 @@
+//! Cargo registry integration tests.
+//!
+//! Drives the real router with the requests `cargo publish`, `cargo add` and `cargo yank` send.
+//! No `cargo` binary is invoked: the bytes are built here so a test can assert on the exact frame
+//! layout and header shape a real client produces, including the ones a passing `cargo publish`
+//! would never let us see.
+
+mod common;
+
+use axum::http::StatusCode;
+use common::{TestServer, skip_without_database};
+use nitro_repo::seed::artifacts;
+use serde_json::{Value, json};
+
+const STORAGE: &str = "local";
+const REPOSITORY: &str = "crates";
+
+fn base() -> String {
+    format!("/repositories/{STORAGE}/{REPOSITORY}")
+}
+
+fn metadata(name: &str, version: &str) -> Value {
+    json!({
+        "name": name,
+        "vers": version,
+        "deps": [],
+        "features": {},
+        "authors": ["Test Admin"],
+        "description": "A crate published by the integration tests",
+        "documentation": null,
+        "homepage": null,
+        "readme": null,
+        "readme_file": null,
+        "keywords": [],
+        "categories": [],
+        "license": "MIT",
+        "license_file": null,
+        "repository": null,
+        "links": null,
+    })
+}
+
+struct Registry {
+    server: TestServer,
+    token: String,
+}
+
+impl Registry {
+    async fn start() -> Option<Self> {
+        let server = TestServer::start().await?;
+        server.install().await;
+        let session = server.sign_in().await;
+        let repository = server
+            .create_repository(&session, STORAGE, REPOSITORY, "cargo")
+            .await;
+        let token = server
+            .create_repository_token(&session, &repository, &["Read", "Write", "Edit"])
+            .await;
+        Some(Self { server, token })
+    }
+
+    /// What `cargo publish` sends: `PUT /api/v1/crates/new` with the two-frame body and a bare
+    /// token.
+    async fn publish(&self, name: &str, version: &str) -> common::TestResponse {
+        let crate_file = artifacts::crate_file(name, version, Some("Example")).expect("builds");
+        let body = artifacts::cargo_publish_body(&metadata(name, version), &crate_file);
+        self.server
+            .request_with_bare_token(
+                "PUT",
+                &format!("{}/api/v1/crates/new", base()),
+                &self.token,
+                body,
+            )
+            .await
+    }
+
+    /// The index lines for a crate, parsed.
+    async fn index(&self, name: &str) -> Vec<Value> {
+        let path = index_path(name);
+        let response = self.server.get(&format!("{}/index/{path}", base())).await;
+        assert_eq!(
+            response.status,
+            StatusCode::OK,
+            "index fetch failed: {}",
+            response.text
+        );
+        response
+            .text
+            .lines()
+            .filter(|line| !line.trim().is_empty())
+            .map(|line| serde_json::from_str(line).expect("each index line should be JSON"))
+            .collect()
+    }
+}
+
+/// Mirrors the server's own prefix rule, written out separately so a test would catch the server
+/// changing it.
+fn index_path(name: &str) -> String {
+    let lower = name.to_lowercase();
+    match lower.len() {
+        1 => format!("1/{lower}"),
+        2 => format!("2/{lower}"),
+        3 => format!("3/{}/{lower}", &lower[0..1]),
+        _ => format!("{}/{}/{lower}", &lower[0..2], &lower[2..4]),
+    }
+}
+
+#[tokio::test]
+async fn a_published_crate_appears_in_the_index() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "a_published_crate_appears_in_the_index"
+        ));
+        return;
+    };
+
+    let response = registry.publish("example", "1.0.0").await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "publish failed: {}",
+        response.text
+    );
+
+    let lines = registry.index("example").await;
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert_eq!(lines[0]["name"], "example");
+    assert_eq!(lines[0]["vers"], "1.0.0");
+    assert_eq!(lines[0]["yanked"], false);
+    assert_eq!(lines[0]["v"], 2);
+
+    // `cksum` is what cargo verifies every download against, so it has to be the digest of the
+    // bytes the registry actually stored — not merely present.
+    let expected =
+        artifacts::sha256_hex(&artifacts::crate_file("example", "1.0.0", Some("Example")).unwrap());
+    assert_eq!(lines[0]["cksum"], expected);
+}
+
+#[tokio::test]
+async fn a_published_crate_can_be_downloaded() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("a_published_crate_can_be_downloaded"));
+        return;
+    };
+    registry.publish("example", "1.0.0").await;
+
+    let response = registry
+        .server
+        .get(&format!("{}/api/v1/crates/example/1.0.0/download", base()))
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "download failed: {}",
+        response.text
+    );
+
+    let expected = artifacts::crate_file("example", "1.0.0", Some("Example")).unwrap();
+    assert_eq!(response.bytes, expected);
+}
+
+#[tokio::test]
+async fn the_index_path_is_correct_for_every_name_length() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "the_index_path_is_correct_for_every_name_length"
+        ));
+        return;
+    };
+
+    // One name per bucket of the prefix rule: `1/`, `2/`, `3/{c}/` and `{c1c2}/{c3c4}/`.
+    for name in ["a", "ab", "abc", "abcd", "example"] {
+        let response = registry.publish(name, "1.0.0").await;
+        assert_eq!(
+            response.status,
+            StatusCode::OK,
+            "publishing `{name}` failed: {}",
+            response.text
+        );
+        let lines = registry.index(name).await;
+        assert_eq!(lines[0]["name"], name, "wrong crate served for `{name}`");
+    }
+}
+
+/// A prefix that does not match the name would let one crate be served under another's path, and a
+/// cargo client caches by path.
+#[tokio::test]
+async fn an_index_path_that_does_not_match_the_name_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "an_index_path_that_does_not_match_the_name_is_refused"
+        ));
+        return;
+    };
+    registry.publish("example", "1.0.0").await;
+
+    // `example` lives at `ex/am/example`.
+    let response = registry
+        .server
+        .get(&format!("{}/index/aa/bb/example", base()))
+        .await;
+    assert_eq!(response.status, StatusCode::NOT_FOUND, "{}", response.text);
+}
+
+#[tokio::test]
+async fn republishing_an_existing_version_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "republishing_an_existing_version_is_refused"
+        ));
+        return;
+    };
+    assert_eq!(
+        registry.publish("example", "1.0.0").await.status,
+        StatusCode::OK
+    );
+
+    let second = registry.publish("example", "1.0.0").await;
+    assert_eq!(second.status, StatusCode::CONFLICT, "{}", second.text);
+    // Cargo prints `errors[].detail`; anything else reaches the user as a bare status.
+    assert!(
+        second.json()["errors"][0]["detail"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("already exists"),
+        "{}",
+        second.text
+    );
+
+    // The first publish must still be intact.
+    let lines = registry.index("example").await;
+    assert_eq!(lines.len(), 1);
+}
+
+#[tokio::test]
+async fn yank_marks_the_version_and_unyank_clears_it() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "yank_marks_the_version_and_unyank_clears_it"
+        ));
+        return;
+    };
+    registry.publish("example", "1.0.0").await;
+
+    let yank = registry
+        .server
+        .request_with_bare_token(
+            "DELETE",
+            &format!("{}/api/v1/crates/example/1.0.0/yank", base()),
+            &registry.token,
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(yank.status, StatusCode::OK, "{}", yank.text);
+    assert_eq!(registry.index("example").await[0]["yanked"], true);
+
+    // A yanked version is still downloadable — a lockfile that already pins it must keep working.
+    let download = registry
+        .server
+        .get(&format!("{}/api/v1/crates/example/1.0.0/download", base()))
+        .await;
+    assert_eq!(download.status, StatusCode::OK, "{}", download.text);
+
+    let unyank = registry
+        .server
+        .request_with_bare_token(
+            "PUT",
+            &format!("{}/api/v1/crates/example/1.0.0/unyank", base()),
+            &registry.token,
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(unyank.status, StatusCode::OK, "{}", unyank.text);
+    assert_eq!(registry.index("example").await[0]["yanked"], false);
+}
+
+#[tokio::test]
+async fn config_json_tells_cargo_where_to_find_the_api() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "config_json_tells_cargo_where_to_find_the_api"
+        ));
+        return;
+    };
+
+    let response = registry
+        .server
+        .get(&format!("{}/index/config.json", base()))
+        .await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text);
+
+    let config = response.json();
+    let expected = format!("http://localhost:6742{}", base());
+    assert_eq!(config["api"], expected);
+    assert_eq!(config["dl"], format!("{expected}/api/v1/crates"));
+    // The registry is public, so cargo should not be told to send a token.
+    assert_eq!(config["auth-required"], false);
+}
+
+/// A custom domain has to describe *itself* — telling cargo to go back through
+/// `/repositories/{storage}/{name}` would work only where both hosts are reachable.
+#[tokio::test]
+async fn config_json_follows_a_custom_domain() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("config_json_follows_a_custom_domain"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, REPOSITORY, "cargo")
+        .await;
+    let added = server
+        .add_hostname(&session, &repository, "crates.example.com")
+        .await;
+    assert!(added.status.is_success(), "{}", added.text);
+
+    let response = server
+        .get_with_host("crates.example.com", "/index/config.json")
+        .await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text);
+
+    let config = response.json();
+    assert_eq!(config["api"], "http://crates.example.com");
+    assert_eq!(config["dl"], "http://crates.example.com/api/v1/crates");
+}
+
+#[tokio::test]
+async fn an_anonymous_publish_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("an_anonymous_publish_is_refused"));
+        return;
+    };
+
+    let crate_file = artifacts::crate_file("example", "1.0.0", None).unwrap();
+    let body = artifacts::cargo_publish_body(&metadata("example", "1.0.0"), &crate_file);
+    let response = registry
+        .server
+        .request(
+            axum::http::Request::builder()
+                .method("PUT")
+                .uri(format!("{}/api/v1/crates/new", base()))
+                .body(axum::body::Body::from(body))
+                .unwrap(),
+        )
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::UNAUTHORIZED,
+        "{}",
+        response.text
+    );
+
+    // Nothing should have been recorded.
+    let index = registry
+        .server
+        .get(&format!("{}/index/ex/am/example", base()))
+        .await;
+    assert_eq!(index.status, StatusCode::NOT_FOUND);
+}
+
+/// The whole point of the scheme-less `Authorization` header change: cargo sends the token bare,
+/// and the parser used to reject anything that was not `<scheme> <value>`.
+#[tokio::test]
+async fn a_bare_authorization_token_is_accepted() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "a_bare_authorization_token_is_accepted"
+        ));
+        return;
+    };
+
+    let response = registry.publish("example", "1.0.0").await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "a bare token should authenticate: {}",
+        response.text
+    );
+}
+
+#[tokio::test]
+async fn the_index_answers_conditional_requests() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "the_index_answers_conditional_requests"
+        ));
+        return;
+    };
+    registry.publish("example", "1.0.0").await;
+
+    let first = registry
+        .server
+        .get(&format!("{}/index/ex/am/example", base()))
+        .await;
+    let etag = first
+        .headers
+        .get("etag")
+        .expect("the index should carry an ETag")
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    let second = registry
+        .server
+        .get_with_headers(
+            &format!("{}/index/ex/am/example", base()),
+            &[("if-none-match", &etag)],
+        )
+        .await;
+    assert_eq!(second.status, StatusCode::NOT_MODIFIED, "{}", second.text);
+
+    // Publishing another version must change the ETag, or a client would never see it.
+    registry.publish("example", "1.1.0").await;
+    let third = registry
+        .server
+        .get_with_headers(
+            &format!("{}/index/ex/am/example", base()),
+            &[("if-none-match", &etag)],
+        )
+        .await;
+    assert_eq!(third.status, StatusCode::OK, "{}", third.text);
+    assert_eq!(registry.index("example").await.len(), 2);
+}
+
+#[tokio::test]
+async fn the_publisher_becomes_the_crates_owner() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "the_publisher_becomes_the_crates_owner"
+        ));
+        return;
+    };
+    registry.publish("example", "1.0.0").await;
+
+    let response = registry
+        .server
+        .get(&format!("{}/api/v1/crates/example/owners", base()))
+        .await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text);
+
+    let owners = response.json();
+    let logins: Vec<&str> = owners["users"]
+        .as_array()
+        .expect("users should be a list")
+        .iter()
+        .map(|user| user["login"].as_str().unwrap())
+        .collect();
+    assert_eq!(logins, vec![common::TEST_USERNAME]);
+}
+
+#[tokio::test]
+async fn search_finds_a_published_crate() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("search_finds_a_published_crate"));
+        return;
+    };
+    registry.publish("example", "1.0.0").await;
+    registry.publish("unrelated", "2.0.0").await;
+
+    let response = registry
+        .server
+        .get(&format!("{}/api/v1/crates?q=exam&per_page=10", base()))
+        .await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.text);
+
+    let results = response.json();
+    let names: Vec<&str> = results["crates"]
+        .as_array()
+        .expect("crates should be a list")
+        .iter()
+        .map(|found| found["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["example"]);
+    assert_eq!(results["crates"][0]["max_version"], "1.0.0");
+}
+
+/// A malformed frame must be refused before anything is allocated for it, and must not leave a
+/// half-created project behind.
+#[tokio::test]
+async fn a_malformed_publish_body_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("a_malformed_publish_body_is_refused"));
+        return;
+    };
+
+    // A metadata length of u32::MAX with two bytes behind it.
+    let mut body = u32::MAX.to_le_bytes().to_vec();
+    body.extend_from_slice(b"{}");
+
+    let response = registry
+        .server
+        .request_with_bare_token(
+            "PUT",
+            &format!("{}/api/v1/crates/new", base()),
+            &registry.token,
+            body,
+        )
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::BAD_REQUEST,
+        "{}",
+        response.text
+    );
+}

--- a/nitro_repo/tests/common/mod.rs
+++ b/nitro_repo/tests/common/mod.rs
@@ -327,6 +327,78 @@ impl TestServer {
         .await
     }
 
+    /// Mints an auth token scoped to one repository, and returns its secret.
+    ///
+    /// This is how cargo and Docker authenticate — neither ever sees the user's password — so a
+    /// test that wants to behave like the real client has to go and get one the same way.
+    pub async fn create_repository_token(
+        &self,
+        session: &str,
+        repository_id: &str,
+        actions: &[&str],
+    ) -> String {
+        let response = self
+            .post_json_as(
+                "/api/user/token/create",
+                json!({
+                    "name": "integration test",
+                    "repository_scopes": [
+                        { "repository_id": repository_id, "scopes": actions }
+                    ],
+                }),
+                session,
+            )
+            .await;
+        assert!(
+            response.status.is_success(),
+            "creating a token failed: {} {}",
+            response.status,
+            response.text
+        );
+        response.json()["token"]
+            .as_str()
+            .expect("the response should carry a token")
+            .to_owned()
+    }
+
+    /// A request with an arbitrary method, body, headers and (optionally) a `Host`.
+    ///
+    /// Docker pushes need all four at once — `PATCH` with a `Content-Range`, `PUT` with a
+    /// `Content-Type`, both bearing a token — which none of the narrower helpers above cover.
+    pub async fn send(
+        &self,
+        method: &str,
+        path: &str,
+        headers: &[(&str, &str)],
+        body: Vec<u8>,
+    ) -> TestResponse {
+        let mut builder = Request::builder().method(method).uri(path);
+        for (name, value) in headers {
+            builder = builder.header(*name, *value);
+        }
+        self.request(builder.body(Body::from(body)).expect("valid request"))
+            .await
+    }
+
+    /// A request carrying `Authorization: <token>` with no scheme — the way cargo sends it.
+    pub async fn request_with_bare_token(
+        &self,
+        method: &str,
+        path: &str,
+        token: &str,
+        body: Vec<u8>,
+    ) -> TestResponse {
+        self.request(
+            Request::builder()
+                .method(method)
+                .uri(path)
+                .header(header::AUTHORIZATION, token)
+                .body(Body::from(body))
+                .expect("valid request"),
+        )
+        .await
+    }
+
     /// A `GET` addressed to a specific host.
     ///
     /// `Request::builder().uri("/x")` produces a URI with no authority, so `Host` is the only

--- a/nitro_repo/tests/docker.rs
+++ b/nitro_repo/tests/docker.rs
@@ -1,0 +1,916 @@
+//! Docker registry integration tests.
+//!
+//! Drives the real router with the request sequence `docker push` and `docker pull` send: the
+//! `/v2/` version probe, the bearer challenge and token exchange, `POST`/`PATCH`/`PUT` for each
+//! blob, then the manifest. No Docker daemon is involved — the bytes are built here so the tests
+//! can assert on things a successful push would never reveal, such as what happens to a blob whose
+//! digest is wrong.
+
+mod common;
+
+use axum::http::StatusCode;
+use base64::{Engine, engine::general_purpose::STANDARD};
+use common::{TestResponse, TestServer, skip_without_database};
+use nitro_repo::seed::artifacts;
+
+const STORAGE: &str = "local";
+const REPOSITORY: &str = "docker";
+/// In prefix mode the storage and repository are the first two segments of the image name.
+const IMAGE: &str = "local/docker/alpine";
+
+const OCI_MANIFEST_TYPE: &str = "application/vnd.oci.image.manifest.v1+json";
+
+struct Registry {
+    server: TestServer,
+    token: String,
+}
+
+/// The bytes of one image: a layer, a config that references it, and a manifest over both.
+struct Image {
+    layer: Vec<u8>,
+    config: Vec<u8>,
+    manifest: Vec<u8>,
+}
+
+impl Image {
+    fn build(marker: &str) -> Self {
+        let layer = artifacts::oci_layer("hello.txt", marker).expect("builds");
+        let config = artifacts::oci_config(&layer);
+        let manifest = artifacts::oci_manifest(&config, &layer.gzipped);
+        Self {
+            layer: layer.gzipped,
+            config,
+            manifest,
+        }
+    }
+
+    fn digest(&self) -> String {
+        artifacts::oci_digest(&self.manifest)
+    }
+}
+
+impl Registry {
+    async fn start() -> Option<Self> {
+        let server = TestServer::start().await?;
+        server.install().await;
+        let session = server.sign_in().await;
+        let repository = server
+            .create_repository(&session, STORAGE, REPOSITORY, "docker")
+            .await;
+        let token = server
+            .create_repository_token(&session, &repository, &["Read", "Write", "Edit"])
+            .await;
+        Some(Self { server, token })
+    }
+
+    fn auth(&self) -> String {
+        format!("Bearer {}", self.token)
+    }
+
+    /// Uploads one blob the way a client does: open a session, stream it, commit it by digest.
+    async fn push_blob(&self, image: &str, bytes: &[u8]) -> TestResponse {
+        let digest = artifacts::oci_digest(bytes);
+
+        let started = self
+            .server
+            .send(
+                "POST",
+                &format!("/v2/{image}/blobs/uploads/"),
+                &[("authorization", &self.auth())],
+                Vec::new(),
+            )
+            .await;
+        assert_eq!(
+            started.status,
+            StatusCode::ACCEPTED,
+            "opening an upload failed: {}",
+            started.text
+        );
+        let location = started
+            .headers
+            .get("location")
+            .expect("an opened upload should carry a Location")
+            .to_str()
+            .unwrap()
+            .to_owned();
+
+        let patched = self
+            .server
+            .send(
+                "PATCH",
+                &location,
+                &[
+                    ("authorization", &self.auth()),
+                    (
+                        "content-range",
+                        &format!("0-{}", bytes.len().saturating_sub(1)),
+                    ),
+                ],
+                bytes.to_vec(),
+            )
+            .await;
+        assert_eq!(
+            patched.status,
+            StatusCode::ACCEPTED,
+            "streaming a blob failed: {}",
+            patched.text
+        );
+
+        self.server
+            .send(
+                "PUT",
+                &format!("{location}?digest={digest}"),
+                &[("authorization", &self.auth())],
+                Vec::new(),
+            )
+            .await
+    }
+
+    async fn push_manifest(&self, image: &str, reference: &str, manifest: &[u8]) -> TestResponse {
+        self.server
+            .send(
+                "PUT",
+                &format!("/v2/{image}/manifests/{reference}"),
+                &[
+                    ("authorization", &self.auth()),
+                    ("content-type", OCI_MANIFEST_TYPE),
+                ],
+                manifest.to_vec(),
+            )
+            .await
+    }
+
+    /// The whole of `docker push`.
+    async fn push(&self, image: &str, tag: &str, built: &Image) -> TestResponse {
+        assert_eq!(
+            self.push_blob(image, &built.layer).await.status,
+            StatusCode::CREATED
+        );
+        assert_eq!(
+            self.push_blob(image, &built.config).await.status,
+            StatusCode::CREATED
+        );
+        self.push_manifest(image, tag, &built.manifest).await
+    }
+
+    async fn get(&self, path: &str) -> TestResponse {
+        self.server
+            .send("GET", path, &[("authorization", &self.auth())], Vec::new())
+            .await
+    }
+}
+
+#[tokio::test]
+async fn an_image_round_trips() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("an_image_round_trips"));
+        return;
+    };
+    let built = Image::build("round trip");
+
+    let pushed = registry.push(IMAGE, "1.0", &built).await;
+    assert_eq!(
+        pushed.status,
+        StatusCode::CREATED,
+        "pushing the manifest failed: {}",
+        pushed.text
+    );
+    assert_eq!(
+        pushed.headers.get("docker-content-digest").unwrap(),
+        built.digest().as_str()
+    );
+
+    // By tag.
+    let by_tag = registry.get(&format!("/v2/{IMAGE}/manifests/1.0")).await;
+    assert_eq!(by_tag.status, StatusCode::OK, "{}", by_tag.text);
+    assert_eq!(by_tag.bytes, built.manifest);
+    assert_eq!(
+        by_tag.headers.get("content-type").unwrap(),
+        OCI_MANIFEST_TYPE
+    );
+    assert_eq!(
+        by_tag.headers.get("docker-content-digest").unwrap(),
+        built.digest().as_str()
+    );
+
+    // By digest — the same bytes, which is what makes the digest meaningful.
+    let by_digest = registry
+        .get(&format!("/v2/{IMAGE}/manifests/{}", built.digest()))
+        .await;
+    assert_eq!(by_digest.status, StatusCode::OK, "{}", by_digest.text);
+    assert_eq!(by_digest.bytes, built.manifest);
+
+    // And the layer comes back byte-for-byte.
+    let layer = registry
+        .get(&format!(
+            "/v2/{IMAGE}/blobs/{}",
+            artifacts::oci_digest(&built.layer)
+        ))
+        .await;
+    assert_eq!(layer.status, StatusCode::OK, "{}", layer.text);
+    assert_eq!(layer.bytes, built.layer);
+}
+
+/// A push re-uploads every layer unless `HEAD` can tell it what is already here, so this is the
+/// difference between a fast push and a slow one.
+#[tokio::test]
+async fn head_reports_what_is_already_present() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "head_reports_what_is_already_present"
+        ));
+        return;
+    };
+    let built = Image::build("head");
+    let layer_digest = artifacts::oci_digest(&built.layer);
+
+    let missing = registry
+        .server
+        .send(
+            "HEAD",
+            &format!("/v2/{IMAGE}/blobs/{layer_digest}"),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(missing.status, StatusCode::NOT_FOUND);
+
+    registry.push(IMAGE, "1.0", &built).await;
+
+    let present = registry
+        .server
+        .send(
+            "HEAD",
+            &format!("/v2/{IMAGE}/blobs/{layer_digest}"),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(present.status, StatusCode::OK, "{}", present.text);
+    // Same headers as the GET, no body.
+    assert_eq!(
+        present.headers.get("content-length").unwrap(),
+        built.layer.len().to_string().as_str()
+    );
+    assert!(present.bytes.is_empty());
+
+    let manifest_head = registry
+        .server
+        .send(
+            "HEAD",
+            &format!("/v2/{IMAGE}/manifests/1.0"),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(manifest_head.status, StatusCode::OK);
+    assert_eq!(
+        manifest_head.headers.get("docker-content-digest").unwrap(),
+        built.digest().as_str()
+    );
+    assert!(manifest_head.bytes.is_empty());
+}
+
+#[tokio::test]
+async fn a_blob_whose_digest_does_not_match_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "a_blob_whose_digest_does_not_match_is_refused"
+        ));
+        return;
+    };
+
+    let started = registry
+        .server
+        .send(
+            "POST",
+            &format!("/v2/{IMAGE}/blobs/uploads/"),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    let location = started
+        .headers
+        .get("location")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_owned();
+
+    registry
+        .server
+        .send(
+            "PATCH",
+            &location,
+            &[("authorization", &registry.auth())],
+            b"the real content".to_vec(),
+        )
+        .await;
+
+    // Committed under the digest of something else entirely.
+    let wrong = artifacts::oci_digest(b"not what was uploaded");
+    let committed = registry
+        .server
+        .send(
+            "PUT",
+            &format!("{location}?digest={wrong}"),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(
+        committed.status,
+        StatusCode::BAD_REQUEST,
+        "{}",
+        committed.text
+    );
+    assert_eq!(committed.json()["errors"][0]["code"], "DIGEST_INVALID");
+
+    // Nothing must have reached storage under either digest.
+    for digest in [wrong, artifacts::oci_digest(b"the real content")] {
+        let fetched = registry.get(&format!("/v2/{IMAGE}/blobs/{digest}")).await;
+        assert_eq!(fetched.status, StatusCode::NOT_FOUND, "{digest}");
+    }
+}
+
+/// A manifest accepted before its layers are here produces an image that pushes fine and fails
+/// every pull, with nothing to say which push was at fault.
+#[tokio::test]
+async fn a_manifest_referencing_a_missing_blob_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "a_manifest_referencing_a_missing_blob_is_refused"
+        ));
+        return;
+    };
+    let built = Image::build("missing blob");
+
+    // The config is pushed but the layer is not.
+    assert_eq!(
+        registry.push_blob(IMAGE, &built.config).await.status,
+        StatusCode::CREATED
+    );
+
+    let pushed = registry.push_manifest(IMAGE, "1.0", &built.manifest).await;
+    assert_eq!(pushed.status, StatusCode::BAD_REQUEST, "{}", pushed.text);
+    assert_eq!(pushed.json()["errors"][0]["code"], "MANIFEST_BLOB_UNKNOWN");
+
+    let fetched = registry.get(&format!("/v2/{IMAGE}/manifests/1.0")).await;
+    assert_eq!(fetched.status, StatusCode::NOT_FOUND);
+}
+
+/// A manifest pushed by digest must actually hash to that digest, or the registry would serve
+/// content under an identity that is not its own.
+#[tokio::test]
+async fn a_manifest_pushed_under_the_wrong_digest_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "a_manifest_pushed_under_the_wrong_digest_is_refused"
+        ));
+        return;
+    };
+    let built = Image::build("wrong digest");
+    registry.push_blob(IMAGE, &built.layer).await;
+    registry.push_blob(IMAGE, &built.config).await;
+
+    let wrong = artifacts::oci_digest(b"a different manifest");
+    let pushed = registry.push_manifest(IMAGE, &wrong, &built.manifest).await;
+    assert_eq!(pushed.status, StatusCode::BAD_REQUEST, "{}", pushed.text);
+    assert_eq!(pushed.json()["errors"][0]["code"], "DIGEST_INVALID");
+}
+
+#[tokio::test]
+async fn tags_list_and_catalog_reflect_what_was_pushed() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "tags_list_and_catalog_reflect_what_was_pushed"
+        ));
+        return;
+    };
+
+    for tag in ["1.0", "1.1", "latest"] {
+        let built = Image::build(tag);
+        assert_eq!(
+            registry.push(IMAGE, tag, &built).await.status,
+            StatusCode::CREATED
+        );
+    }
+    let other = Image::build("other");
+    registry.push("local/docker/busybox", "1.0", &other).await;
+
+    let tags = registry.get(&format!("/v2/{IMAGE}/tags/list")).await;
+    assert_eq!(tags.status, StatusCode::OK, "{}", tags.text);
+    let body = tags.json();
+    assert_eq!(body["name"], IMAGE);
+    // Lexically ordered, which is what the spec says and what makes `?last=` paging meaningful.
+    assert_eq!(
+        body["tags"].as_array().unwrap(),
+        &vec!["1.0", "1.1", "latest"]
+    );
+
+    let catalog = registry.get("/v2/local/docker/_catalog").await;
+    assert_eq!(catalog.status, StatusCode::OK, "{}", catalog.text);
+    let repositories = catalog.json();
+    let names: Vec<&str> = repositories["repositories"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|name| name.as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["local/docker/alpine", "local/docker/busybox"]);
+}
+
+/// `:latest` moves with every push. A repository that refused to re-tag would be unusable.
+#[tokio::test]
+async fn a_tag_can_be_moved_to_a_new_manifest() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "a_tag_can_be_moved_to_a_new_manifest"
+        ));
+        return;
+    };
+
+    let first = Image::build("first");
+    assert_eq!(
+        registry.push(IMAGE, "latest", &first).await.status,
+        StatusCode::CREATED
+    );
+
+    let second = Image::build("second");
+    assert_ne!(first.digest(), second.digest());
+    assert_eq!(
+        registry.push(IMAGE, "latest", &second).await.status,
+        StatusCode::CREATED
+    );
+
+    let fetched = registry.get(&format!("/v2/{IMAGE}/manifests/latest")).await;
+    assert_eq!(fetched.bytes, second.manifest);
+
+    // The old manifest is still reachable by digest — only the tag moved.
+    let old = registry
+        .get(&format!("/v2/{IMAGE}/manifests/{}", first.digest()))
+        .await;
+    assert_eq!(old.status, StatusCode::OK, "{}", old.text);
+    assert_eq!(old.bytes, first.manifest);
+
+    // And there is still exactly one tag.
+    let tags = registry.get(&format!("/v2/{IMAGE}/tags/list")).await;
+    assert_eq!(tags.json()["tags"].as_array().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn an_anonymous_push_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("an_anonymous_push_is_refused"));
+        return;
+    };
+
+    let started = registry
+        .server
+        .send(
+            "POST",
+            &format!("/v2/{IMAGE}/blobs/uploads/"),
+            &[],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(started.status, StatusCode::UNAUTHORIZED, "{}", started.text);
+    // A client that is not challenged never tries to authenticate.
+    let challenge = started
+        .headers
+        .get("www-authenticate")
+        .expect("an anonymous push should be challenged")
+        .to_str()
+        .unwrap();
+    assert!(challenge.starts_with("Bearer realm="), "{challenge}");
+    assert!(
+        challenge.contains(&format!("scope=\"repository:{IMAGE}:pull,push\"")),
+        "{challenge}"
+    );
+}
+
+/// The `/v2/` probe and the realm exchange, which is the whole of `docker login`.
+#[tokio::test]
+async fn the_token_endpoint_mints_a_usable_credential() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "the_token_endpoint_mints_a_usable_credential"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, STORAGE, REPOSITORY, "docker")
+        .await;
+
+    // A public registry answers the probe without credentials.
+    let probe = server.get("/v2/").await;
+    assert_eq!(probe.status, StatusCode::OK, "{}", probe.text);
+    assert_eq!(
+        probe
+            .headers
+            .get("docker-distribution-api-version")
+            .unwrap(),
+        "registry/2.0"
+    );
+
+    let credentials = STANDARD.encode(format!(
+        "{}:{}",
+        common::TEST_USERNAME,
+        common::TEST_PASSWORD
+    ));
+    let minted = server
+        .send(
+            "GET",
+            &format!("/api/docker/token?service=nitro&scope=repository:{IMAGE}:pull,push"),
+            &[("authorization", &format!("Basic {credentials}"))],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(minted.status, StatusCode::OK, "{}", minted.text);
+
+    let body = minted.json();
+    let token = body["token"].as_str().expect("a token").to_owned();
+    // Both names are sent because different clients read different ones.
+    assert_eq!(body["access_token"].as_str(), Some(token.as_str()));
+    assert!(body["expires_in"].as_i64().unwrap() > 0);
+
+    // And the token actually authenticates a push.
+    let registry = Registry { server, token };
+    let built = Image::build("via token");
+    assert_eq!(
+        registry.push(IMAGE, "1.0", &built).await.status,
+        StatusCode::CREATED
+    );
+}
+
+#[tokio::test]
+async fn bad_credentials_do_not_mint_a_token() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("bad_credentials_do_not_mint_a_token"));
+        return;
+    };
+    server.install().await;
+
+    let credentials = STANDARD.encode(format!("{}:wrong-password", common::TEST_USERNAME));
+    let refused = server
+        .send(
+            "GET",
+            "/api/docker/token?scope=repository:local/docker/alpine:pull",
+            &[("authorization", &format!("Basic {credentials}"))],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(refused.status, StatusCode::UNAUTHORIZED, "{}", refused.text);
+}
+
+/// Hostname mode: the image name carries no storage/repository prefix, because the host already
+/// says which repository this is.
+#[tokio::test]
+async fn an_image_round_trips_over_a_custom_domain() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "an_image_round_trips_over_a_custom_domain"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, REPOSITORY, "docker")
+        .await;
+    let added = server
+        .add_hostname(&session, &repository, "docker.example.com")
+        .await;
+    assert!(added.status.is_success(), "{}", added.text);
+    let token = server
+        .create_repository_token(&session, &repository, &["Read", "Write"])
+        .await;
+    let auth = format!("Bearer {token}");
+
+    let built = Image::build("custom domain");
+    let host = [("host", "docker.example.com")];
+
+    // Blob, then manifest, all under the bare image name.
+    for blob in [&built.layer, &built.config] {
+        let started = server
+            .send(
+                "POST",
+                "/v2/alpine/blobs/uploads/",
+                &[("authorization", &auth), host[0]],
+                Vec::new(),
+            )
+            .await;
+        assert_eq!(started.status, StatusCode::ACCEPTED, "{}", started.text);
+        let location = started
+            .headers
+            .get("location")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_owned();
+        server
+            .send(
+                "PATCH",
+                &location,
+                &[("authorization", &auth), host[0]],
+                blob.to_vec(),
+            )
+            .await;
+        let committed = server
+            .send(
+                "PUT",
+                &format!("{location}?digest={}", artifacts::oci_digest(blob)),
+                &[("authorization", &auth), host[0]],
+                Vec::new(),
+            )
+            .await;
+        assert_eq!(committed.status, StatusCode::CREATED, "{}", committed.text);
+    }
+
+    let pushed = server
+        .send(
+            "PUT",
+            "/v2/alpine/manifests/1.0",
+            &[
+                ("authorization", &auth),
+                ("content-type", OCI_MANIFEST_TYPE),
+                host[0],
+            ],
+            built.manifest.clone(),
+        )
+        .await;
+    assert_eq!(pushed.status, StatusCode::CREATED, "{}", pushed.text);
+
+    let fetched = server
+        .send(
+            "GET",
+            "/v2/alpine/manifests/1.0",
+            &[("authorization", &auth), host[0]],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(fetched.status, StatusCode::OK, "{}", fetched.text);
+    assert_eq!(fetched.bytes, built.manifest);
+}
+
+/// `/v2` is mounted at the host root, so it must not swallow a Maven artifact whose path happens to
+/// begin with `v2/` on a custom domain.
+#[tokio::test]
+async fn a_v2_path_on_a_maven_domain_still_serves_the_artifact() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_v2_path_on_a_maven_domain_still_serves_the_artifact"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, "releases", "maven")
+        .await;
+    let added = server
+        .add_hostname(&session, &repository, "maven.example.com")
+        .await;
+    assert!(added.status.is_success(), "{}", added.text);
+
+    let deployed = server
+        .put_with_basic_and_host(
+            "maven.example.com",
+            "/v2/dev/kingtux/tms/1.0.0/tms-1.0.0.jar",
+            b"not really a jar".to_vec(),
+            "application/java-archive",
+        )
+        .await;
+    assert!(
+        deployed.status.is_success(),
+        "deploy under a v2/ path failed: {} {}",
+        deployed.status,
+        deployed.text
+    );
+
+    let fetched = server
+        .get_with_host(
+            "maven.example.com",
+            "/v2/dev/kingtux/tms/1.0.0/tms-1.0.0.jar",
+        )
+        .await;
+    assert_eq!(fetched.status, StatusCode::OK, "{}", fetched.text);
+    assert_eq!(fetched.bytes, b"not really a jar");
+}
+
+#[tokio::test]
+async fn deleting_a_tag_leaves_the_manifest_reachable_by_digest() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "deleting_a_tag_leaves_the_manifest_reachable_by_digest"
+        ));
+        return;
+    };
+    let built = Image::build("delete");
+    registry.push(IMAGE, "1.0", &built).await;
+
+    let deleted = registry
+        .server
+        .send(
+            "DELETE",
+            &format!("/v2/{IMAGE}/manifests/1.0"),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(deleted.status, StatusCode::ACCEPTED, "{}", deleted.text);
+
+    assert_eq!(
+        registry
+            .get(&format!("/v2/{IMAGE}/manifests/1.0"))
+            .await
+            .status,
+        StatusCode::NOT_FOUND
+    );
+    // The manifest itself is untouched — another tag or a pinned digest may still want it.
+    assert_eq!(
+        registry
+            .get(&format!("/v2/{IMAGE}/manifests/{}", built.digest()))
+            .await
+            .status,
+        StatusCode::OK
+    );
+}
+
+/// Nothing reference-counts layers, so deleting one would corrupt every other manifest sharing it.
+#[tokio::test]
+async fn deleting_a_blob_is_refused() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database("deleting_a_blob_is_refused"));
+        return;
+    };
+    let built = Image::build("blob delete");
+    registry.push(IMAGE, "1.0", &built).await;
+
+    let refused = registry
+        .server
+        .send(
+            "DELETE",
+            &format!("/v2/{IMAGE}/blobs/{}", artifacts::oci_digest(&built.layer)),
+            &[("authorization", &registry.auth())],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(
+        refused.status,
+        StatusCode::METHOD_NOT_ALLOWED,
+        "{}",
+        refused.text
+    );
+    assert_eq!(refused.json()["errors"][0]["code"], "UNSUPPORTED");
+}
+
+#[tokio::test]
+async fn an_unresolvable_prefix_says_what_was_expected() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "an_unresolvable_prefix_says_what_was_expected"
+        ));
+        return;
+    };
+
+    // One segment: there is no `{storage}/{repository}` in it at all.
+    let single = registry.get("/v2/alpine/manifests/latest").await;
+    assert_eq!(single.status, StatusCode::NOT_FOUND, "{}", single.text);
+    assert_eq!(single.json()["errors"][0]["code"], "NAME_UNKNOWN");
+
+    // Two segments that name nothing.
+    let missing = registry.get("/v2/nope/nothing/manifests/latest").await;
+    assert_eq!(missing.status, StatusCode::NOT_FOUND, "{}", missing.text);
+    assert!(
+        missing.json()["errors"][0]["message"]
+            .as_str()
+            .unwrap()
+            .contains("nope/nothing"),
+        "{}",
+        missing.text
+    );
+}
+
+/// A private registry must challenge rather than refuse outright, or the client never sends
+/// credentials.
+#[tokio::test]
+async fn a_private_registry_challenges_an_anonymous_pull() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_private_registry_challenges_an_anonymous_pull"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, REPOSITORY, "docker")
+        .await;
+    let updated = server
+        .put_json_as(
+            &format!("/api/repository/{repository}"),
+            serde_json::json!({ "visibility": "Private", "active": true }),
+            &session,
+        )
+        .await;
+    assert!(updated.status.is_success(), "{}", updated.text);
+
+    let refused = server.get(&format!("/v2/{IMAGE}/manifests/latest")).await;
+    assert_eq!(refused.status, StatusCode::UNAUTHORIZED, "{}", refused.text);
+    assert!(
+        refused
+            .headers
+            .get("www-authenticate")
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .starts_with("Bearer realm="),
+    );
+}
+
+#[tokio::test]
+async fn an_index_can_be_pushed_once_its_children_are_present() {
+    let Some(registry) = Registry::start().await else {
+        assert!(skip_without_database(
+            "an_index_can_be_pushed_once_its_children_are_present"
+        ));
+        return;
+    };
+
+    let amd64 = Image::build("amd64");
+    let arm64 = Image::build("arm64");
+
+    let index = serde_json::json!({
+        "schemaVersion": 2,
+        "mediaType": "application/vnd.oci.image.index.v1+json",
+        "manifests": [
+            {
+                "mediaType": OCI_MANIFEST_TYPE,
+                "digest": amd64.digest(),
+                "size": amd64.manifest.len(),
+                "platform": { "os": "linux", "architecture": "amd64" },
+            },
+            {
+                "mediaType": OCI_MANIFEST_TYPE,
+                "digest": arm64.digest(),
+                "size": arm64.manifest.len(),
+                "platform": { "os": "linux", "architecture": "arm64" },
+            },
+        ],
+    });
+    let index_bytes = serde_json::to_vec(&index).unwrap();
+
+    // Before the children exist, the index must be refused.
+    let early = registry
+        .server
+        .send(
+            "PUT",
+            &format!("/v2/{IMAGE}/manifests/multi"),
+            &[
+                ("authorization", &registry.auth()),
+                ("content-type", "application/vnd.oci.image.index.v1+json"),
+            ],
+            index_bytes.clone(),
+        )
+        .await;
+    assert_eq!(early.status, StatusCode::BAD_REQUEST, "{}", early.text);
+    assert_eq!(early.json()["errors"][0]["code"], "MANIFEST_BLOB_UNKNOWN");
+
+    // Push each platform by digest, then the index.
+    for built in [&amd64, &arm64] {
+        registry.push_blob(IMAGE, &built.layer).await;
+        registry.push_blob(IMAGE, &built.config).await;
+        let pushed = registry
+            .push_manifest(IMAGE, &built.digest(), &built.manifest)
+            .await;
+        assert_eq!(pushed.status, StatusCode::CREATED, "{}", pushed.text);
+    }
+
+    let pushed = registry
+        .server
+        .send(
+            "PUT",
+            &format!("/v2/{IMAGE}/manifests/multi"),
+            &[
+                ("authorization", &registry.auth()),
+                ("content-type", "application/vnd.oci.image.index.v1+json"),
+            ],
+            index_bytes.clone(),
+        )
+        .await;
+    assert_eq!(pushed.status, StatusCode::CREATED, "{}", pushed.text);
+
+    let fetched = registry.get(&format!("/v2/{IMAGE}/manifests/multi")).await;
+    assert_eq!(fetched.bytes, index_bytes);
+    assert_eq!(
+        fetched.headers.get("content-type").unwrap(),
+        "application/vnd.oci.image.index.v1+json"
+    );
+
+    // The per-platform manifests are reachable by digest but are not tags.
+    let tags = registry.get(&format!("/v2/{IMAGE}/tags/list")).await;
+    assert_eq!(tags.json()["tags"].as_array().unwrap(), &vec!["multi"]);
+}

--- a/nitro_repo/tests/npm.rs
+++ b/nitro_repo/tests/npm.rs
@@ -207,6 +207,45 @@ async fn republishing_an_existing_version_is_refused() {
     );
 }
 
+/// `npm search` answered 500 for every query.
+///
+/// `projects.key` is declared `COLLATE ignoreCase`, and Postgres refuses `ILIKE` against a
+/// nondeterministic collation. The search query has always been written that way; nothing ever
+/// called it in a test, so the failure only ever showed up as a 500 in front of a user.
+#[tokio::test]
+async fn search_finds_a_published_package() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database("search_finds_a_published_package"));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+    publish(&server, "local/npm", "example", "1.0.0").await;
+    publish(&server, "local/npm", "unrelated", "2.0.0").await;
+
+    let response = server
+        .get("/repositories/local/npm/-/v1/search?text=exam&size=10")
+        .await;
+    assert_eq!(
+        response.status,
+        StatusCode::OK,
+        "search should succeed: {}",
+        response.text
+    );
+
+    let results = response.json();
+    let names: Vec<&str> = results["objects"]
+        .as_array()
+        .expect("objects should be a list")
+        .iter()
+        .map(|found| found["package"]["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(names, vec!["example"]);
+}
+
 /// The registry advertises this to `npm ping`, and npm refuses to talk to a registry that 404s it.
 #[tokio::test]
 async fn the_registry_answers_ping() {

--- a/seed.example.toml
+++ b/seed.example.toml
@@ -1,8 +1,8 @@
 # Example seed configuration.
 #
 # `nitro_repo seed --config seed.example.toml` deploys this suite into a running
-# instance over the real Maven and npm protocols. Re-running is safe — anything already
-# present is left alone.
+# instance over the real Maven, npm, Cargo and Docker protocols. Re-running is safe —
+# anything already present is left alone.
 #
 # Regenerate with: nitro_repo seed --config seed.toml --write-example
 
@@ -35,6 +35,18 @@ visibility = "Public"
 storage = "local"
 name = "npm"
 type = "npm"
+visibility = "Public"
+
+[[repositories]]
+storage = "local"
+name = "crates"
+type = "cargo"
+visibility = "Public"
+
+[[repositories]]
+storage = "local"
+name = "docker"
+type = "docker"
 visibility = "Public"
 
 [[maven]]
@@ -88,3 +100,26 @@ description = "Prerelease versions, and a non-latest dist-tag"
 
 [npm.dist_tags]
 next = "2.0.0-beta.1"
+
+# Four characters or more, so the sparse index path goes through the `{c1c2}/{c3c4}/`
+# branch rather than one of the short-name special cases.
+[[cargo]]
+repository = "local/crates"
+name = "nitro-example"
+versions = ["0.1.0", "0.2.0", "1.0.0"]
+description = "A seeded crate"
+
+# Three characters: the `3/{first}/` branch, which is easy to get wrong.
+[[cargo]]
+repository = "local/crates"
+name = "nrx"
+versions = ["0.1.0"]
+description = "A short crate name, for the index prefix rule"
+
+# The name carries no `{storage}/{repository}` prefix — the seeder adds it, because a
+# registry with no hostname of its own is addressed as
+# `docker pull localhost:6742/local/docker/example:1.0`.
+[[docker]]
+repository = "local/docker"
+name = "example"
+tags = ["1.0", "latest"]

--- a/site/src/components/nr/repository/RepositoryHelper.vue
+++ b/site/src/components/nr/repository/RepositoryHelper.vue
@@ -14,6 +14,8 @@ import type { RepositoryWithStorageName } from "@/types/repository";
 import { computed, type PropType } from "vue";
 import MavenRepositoryHelper from "./types/maven/MavenRepositoryHelper.vue";
 import NPMRepositoryHelper from "./types/npm/NPMRepositoryHelper.vue";
+import CargoRepositoryHelper from "./types/cargo/CargoRepositoryHelper.vue";
+import DockerRepositoryHelper from "./types/docker/DockerRepositoryHelper.vue";
 
 const props = defineProps({
   repository: {
@@ -29,6 +31,14 @@ const helpers = [
   {
     type: "npm",
     component: NPMRepositoryHelper,
+  },
+  {
+    type: "cargo",
+    component: CargoRepositoryHelper,
+  },
+  {
+    type: "docker",
+    component: DockerRepositoryHelper,
   },
 ];
 const repositoryHelper = computed(() => {

--- a/site/src/components/nr/repository/browse/fileIcons.ts
+++ b/site/src/components/nr/repository/browse/fileIcons.ts
@@ -51,6 +51,9 @@ const BY_EXTENSION: Record<string, FileIcon> = {
 
   // npm
   tgz: { icon: "box-archive", color: "--file-archive", label: "npm tarball" },
+  // Cargo. A `.crate` is a gzipped tar, so it belongs with the archives rather than looking like
+  // an unknown binary.
+  crate: { icon: "box-archive", color: "--file-archive", label: "Rust crate" },
   tar: { icon: "box-archive", color: "--file-archive", label: "Tarball" },
   zip: { icon: "box-archive", color: "--file-archive", label: "Zip archive" },
   gz: { icon: "box-archive", color: "--file-archive", label: "Gzip archive" },

--- a/site/src/components/nr/repository/types/cargo/CargoConfig.vue
+++ b/site/src/components/nr/repository/types/cargo/CargoConfig.vue
@@ -1,0 +1,94 @@
+<template>
+  <div v-if="isCreate">
+    <form @submit.prevent="">
+      <DropDown
+        v-model="input.cargoTypes"
+        :options="cargoTypes"
+        required
+        >Cargo Registry Type</DropDown
+      >
+    </form>
+  </div>
+  <div v-else-if="value">
+    <TextInput
+      v-model="value.type"
+      required
+      disabled
+      >Repository Type</TextInput
+    >
+    <p class="note">
+      A hosted Cargo registry has nothing else to configure. The registry type cannot be changed
+      after the repository is created.
+    </p>
+  </div>
+</template>
+<script setup lang="ts">
+import DropDown from "@/components/form/dropdown/DropDown.vue";
+import TextInput from "@/components/form/text/TextInput.vue";
+import { type CargoConfigType } from "./cargo";
+import http from "@/http";
+import { computed, ref, watch } from "vue";
+import { notify } from "@kyvg/vue3-notification";
+
+// Only what `CargoRegistryConfig` on the backend accepts. Offering a variant the server does not
+// have produces a repository it refuses to validate, which is how npm's `Proxy` option behaved.
+const cargoTypes = [
+  {
+    value: "Hosted",
+    label: "Hosted",
+  },
+];
+const props = defineProps({
+  settingName: String,
+  repository: {
+    type: String,
+    required: false,
+  },
+});
+const input = ref({
+  cargoTypes: "",
+});
+const isCreate = computed(() => {
+  return !props.repository;
+});
+const value = defineModel<CargoConfigType>();
+watch(input.value, () => {
+  if (input.value.cargoTypes === "") {
+    return;
+  }
+  if (!isCreate.value) {
+    return;
+  }
+  if (input.value.cargoTypes === "Hosted") {
+    value.value = {
+      type: "Hosted",
+    };
+  } else {
+    notify({
+      type: "error",
+      title: "Error",
+      text: "Invalid Cargo registry type",
+    });
+    input.value.cargoTypes = "";
+  }
+});
+async function load() {
+  if (props.repository) {
+    await http
+      .get(`/api/repository/${props.repository}/config/cargo`)
+      .then((response) => {
+        value.value = response.data;
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+}
+load();
+</script>
+<style scoped lang="scss">
+.note {
+  opacity: 0.8;
+  font-size: 0.9rem;
+}
+</style>

--- a/site/src/components/nr/repository/types/cargo/CargoProjectHelper.vue
+++ b/site/src/components/nr/repository/types/cargo/CargoProjectHelper.vue
@@ -1,0 +1,108 @@
+<template>
+  <div class="cargoProject">
+    <div class="projectHeader">
+      <h1>{{ project.name }}</h1>
+      <RouterLink
+        class="openProject"
+        :to="{ name: 'ProjectPageView', params: { projectId: project.id } }"
+        >Open Project</RouterLink
+      >
+    </div>
+    <div class="info">
+      <div class="codeBlock">
+        <h2>Add</h2>
+        <CodeMenu
+          defaultTab="cargo-add"
+          :snippets="snippets" />
+      </div>
+      <div class="details">
+        <CopyCode :code="project.project_key">Crate</CopyCode>
+        <CopyCode
+          v-if="project.latest_release"
+          :code="project.latest_release"
+          >Latest</CopyCode
+        >
+        <CopyCode
+          v-if="project.latest_pre_release"
+          :code="project.latest_pre_release"
+          >Latest Pre-Release</CopyCode
+        >
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Project, ProjectVersion } from "@/types/project";
+import type { RepositoryWithStorageName } from "@/types/repository";
+import { computed, type PropType } from "vue";
+import { createProjectSnippets } from "./CargoRepositoryHelpers";
+import CodeMenu from "@/components/core/code/CodeMenu.vue";
+import CopyCode from "@/components/core/code/CopyCode.vue";
+import { RouterLink } from "vue-router";
+
+const props = defineProps({
+  project: {
+    type: Object as PropType<Project>,
+    required: true,
+  },
+  version: {
+    type: Object as PropType<ProjectVersion>,
+    required: false,
+  },
+  repository: {
+    type: Object as PropType<RepositoryWithStorageName>,
+    required: true,
+  },
+});
+
+// Cargo has no `latest` tag to fall back on the way npm does, so an unknown version becomes the
+// wildcard requirement — which resolves to the newest match rather than failing.
+const version = computed(() => {
+  return (
+    props.version?.version ??
+    props.project.latest_release ??
+    props.project.latest_pre_release ??
+    "*"
+  );
+});
+const snippets = computed(() => createProjectSnippets(props.project, version.value));
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/styles/theme.scss";
+
+.cargoProject {
+  margin: 0 auto;
+}
+.details {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.info {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap-reverse;
+}
+.codeBlock {
+  flex-grow: 1;
+  max-width: 50%;
+}
+.projectHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  .openProject {
+    margin-left: 1rem;
+    display: block;
+    padding: 0.5rem;
+    border: 1px solid gray;
+    border-radius: 0.5rem;
+    background-color: $primary-30;
+    color: white;
+    text-decoration: none;
+    text-align: end;
+  }
+}
+</style>

--- a/site/src/components/nr/repository/types/cargo/CargoRepositoryHelper.vue
+++ b/site/src/components/nr/repository/types/cargo/CargoRepositoryHelper.vue
@@ -1,0 +1,26 @@
+<template>
+  <div class="cargoRepository">
+    <div id="pullFromRepo">
+      <h2>Pull from Repository</h2>
+      <CodeMenu
+        :snippets="snippetsForPull"
+        defaultTab="config" />
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { type RepositoryWithStorageName } from "@/types/repository";
+import { type PropType } from "vue";
+import { createSnippetsForPulling } from "./CargoRepositoryHelpers";
+
+import CodeMenu from "@/components/core/code/CodeMenu.vue";
+
+const props = defineProps({
+  repository: {
+    type: Object as PropType<RepositoryWithStorageName>,
+    required: true,
+  },
+});
+
+const snippetsForPull = createSnippetsForPulling(props.repository);
+</script>

--- a/site/src/components/nr/repository/types/cargo/CargoRepositoryHelpers.ts
+++ b/site/src/components/nr/repository/types/cargo/CargoRepositoryHelpers.ts
@@ -1,0 +1,62 @@
+import type { CodeSnippet } from "@/components/core/code/code";
+import type { Project } from "@/types/project";
+import { createRepositoryRoute, type RepositoryWithStorageName } from "@/types/repository";
+
+/**
+ * Cargo needs three separate things configured, and they go in three different files, so each is
+ * offered on its own rather than as one block to be split up by hand:
+ *
+ *  - the registry itself, in `.cargo/config.toml`;
+ *  - a token, which `cargo login` writes to `credentials.toml`;
+ *  - `publish = ["nitro"]` in the crate's own manifest, without which `cargo publish` defaults to
+ *    crates.io and refuses.
+ */
+export function createSnippetsForPulling(
+  repository: RepositoryWithStorageName,
+): Array<CodeSnippet> {
+  const url = createRepositoryRoute(repository);
+  return [
+    {
+      name: ".cargo/config.toml",
+      key: "config",
+      language: "toml",
+      // The trailing slash matters: cargo appends the index path to this URL, and without it the
+      // last segment is replaced rather than appended.
+      code: `[registries.nitro]
+index = "sparse+${url}/index/"`,
+    },
+    {
+      name: "Login",
+      key: "login",
+      language: "bash",
+      code: `cargo login --registry nitro
+# Paste an auth token from Profile → Tokens.`,
+    },
+    {
+      name: "Cargo.toml",
+      key: "manifest",
+      language: "toml",
+      code: `[package]
+# Without this, \`cargo publish\` targets crates.io.
+publish = ["nitro"]`,
+    },
+  ];
+}
+
+export function createProjectSnippets(project: Project, version: string = "*"): Array<CodeSnippet> {
+  return [
+    {
+      name: "cargo add",
+      key: "cargo-add",
+      language: "bash",
+      code: `cargo add ${project.project_key}@${version} --registry nitro`,
+    },
+    {
+      name: "Cargo.toml",
+      key: "manifest",
+      language: "toml",
+      code: `[dependencies]
+${project.project_key} = { version = "${version}", registry = "nitro" }`,
+    },
+  ];
+}

--- a/site/src/components/nr/repository/types/cargo/cargo.ts
+++ b/site/src/components/nr/repository/types/cargo/cargo.ts
@@ -1,0 +1,28 @@
+import { RustIcon } from "vue3-simple-icons";
+import CargoProjectHelper from "./CargoProjectHelper.vue";
+import type { FrontendRepositoryType } from "@/types/repository";
+
+export const CargoFrontendDefinition = {
+  name: "cargo",
+  properName: "Cargo",
+  projectComponent: {
+    component: CargoProjectHelper,
+    props: {},
+  },
+  icons: [
+    {
+      name: "Rust",
+      component: RustIcon,
+      url: "https://doc.rust-lang.org/cargo/",
+      props: {},
+    },
+  ],
+} as FrontendRepositoryType;
+
+/**
+ * Mirrors `CargoRegistryConfig` on the backend. Only `Hosted` exists; a `Proxy` variant would be
+ * added here at the same time as the server's.
+ */
+export type CargoConfigType = {
+  type: "Hosted";
+};

--- a/site/src/components/nr/repository/types/docker/DockerConfig.vue
+++ b/site/src/components/nr/repository/types/docker/DockerConfig.vue
@@ -1,0 +1,94 @@
+<template>
+  <div v-if="isCreate">
+    <form @submit.prevent="">
+      <DropDown
+        v-model="input.dockerTypes"
+        :options="dockerTypes"
+        required
+        >Docker Registry Type</DropDown
+      >
+    </form>
+  </div>
+  <div v-else-if="value">
+    <TextInput
+      v-model="value.type"
+      required
+      disabled
+      >Repository Type</TextInput
+    >
+    <p class="note">
+      A hosted Docker registry has nothing else to configure. The registry type cannot be changed
+      after the repository is created.
+    </p>
+  </div>
+</template>
+<script setup lang="ts">
+import DropDown from "@/components/form/dropdown/DropDown.vue";
+import TextInput from "@/components/form/text/TextInput.vue";
+import { type DockerConfigType } from "./docker";
+import http from "@/http";
+import { computed, ref, watch } from "vue";
+import { notify } from "@kyvg/vue3-notification";
+
+// Only what `CargoRegistryConfig` on the backend accepts. Offering a variant the server does not
+// have produces a repository it refuses to validate, which is how npm's `Proxy` option behaved.
+const dockerTypes = [
+  {
+    value: "Hosted",
+    label: "Hosted",
+  },
+];
+const props = defineProps({
+  settingName: String,
+  repository: {
+    type: String,
+    required: false,
+  },
+});
+const input = ref({
+  dockerTypes: "",
+});
+const isCreate = computed(() => {
+  return !props.repository;
+});
+const value = defineModel<DockerConfigType>();
+watch(input.value, () => {
+  if (input.value.dockerTypes === "") {
+    return;
+  }
+  if (!isCreate.value) {
+    return;
+  }
+  if (input.value.dockerTypes === "Hosted") {
+    value.value = {
+      type: "Hosted",
+    };
+  } else {
+    notify({
+      type: "error",
+      title: "Error",
+      text: "Invalid Docker registry type",
+    });
+    input.value.dockerTypes = "";
+  }
+});
+async function load() {
+  if (props.repository) {
+    await http
+      .get(`/api/repository/${props.repository}/config/docker`)
+      .then((response) => {
+        value.value = response.data;
+      })
+      .catch((error) => {
+        console.error(error);
+      });
+  }
+}
+load();
+</script>
+<style scoped lang="scss">
+.note {
+  opacity: 0.8;
+  font-size: 0.9rem;
+}
+</style>

--- a/site/src/components/nr/repository/types/docker/DockerProjectHelper.vue
+++ b/site/src/components/nr/repository/types/docker/DockerProjectHelper.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="dockerProject">
+    <div class="projectHeader">
+      <h1>{{ project.name }}</h1>
+      <RouterLink
+        class="openProject"
+        :to="{ name: 'ProjectPageView', params: { projectId: project.id } }"
+        >Open Project</RouterLink
+      >
+    </div>
+    <div class="info">
+      <div class="codeBlock">
+        <h2>Pull</h2>
+        <CodeMenu
+          defaultTab="pull"
+          :snippets="snippets" />
+      </div>
+      <div class="details">
+        <CopyCode :code="project.project_key">Image</CopyCode>
+        <CopyCode
+          v-if="project.latest_release"
+          :code="project.latest_release"
+          >Latest Tag</CopyCode
+        >
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { Project, ProjectVersion } from "@/types/project";
+import type { RepositoryHostname, RepositoryWithStorageName } from "@/types/repository";
+import { computed, ref, type PropType } from "vue";
+import { createProjectSnippets } from "./DockerRepositoryHelpers";
+import CodeMenu from "@/components/core/code/CodeMenu.vue";
+import CopyCode from "@/components/core/code/CopyCode.vue";
+import { RouterLink } from "vue-router";
+import http from "@/http";
+
+const props = defineProps({
+  project: {
+    type: Object as PropType<Project>,
+    required: true,
+  },
+  version: {
+    type: Object as PropType<ProjectVersion>,
+    required: false,
+  },
+  repository: {
+    type: Object as PropType<RepositoryWithStorageName>,
+    required: true,
+  },
+});
+
+const hostname = ref<string | undefined>(undefined);
+http
+  .get<RepositoryHostname[]>(`/api/repository/${props.repository.id}/hostnames`)
+  .then((response) => {
+    hostname.value = response.data[0]?.hostname;
+  })
+  .catch(() => {
+    hostname.value = undefined;
+  });
+
+// A Docker tag *is* the version, and `latest` is the conventional default rather than something the
+// registry resolves — so it is only a fallback when nothing more specific is known.
+const tag = computed(() => {
+  return props.version?.version ?? props.project.latest_release ?? "latest";
+});
+const snippets = computed(() =>
+  createProjectSnippets(props.repository, props.project, tag.value, hostname.value),
+);
+</script>
+
+<style lang="scss" scoped>
+@import "@/assets/styles/theme.scss";
+
+.dockerProject {
+  margin: 0 auto;
+}
+.details {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.info {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap-reverse;
+}
+.codeBlock {
+  flex-grow: 1;
+  max-width: 50%;
+}
+.projectHeader {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+  .openProject {
+    margin-left: 1rem;
+    display: block;
+    padding: 0.5rem;
+    border: 1px solid gray;
+    border-radius: 0.5rem;
+    background-color: $primary-30;
+    color: white;
+    text-decoration: none;
+    text-align: end;
+  }
+}
+</style>

--- a/site/src/components/nr/repository/types/docker/DockerRepositoryHelper.vue
+++ b/site/src/components/nr/repository/types/docker/DockerRepositoryHelper.vue
@@ -1,0 +1,58 @@
+<template>
+  <div class="dockerRepository">
+    <div id="pullFromRepo">
+      <h2>Pull from Repository</h2>
+      <CodeMenu
+        :snippets="snippetsForPull"
+        defaultTab="login" />
+      <p
+        v-if="!hostname"
+        class="note">
+        This registry has no hostname of its own, so image names must begin with
+        <code>{{ repository.storage_name }}/{{ repository.name }}</code
+        >. Attach a hostname under <strong>Hostnames</strong> to use bare image names.
+      </p>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+import { type RepositoryWithStorageName, type RepositoryHostname } from "@/types/repository";
+import { computed, ref, type PropType } from "vue";
+import { createSnippetsForPulling } from "./DockerRepositoryHelpers";
+import http from "@/http";
+
+import CodeMenu from "@/components/core/code/CodeMenu.vue";
+
+const props = defineProps({
+  repository: {
+    type: Object as PropType<RepositoryWithStorageName>,
+    required: true,
+  },
+});
+
+// Fetched rather than passed in: a Docker client's image names depend on whether the repository has
+// a hostname, and the snippets are wrong — they 404 — if that is guessed rather than looked up.
+const hostname = ref<string | undefined>(undefined);
+
+async function loadHostname() {
+  await http
+    .get<RepositoryHostname[]>(`/api/repository/${props.repository.id}/hostnames`)
+    .then((response) => {
+      hostname.value = response.data[0]?.hostname;
+    })
+    .catch(() => {
+      // A reader without permission to list hostnames still gets working snippets, in the
+      // path-prefixed form that always works.
+      hostname.value = undefined;
+    });
+}
+loadHostname();
+
+const snippetsForPull = computed(() => createSnippetsForPulling(props.repository, hostname.value));
+</script>
+<style scoped lang="scss">
+.note {
+  opacity: 0.8;
+  font-size: 0.9rem;
+}
+</style>

--- a/site/src/components/nr/repository/types/docker/DockerRepositoryHelpers.ts
+++ b/site/src/components/nr/repository/types/docker/DockerRepositoryHelpers.ts
@@ -1,0 +1,99 @@
+import type { CodeSnippet } from "@/components/core/code/code";
+import type { Project } from "@/types/project";
+import type { RepositoryWithStorageName } from "@/types/repository";
+
+/**
+ * The registry host and the image-name prefix a client must use.
+ *
+ * A Docker client cannot be given a URL path — `docker pull host/x/y` always requests
+ * `https://host/v2/x/y/...`. So a repository is addressed one of two ways, and which one applies
+ * depends on whether it has a hostname of its own:
+ *
+ *  - **hostname**: `docker pull docker.example.com/myimage` — the host identifies the repository,
+ *    so image names carry no prefix;
+ *  - **prefix**: `docker pull nitro.example.com/local/docker/myimage` — the first two segments of
+ *    the image name are the storage and the repository.
+ *
+ * `hostname` is only reported when one is attached; otherwise the prefix form is the only one that
+ * works, and showing a bare name would give the user a command that 404s.
+ */
+export interface DockerAddress {
+  /** The registry host, without a scheme. */
+  host: string;
+  /** `{storage}/{repository}/`, or empty when the repository has its own hostname. */
+  prefix: string;
+}
+
+export function dockerAddress(
+  repository: RepositoryWithStorageName,
+  hostname?: string,
+): DockerAddress {
+  if (hostname) {
+    return { host: hostname, prefix: "" };
+  }
+  // The instance's own host, as the browser reached it — which is also the host a client on this
+  // network can reach. Includes the port, which a registry URL needs.
+  return {
+    host: window.location.host,
+    prefix: `${repository.storage_name}/${repository.name}/`,
+  };
+}
+
+export function createSnippetsForPulling(
+  repository: RepositoryWithStorageName,
+  hostname?: string,
+): Array<CodeSnippet> {
+  const { host, prefix } = dockerAddress(repository, hostname);
+  return [
+    {
+      name: "Login",
+      key: "login",
+      language: "bash",
+      code: `docker login ${host}
+# Username, and an auth token from Profile → Tokens as the password.`,
+    },
+    {
+      name: "Pull",
+      key: "pull",
+      language: "bash",
+      code: `docker pull ${host}/${prefix}IMAGE:TAG`,
+    },
+    {
+      name: "Push",
+      key: "push",
+      language: "bash",
+      code: `docker tag IMAGE:TAG ${host}/${prefix}IMAGE:TAG
+docker push ${host}/${prefix}IMAGE:TAG`,
+    },
+  ];
+}
+
+export function createProjectSnippets(
+  repository: RepositoryWithStorageName,
+  project: Project,
+  tag: string = "latest",
+  hostname?: string,
+): Array<CodeSnippet> {
+  const { host, prefix } = dockerAddress(repository, hostname);
+  const reference = `${host}/${prefix}${project.project_key}:${tag}`;
+  return [
+    {
+      name: "Pull",
+      key: "pull",
+      language: "bash",
+      code: `docker pull ${reference}`,
+    },
+    {
+      name: "Run",
+      key: "run",
+      language: "bash",
+      code: `docker run --rm ${reference}`,
+    },
+    {
+      name: "Dockerfile",
+      key: "dockerfile",
+      language: "dockerfile",
+      code: `FROM ${reference}`,
+    },
+  ];
+}

--- a/site/src/components/nr/repository/types/docker/docker.ts
+++ b/site/src/components/nr/repository/types/docker/docker.ts
@@ -1,0 +1,28 @@
+import { DockerIcon } from "vue3-simple-icons";
+import DockerProjectHelper from "./DockerProjectHelper.vue";
+import type { FrontendRepositoryType } from "@/types/repository";
+
+export const DockerFrontendDefinition = {
+  name: "docker",
+  properName: "Docker",
+  projectComponent: {
+    component: DockerProjectHelper,
+    props: {},
+  },
+  icons: [
+    {
+      name: "Docker",
+      component: DockerIcon,
+      url: "https://docs.docker.com/registry/spec/api/",
+      props: {},
+    },
+  ],
+} as FrontendRepositoryType;
+
+/**
+ * Mirrors `DockerRegistryConfig` on the backend. Only `Hosted` exists; a `Proxy` variant (a
+ * pull-through cache) would be added here at the same time as the server's.
+ */
+export type DockerConfigType = {
+  type: "Hosted";
+};

--- a/site/src/types/api.d.ts
+++ b/site/src/types/api.d.ts
@@ -4,6 +4,23 @@
  */
 
 export interface paths {
+  "/api/docker/token": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Exchanges Basic credentials for a bearer token. */
+    get: operations["token"];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   "/api/info": {
     parameters: {
       query?: never;
@@ -47,6 +64,24 @@ export interface paths {
     put?: never;
     /** Installs the site with the first user. If Site is already installed, it will return a 404. */
     post: operations["install"];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  "/api/npm/login/{session}": {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Describes a pending npm login session. */
+    get: operations["login_session"];
+    put?: never;
+    /** Approves a pending npm login and releases a token to the waiting client. */
+    post: operations["complete_login"];
     delete?: never;
     options?: never;
     head?: never;
@@ -1408,6 +1443,17 @@ export interface components {
       password?: string | null;
       username: components["schemas"]["Username"];
     };
+    NpmLoginCompleteResponse: {
+      /** Format: uuid */
+      repository_id: string;
+      repository_name: string;
+    };
+    /** @description What the login page needs to show the user before they approve. */
+    NpmLoginSessionResponse: {
+      /** Format: uuid */
+      repository_id: string;
+      repository_name: string;
+    };
     /** @enum {string} */
     PageType: "Markdown" | "HTML" | "None";
     PasswordRules: {
@@ -1555,6 +1601,17 @@ export interface components {
           /** @enum {string} */
           type: "FileSystemV2";
         };
+    TokenResponse: {
+      access_token: string;
+      /** Format: int64 */
+      expires_in: number;
+      issued_at: string;
+      /**
+       * @description The spec names this `token`; the OAuth2 flow names the same value `access_token`. Both are
+       *     sent because different clients read different ones.
+       */
+      token: string;
+    };
     UpdatePermissions: {
       admin?: boolean | null;
       default_repository_actions?: components["schemas"]["RepositoryActions"][] | null;
@@ -1665,6 +1722,33 @@ export interface components {
 }
 export type $defs = Record<string, never>;
 export interface operations {
+  token: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description A bearer token for the requested scope */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["TokenResponse"];
+        };
+      };
+      /** @description The credentials were not accepted */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
   info: {
     parameters: {
       query?: never;
@@ -1726,6 +1810,80 @@ export interface operations {
         content?: never;
       };
       /** @description Site is already installed */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  login_session: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The login session id npm was handed */
+        session: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description The pending session */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NpmLoginSessionResponse"];
+        };
+      };
+      /** @description Unknown or expired session */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  complete_login: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description The login session id npm was handed */
+        session: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Login approved */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          "application/json": components["schemas"]["NpmLoginCompleteResponse"];
+        };
+      };
+      /** @description Not signed in */
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Cannot write to this repository */
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Unknown or expired session */
       404: {
         headers: {
           [name: string]: unknown;

--- a/site/src/types/repository.ts
+++ b/site/src/types/repository.ts
@@ -8,6 +8,10 @@ import { apiURL } from "@/config";
 import { MavenFrontendDefinition } from "@/components/nr/repository/types/maven/maven";
 import { NPMFrontendDefinition } from "@/components/nr/repository/types/npm/npm";
 import NPMConfig from "@/components/nr/repository/types/npm/NPMConfig.vue";
+import { CargoFrontendDefinition } from "@/components/nr/repository/types/cargo/cargo";
+import CargoConfig from "@/components/nr/repository/types/cargo/CargoConfig.vue";
+import { DockerFrontendDefinition } from "@/components/nr/repository/types/docker/docker";
+import DockerConfig from "@/components/nr/repository/types/docker/DockerConfig.vue";
 import BadgeConfig from "@/components/nr/repository/configs/BadgeConfig.vue";
 import type { RepositoryActionsType } from "./user";
 
@@ -76,6 +80,16 @@ export const configTypes: ConfigType[] = [
     component: NPMConfig,
   },
   {
+    name: "cargo",
+    title: "Cargo",
+    component: CargoConfig,
+  },
+  {
+    name: "docker",
+    title: "Docker",
+    component: DockerConfig,
+  },
+  {
     // Missing entirely, which is why badge settings rendered through the generic JSON-schema
     // fallback — raw hex text fields with no preview. (#501)
     name: "project",
@@ -105,6 +119,8 @@ export interface FrontendRepositoryType {
 export const repositoryTypes: FrontendRepositoryType[] = [
   MavenFrontendDefinition,
   NPMFrontendDefinition,
+  CargoFrontendDefinition,
+  DockerFrontendDefinition,
 ];
 export function findRepositoryType(name: string): FrontendRepositoryType | undefined {
   return repositoryTypes.find((repositoryType) => repositoryType.name === name);


### PR DESCRIPTION
Closes #6, closes #419.

Two new repository types, both hosted-only. Proxying, for either, is a later config the way Maven's is.

## Cargo

The sparse index — the HTTP one, default since Rust 1.68 — so there is no git server in the way and the existing storage and routing carry it unchanged. Publish, download, yank/unyank, owners and search.

**No new tables.** A version's index record lives in `project_versions.extra`, and ownership reuses `project_members`, so `cargo owner` and the project pages read the same rows.

The index is generated per request and carries an `ETag`, because cargo revalidates constantly and a `304` is the common case. `config.json` is generated too: it has to name whichever host the client actually used, so a repository reached on a custom domain describes that domain rather than sending the client back through `/repositories/{storage}/{name}`.

## Docker

The OCI distribution API: manifests, blobs, resumable uploads, tags, catalog, referrers, multi-arch indexes, deletes, and the `WWW-Authenticate: Bearer` handshake `docker login` performs.

Docker is the one type that **cannot** live under `/repositories/{storage}/{name}` — a client always requests `/v2/...` at the root of its host and there is no setting that adds a prefix. So `/v2` is mounted at the host root and resolves a repository two ways:

- by a hostname registered to it — `docker pull docker.example.com/myimage`
- by taking the first two segments of the image name as storage and repository — `docker pull repo.example.com/local/docker/myimage`

A `/v2` request whose host belongs to a *non-Docker* repository falls through to the normal host dispatch, so a Maven artifact stored under `v2/` still serves over its custom domain.

The token realm is built from the host the client is already talking to rather than from `app_url` — a registry on a custom domain may be the only address that resolves from wherever Docker runs. It lives at `/api/docker/token`, not under `/v2`, so it cannot collide with an image named `token`. The token minted is an ordinary auth token, so revoking one from the profile UI logs the Docker client out too.

Tags are project versions, which gives an image the same project pages, badges and search as everything else. `docker_manifests` — the one new table — covers what a version row cannot: a digest-addressed pull, and a manifest nothing is tagged at (the children of an index, and referrers artifacts).

### Known limitations, all documented rather than left to be discovered

Blob uploads buffer to the staging directory, because no storage backend has a streaming write. That makes an upload node-local and bounded by that node's disk. Adding a streaming write to the `Storage` trait would remove both limits, at the cost of implementing it on all three backends and giving S3 real multipart state — worth doing, but not here.

Also absent: pull-through caching, blob garbage collection, blob deletes, cross-repository mounting, and `Range` on blob GETs.

## Four pre-existing bugs fixed

Separate commit (c143017). Each blocked a real client, and each was found by pointing one at the server rather than by reading the code:

1. **`max_upload` dropped its unit** — `DefaultBodyLimit::max` got `ConfigSize::size`, the bare number, so the default `100MiB` configured a **100-byte** limit and the server answered `413` to essentially every request with a body, including creating a repository.
2. **`Authorization` required a scheme** — anything that was not exactly `<scheme> <value>` was a `400`. Cargo sends its token bare. Also fixed `parse_basic_header` rejecting passwords containing `:`.
3. **`normalize_host` strips the port**, which is right for a lookup and wrong for a URL — every absolute URL derived from a request pointed at the default port. Added `request_authority`; `request_host` is unchanged.
4. **npm search answered `500` for every query** — `projects.key` is `COLLATE ignoreCase` and Postgres refuses `ILIKE` against a nondeterministic collation. Nothing called it in a test, so it only ever showed up in front of a user.

> [!NOTE]
> `ConfigSize::get_as_bytes()` in `tuxs-config-types` is *also* wrong — `Unit::Mebibytes = 1024 * 2` should be `1024 * 1024`. The multiplier is computed locally here until that's fixed upstream.

## Verification

Against **real clients**, not only the test suite:

- `docker login` / `push` / `pull`, including a genuinely new 3 MB layer through the chunked upload path — contents came back byte-identical (`sha256` match after `docker export`).
- `cargo publish`, `cargo add`, `cargo fetch` from a clean `CARGO_HOME`, `cargo yank`/`--undo`, `cargo owner --list`.
- `just seed` populates all four types end-to-end.

31 new integration tests drive the real router with the byte-exact requests those clients send. `just test-integration` now lists them — and `hostnames`, which was missed when it was added.

Full suite green: 140 unit tests, `cargo +nightly fmt --check`, `clippy -D warnings`, `npm run lint`, `npm run build`, and the docs build (link validation passes).

## Also

`NpmAPI` was declared and never nested into the OpenAPI root, so npm's login endpoints were missing from the served document and the generated frontend types. Registered alongside Docker's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)