### PR TITLE
Fix Cargo on a custom domain, and project links when browsing

### DIFF
--- a/docs/src/content/docs/repositories/cargo/index.md
+++ b/docs/src/content/docs/repositories/cargo/index.md
@@ -82,6 +82,19 @@ fetched under another's path, and Cargo caches by path.
 The index is generated from what the registry holds rather than stored, and every response carries
 an `ETag`. Cargo revalidates constantly, so a `304` is the common case.
 
+## How storage is laid out
+
+```text
+crates/{name}/                              the crate
+crates/{name}/{version}/                    one version
+crates/{name}/{version}/{name}-{version}.crate
+```
+
+A version gets a directory of its own rather than sitting as a lone file, which is the layout Maven
+and npm already use. It is also what makes the file browser resolve a path to a project or a
+version — those two directories are exactly the paths recorded against the project and the version,
+so browsing either links to its page.
+
 ## Next
 
 - [Authenticating](/repositories/cargo/authenticating/) — tokens, and CI.

--- a/nitro_repo/src/app/api/mod.rs
+++ b/nitro_repo/src/app/api/mod.rs
@@ -1,6 +1,6 @@
 use axum::{
     Json,
-    extract::{Request, State},
+    extract::{OriginalUri, Request, State},
     response::{IntoResponse, Response},
 };
 use http::{StatusCode, Uri};
@@ -164,7 +164,30 @@ impl Serialize for RouteNotFound {
     }
 }
 /// `/api/*` fall back is different than the rest of the site
-async fn route_not_found(request: Request) -> Response {
+/// The `/api` fallback.
+///
+/// A repository reached on one of its own hostnames owns that host's whole path space, and Cargo's
+/// web API lives at `/api/v1/...` — paths this nest matches before host routing is ever consulted.
+/// Without the fall-through, a Cargo registry on a custom domain served a `config.json` advertising
+/// a `dl` and an `api` that answered `404` from inside the REST API, so `cargo publish` and every
+/// download failed against URLs the registry itself had handed out.
+///
+/// Only *unmatched* `/api` paths get here, so the real API stays reachable on a custom domain — a
+/// request for `/api/user/me` still hits `/api/user/me`.
+async fn route_not_found(State(site): State<NitroRepo>, request: Request) -> Response {
+    let host = crate::app::host_routing::request_host(
+        request.headers(),
+        request.uri(),
+        site.general_security_settings.trust_forwarded_host,
+    );
+    if host
+        .as_deref()
+        .and_then(|host| site.repository_for_hostname(host))
+        .is_some()
+    {
+        return host_route(site, request).await;
+    }
+
     let response: APIErrorResponse<RouteNotFound, ()> = APIErrorResponse {
         message: "Not Found".into(),
         details: Some(RouteNotFound {
@@ -176,4 +199,20 @@ async fn route_not_found(request: Request) -> Response {
     ResponseBuilder::not_found()
         .error_reason("Route not found")
         .json(&response)
+}
+
+/// Hands a request back to host routing with its full path restored.
+///
+/// `nest` strips the prefix it matched, so a handler under `/api` sees `/v1/crates/new` rather than
+/// `/api/v1/crates/new`. Host routing turns the path into a `StoragePath`, and the stripped form
+/// would address the wrong thing entirely — `OriginalUri` is what the router recorded before the
+/// rewrite.
+async fn host_route(site: NitroRepo, mut request: Request) -> Response {
+    if let Some(OriginalUri(original)) = request.extensions().get::<OriginalUri>().cloned() {
+        *request.uri_mut() = original;
+    }
+    match crate::app::host_routing::host_or_frontend(State(site), request).await {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    }
 }

--- a/nitro_repo/src/repository/cargo/hosted.rs
+++ b/nitro_repo/src/repository/cargo/hosted.rs
@@ -24,7 +24,7 @@ use nr_core::{
         config::{
             RepositoryConfigType, project::ProjectConfigType, repository_page::RepositoryPageType,
         },
-        project::{ReleaseType, VersionData},
+        project::{ProjectResolution, ReleaseType, VersionData},
     },
     storage::StoragePath,
     user::permissions::RepositoryActions,
@@ -40,7 +40,7 @@ use super::{
     types::{
         CargoPath, IndexEntry, is_valid_crate_name, publish::PublishMetadata, split_publish_body,
     },
-    utils::{crate_file_path, registry_base_url, to_hex},
+    utils::{crate_file_path, crate_project_dir, crate_version_dir, registry_base_url, to_hex},
 };
 use crate::{
     app::NitroRepo,
@@ -304,6 +304,10 @@ impl CargoHostedRegistry {
         // stored rather than taken from anything the client said.
         let cksum = to_hex(&Sha256::digest(&crate_file));
         let path = crate_file_path(&project.key, &metadata.vers)?;
+        // The *directory*, not the `.crate` file. `project_versions.path` is what browse matches a
+        // requested path against, so pointing it at the file would leave the version directory
+        // resolving to nothing and the file browser showing no link to the version.
+        let version_dir = crate_version_dir(&project.key, &metadata.vers)?;
 
         let version = metadata.vers.clone();
         let stored = StoredVersion {
@@ -316,7 +320,7 @@ impl CargoHostedRegistry {
             project_id: project.id,
             version: version.clone(),
             release_type: ReleaseType::release_type_from_version(&version),
-            version_path: path.to_string(),
+            version_path: version_dir.to_string(),
             publisher: Some(user.id),
             version_page: metadata.readme.clone(),
             extra: VersionData {
@@ -360,8 +364,7 @@ impl CargoHostedRegistry {
             return Ok(project);
         }
 
-        let mut storage_path = StoragePath::parse("crates")?;
-        storage_path.push_mut(&metadata.name);
+        let storage_path = crate_project_dir(&metadata.name)?;
         let project = NewProject {
             scope: None,
             project_key: metadata.name.clone(),
@@ -692,6 +695,40 @@ impl Repository for CargoHostedRegistry {
             .store(repository.active, atomic::Ordering::Relaxed);
         *self.0.visibility.write() = repository.visibility;
         Ok(())
+    }
+
+    /// Tells the file browser which project — and which version — a path belongs to.
+    ///
+    /// Without this the browser shows a bare directory listing with no link to the project page,
+    /// because the default implementation resolves nothing.
+    ///
+    /// Both lookups match against the `path` columns written at publish time, so there is no
+    /// sidecar to keep in step: `crates/{name}` is the project's path and `crates/{name}/{version}`
+    /// is the version's. Maven consults its `RepositoryMeta` first and falls back to exactly these
+    /// two queries; Cargo has no need of the sidecar, so it uses only the queries.
+    #[instrument(fields(repository_type = "cargo/hosted"))]
+    async fn resolve_project_and_version_for_path(
+        &self,
+        path: &StoragePath,
+    ) -> Result<ProjectResolution, CargoRegistryError> {
+        let path = path.to_string();
+
+        if let Some(version) =
+            DBProjectVersion::find_ids_by_version_dir(&path, self.0.id, self.site.as_ref()).await?
+        {
+            debug!(?path, ?version, "Path is a crate version");
+            return Ok(version.into());
+        }
+        if let Some(project) =
+            DBProject::find_by_project_directory(&path, self.0.id, self.site.as_ref()).await?
+        {
+            debug!(?path, "Path is a crate");
+            return Ok(ProjectResolution {
+                project_id: Some(project.id),
+                version_id: None,
+            });
+        }
+        Ok(ProjectResolution::default())
     }
 
     async fn handle_get(

--- a/nitro_repo/src/repository/cargo/utils.rs
+++ b/nitro_repo/src/repository/cargo/utils.rs
@@ -18,13 +18,33 @@ pub fn to_hex(bytes: &[u8]) -> String {
     })
 }
 
-/// Where a crate's `.crate` file is stored, relative to the repository root.
+/// The directory holding every version of a crate, relative to the repository root.
 ///
-/// The crate name is the project key, so the storage layout mirrors what the index says, and
-/// `crates/` keeps the files clear of the `index/` tree a future on-disk index would want.
-pub fn crate_file_path(name: &str, version: &str) -> Result<StoragePath, CargoRegistryError> {
+/// This is also the project's `path`, which is what lets browsing it resolve to the project page —
+/// see [`CargoHostedRegistry::resolve_project_and_version_for_path`]. `crates/` keeps the files
+/// clear of the `index/` tree a future on-disk index would want.
+///
+/// [`CargoHostedRegistry::resolve_project_and_version_for_path`]: super::hosted::CargoHostedRegistry
+pub fn crate_project_dir(name: &str) -> Result<StoragePath, CargoRegistryError> {
     let mut path = StoragePath::parse("crates")?;
     path.push_mut(name);
+    Ok(path)
+}
+
+/// The directory holding one version of a crate.
+///
+/// A version gets a directory of its own rather than sitting as a lone file in the crate's, so that
+/// its path is something `project_versions.path` can name and browsing it resolves to the version.
+/// It is also the layout Maven and npm already use.
+pub fn crate_version_dir(name: &str, version: &str) -> Result<StoragePath, CargoRegistryError> {
+    let mut path = crate_project_dir(name)?;
+    path.push_mut(version);
+    Ok(path)
+}
+
+/// Where a crate's `.crate` file is stored.
+pub fn crate_file_path(name: &str, version: &str) -> Result<StoragePath, CargoRegistryError> {
+    let mut path = crate_version_dir(name, version)?;
     path.push_mut(&format!("{name}-{version}.crate"));
     Ok(path)
 }

--- a/nitro_repo/src/repository/npm/hosted.rs
+++ b/nitro_repo/src/repository/npm/hosted.rs
@@ -13,7 +13,7 @@ use http::{StatusCode, header::CONTENT_TYPE};
 use nr_core::{
     database::entities::{
         project::{
-            DBProject,
+            DBProject, ProjectDBType,
             dist_tags::{DBNpmDistTag, LATEST_TAG},
             versions::{DBProjectVersion, UpdateProjectVersion},
         },
@@ -24,6 +24,7 @@ use nr_core::{
         config::{
             RepositoryConfigType, project::ProjectConfigType, repository_page::RepositoryPageType,
         },
+        project::ProjectResolution,
     },
     storage::StoragePath,
     user::permissions::{HasPermissions, RepositoryActions},
@@ -565,6 +566,37 @@ impl Repository for NPMHostedRegistry {
             .store(repository.active, atomic::Ordering::Relaxed);
         *self.0.visibility.write() = repository.visibility;
         Ok(())
+    }
+
+    /// Tells the file browser which project — and which version — a path belongs to.
+    ///
+    /// npm stored the right paths from the start but never implemented this, so the default
+    /// resolved nothing and browsing a package showed a bare directory listing with no link to its
+    /// project page. Both lookups match the `path` columns written at publish time:
+    /// `{package}` is the project's and `{package}/{version}` is the version's.
+    #[instrument(fields(repository_type = "npm/hosted"))]
+    async fn resolve_project_and_version_for_path(
+        &self,
+        path: &StoragePath,
+    ) -> Result<ProjectResolution, NPMRegistryError> {
+        let path = path.to_string();
+
+        if let Some(version) =
+            DBProjectVersion::find_ids_by_version_dir(&path, self.id, self.site.as_ref()).await?
+        {
+            debug!(?path, ?version, "Path is a package version");
+            return Ok(version.into());
+        }
+        if let Some(project) =
+            DBProject::find_by_project_directory(&path, self.id, self.site.as_ref()).await?
+        {
+            debug!(?path, "Path is a package");
+            return Ok(ProjectResolution {
+                project_id: Some(project.id),
+                version_id: None,
+            });
+        }
+        Ok(ProjectResolution::default())
     }
 
     async fn handle_get(

--- a/nitro_repo/tests/cargo.rs
+++ b/nitro_repo/tests/cargo.rs
@@ -325,6 +325,221 @@ async fn config_json_follows_a_custom_domain() {
     assert_eq!(config["dl"], "http://crates.example.com/api/v1/crates");
 }
 
+/// A registry on a custom domain has to work through the URLs its own `config.json` advertises.
+///
+/// It did not. Cargo's web API lives at `/api/v1/...`, and the `/api` nest matches that before host
+/// routing is consulted — so `config.json` handed out a `dl` and an `api` that answered `404` from
+/// inside the REST API, and every publish and download against a custom domain failed.
+#[tokio::test]
+async fn a_crate_round_trips_over_a_custom_domain() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "a_crate_round_trips_over_a_custom_domain"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, REPOSITORY, "cargo")
+        .await;
+    let added = server
+        .add_hostname(&session, &repository, "crates.example.com")
+        .await;
+    assert!(added.status.is_success(), "{}", added.text);
+    let token = server
+        .create_repository_token(&session, &repository, &["Read", "Write", "Edit"])
+        .await;
+    let host = ("host", "crates.example.com");
+
+    // Everything below uses only what `config.json` reports, so this fails if the two disagree.
+    let config = server
+        .send("GET", "/index/config.json", &[host], Vec::new())
+        .await;
+    assert_eq!(config.status, StatusCode::OK, "{}", config.text);
+    assert_eq!(config.json()["api"], "http://crates.example.com");
+    assert_eq!(
+        config.json()["dl"],
+        "http://crates.example.com/api/v1/crates"
+    );
+
+    let crate_file = artifacts::crate_file("example", "1.0.0", Some("Example")).expect("builds");
+    let published = server
+        .send(
+            "PUT",
+            "/api/v1/crates/new",
+            &[host, ("authorization", &token)],
+            artifacts::cargo_publish_body(&metadata("example", "1.0.0"), &crate_file),
+        )
+        .await;
+    assert_eq!(
+        published.status,
+        StatusCode::OK,
+        "publish over a custom domain failed: {}",
+        published.text
+    );
+
+    let index = server
+        .send("GET", "/index/ex/am/example", &[host], Vec::new())
+        .await;
+    assert_eq!(index.status, StatusCode::OK, "{}", index.text);
+    assert!(index.text.contains("\"vers\":\"1.0.0\""), "{}", index.text);
+
+    let download = server
+        .send(
+            "GET",
+            "/api/v1/crates/example/1.0.0/download",
+            &[host],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(
+        download.status,
+        StatusCode::OK,
+        "download over a custom domain failed: {}",
+        download.text
+    );
+    assert_eq!(download.bytes, crate_file);
+
+    // Yank and owners go through `/api` too.
+    let yanked = server
+        .send(
+            "DELETE",
+            "/api/v1/crates/example/1.0.0/yank",
+            &[host, ("authorization", &token)],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(yanked.status, StatusCode::OK, "{}", yanked.text);
+
+    let owners = server
+        .send("GET", "/api/v1/crates/example/owners", &[host], Vec::new())
+        .await;
+    assert_eq!(owners.status, StatusCode::OK, "{}", owners.text);
+}
+
+/// The fall-through must not shadow the REST API itself on a custom domain — the web UI and every
+/// admin call still go through `/api` on whatever host the browser happens to be using.
+#[tokio::test]
+async fn the_rest_api_still_works_on_a_custom_domain() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "the_rest_api_still_works_on_a_custom_domain"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, REPOSITORY, "cargo")
+        .await;
+    server
+        .add_hostname(&session, &repository, "crates.example.com")
+        .await;
+
+    let info = server
+        .send(
+            "GET",
+            "/api/info",
+            &[("host", "crates.example.com")],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(info.status, StatusCode::OK, "{}", info.text);
+    assert!(info.json()["name"].is_string(), "{}", info.text);
+
+    let configs = server
+        .send(
+            "GET",
+            &format!("/api/repository/{repository}/configs"),
+            &[
+                ("host", "crates.example.com"),
+                ("authorization", &format!("Session {session}")),
+            ],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(configs.status, StatusCode::OK, "{}", configs.text);
+
+    // An `/api` path that is neither a REST route nor a registry route is still a clean 404 rather
+    // than something the registry tried to interpret.
+    let nonsense = server
+        .send(
+            "GET",
+            "/api/nonsense/route",
+            &[("host", "crates.example.com")],
+            Vec::new(),
+        )
+        .await;
+    assert_eq!(nonsense.status, StatusCode::NOT_FOUND, "{}", nonsense.text);
+}
+
+/// And on a host that is *not* a repository, an unknown `/api` path is the REST API's own 404 —
+/// not the frontend, and not an artifact lookup.
+#[tokio::test]
+async fn an_unknown_api_route_is_still_a_json_404() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "an_unknown_api_route_is_still_a_json_404"
+        ));
+        return;
+    };
+    server.install().await;
+
+    let response = server.get("/api/nonsense/route").await;
+    assert_eq!(response.status, StatusCode::NOT_FOUND, "{}", response.text);
+    assert_eq!(response.json()["message"], "Not Found");
+}
+
+/// Browsing a crate's directory has to say which project it is, or the file browser shows a bare
+/// directory listing with no link to the project page.
+#[tokio::test]
+async fn browsing_resolves_the_project_and_version() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "browsing_resolves_the_project_and_version"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, STORAGE, REPOSITORY, "cargo")
+        .await;
+    let token = server
+        .create_repository_token(&session, &repository, &["Read", "Write", "Edit"])
+        .await;
+    let registry = Registry { server, token };
+    registry.publish("example", "1.0.0").await;
+
+    let browse = async |path: &str| {
+        let url = format!("/api/repository/browse/{repository}/{path}?check_for_project=true");
+        registry.server.get_as(&url, &session).await
+    };
+
+    // The crate's own directory is the project.
+    let project = browse("crates/example").await;
+    assert_eq!(project.status, StatusCode::OK, "{}", project.text);
+    assert!(
+        project.json()["project_resolution"]["project_id"].is_string(),
+        "browsing the crate directory should resolve a project: {}",
+        project.text
+    );
+
+    // And a version directory is the version.
+    let version = browse("crates/example/1.0.0").await;
+    assert_eq!(version.status, StatusCode::OK, "{}", version.text);
+    assert!(
+        version.json()["project_resolution"]["version_id"].is_string(),
+        "browsing the version directory should resolve a version: {}",
+        version.text
+    );
+    assert_eq!(
+        version.json()["project_resolution"]["project_id"],
+        project.json()["project_resolution"]["project_id"],
+    );
+}
+
 #[tokio::test]
 async fn an_anonymous_publish_is_refused() {
     let Some(registry) = Registry::start().await else {

--- a/nitro_repo/tests/npm.rs
+++ b/nitro_repo/tests/npm.rs
@@ -246,6 +246,55 @@ async fn search_finds_a_published_package() {
     assert_eq!(names, vec!["example"]);
 }
 
+/// Browsing a package has to say which project it is, or the file browser shows a bare directory
+/// listing with no link to the project page.
+///
+/// npm stored the right paths from the start but never implemented the resolver, so this returned
+/// nulls for every path.
+#[tokio::test]
+async fn browsing_resolves_the_project_and_version() {
+    let Some(server) = TestServer::start().await else {
+        assert!(skip_without_database(
+            "browsing_resolves_the_project_and_version"
+        ));
+        return;
+    };
+    server.install().await;
+    let session = server.sign_in().await;
+    let repository = server
+        .create_repository(&session, "local", "npm", "npm")
+        .await;
+    publish(&server, "local/npm", "@nitro/example", "1.0.0").await;
+
+    let project = server
+        .get_as(
+            &format!("/api/repository/browse/{repository}/@nitro/example?check_for_project=true"),
+            &session,
+        )
+        .await;
+    assert_eq!(project.status, StatusCode::OK, "{}", project.text);
+    assert!(
+        project.json()["project_resolution"]["project_id"].is_string(),
+        "browsing the package directory should resolve a project: {}",
+        project.text
+    );
+
+    let version = server
+        .get_as(
+            &format!(
+                "/api/repository/browse/{repository}/@nitro/example/1.0.0?check_for_project=true"
+            ),
+            &session,
+        )
+        .await;
+    assert_eq!(version.status, StatusCode::OK, "{}", version.text);
+    assert!(
+        version.json()["project_resolution"]["version_id"].is_string(),
+        "browsing the version directory should resolve a version: {}",
+        version.text
+    );
+}
+
 /// The registry advertises this to `npm ping`, and npm refuses to talk to a registry that 404s it.
 #[tokio::test]
 async fn the_registry_answers_ping() {


### PR DESCRIPTION
Follow-up to #569 — two problems reported against it.

## 1. The Cargo web API 404'd on a custom domain

With a hostname attached to a crates repository:

```toml
[registries.nitro]
index = "sparse+https://crates.kingtux.dev/index/"
```

…the index fetched fine, and then **every publish and download failed** — against URLs the registry itself had handed out:

```json
{"dl":"https://crates.kingtux.dev/api/v1/crates","api":"https://crates.kingtux.dev"}
```

Cargo's web API lives at `/api/v1/...`, and the `/api` nest matches that before host routing is ever consulted, so those requests landed in the REST API and got its 404.

The `/api` fallback now hands an unmatched path back to host routing when the request's host belongs to a repository. **Only unmatched paths** — the REST API stays fully reachable on a custom domain (`/api/user/me` still hits `/api/user/me`), and an `/api` path that is neither a REST route nor a registry route is still a clean JSON 404. All three cases are tested.

`nest` strips the prefix it matched, so the delegation restores the full path from `OriginalUri` first — the stripped `/v1/crates/new` would address something else entirely.

## 2. Browsing showed no project or version

`resolve_project_and_version_for_path` was only ever implemented for Maven. The trait default resolves nothing, so the file browser showed a bare directory listing with no link to the project page.

Maven consults its `RepositoryMeta` sidecar and then falls back to matching the `path` columns. Neither Cargo nor npm needs the sidecar — those columns are written at publish time and are enough on their own.

**Cargo needed a layout change** to make that true. A version was a lone `.crate` file in the crate's directory, so `project_versions.path` named a *file* and no directory a user could browse to resolved to a version. A version now gets a directory of its own, which is what Maven and npm already do:

```text
crates/{name}/{version}/{name}-{version}.crate
```

Safe to change — Cargo shipped in #569 and has not been released.

**npm needed no layout change.** It has stored the right paths from the start and only ever lacked the resolver. That is a pre-existing bug, not one #569 introduced; fixed here because it is the same method and shipping project links for Cargo but not npm would be the odd outcome.

## Verified

Against a live instance, which is how both were found:

- browsing `crates/nitro-example` resolves the project; `crates/nitro-example/1.0.0` resolves project **and** version; same for an npm package
- a crate publishes and downloads over `crates.kingtux.dev` through the URLs `config.json` reports

Plus 7 new integration tests. Full suite green, `clippy -D warnings`, docs build with link validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)